### PR TITLE
feat: implement FFT frequency extractor and fix GLCM ASM property

### DIFF
--- a/extractor_config.json
+++ b/extractor_config.json
@@ -25,7 +25,18 @@
         "homogeneity",
         "energy",
         "correlation",
-        "asm"]
+        "ASM"]
+    },
+    "fft": {
+      "frequency_bands": [
+        [0.0, 0.1],
+        [0.1, 0.3],
+        [0.3, 0.5]
+      ],
+      "high_low_threshold": 0.2,
+      "directional_tolerance": 10.0,
+      "peak_threshold_ratio": 0.1,
+      "mm_per_pixel": 0.05
     }
   },
   "file_filters": {

--- a/feature_extractors/__init__.py
+++ b/feature_extractors/__init__.py
@@ -6,6 +6,7 @@
 
 from .base import BaseFeatureExtractor
 from .brightness_statistics import BrightnessStatisticsExtractor
+from .fft_frequency import FFTFrequencyExtractor
 from .glcm_texture import GLCMTextureExtractor
 from .hsv_statistics import HSVStatisticsExtractor
 from .registry import (
@@ -16,6 +17,7 @@ from .registry import (
 from .rgb_statistics import RGBStatisticsExtractor
 from .schema import (
     BrightnessStatisticsParams,
+    FFTFrequencyParams,
     GLCMTextureParams,
     HSVStatisticsParams,
     RGBStatisticsParams,
@@ -24,6 +26,7 @@ from .schema import (
 __all__ = [
     "BaseFeatureExtractor",
     "BrightnessStatisticsExtractor",
+    "FFTFrequencyExtractor",
     "GLCMTextureExtractor",
     "HSVStatisticsExtractor",
     "RGBStatisticsExtractor",
@@ -31,6 +34,7 @@ __all__ = [
     "get_feature_extractor",
     "register_feature_extractor",
     "BrightnessStatisticsParams",
+    "FFTFrequencyParams",
     "GLCMTextureParams",
     "HSVStatisticsParams",
     "RGBStatisticsParams",

--- a/feature_extractors/fft_frequency.py
+++ b/feature_extractors/fft_frequency.py
@@ -1,0 +1,396 @@
+"""FFT（高速フーリエ変換）周波数領域特徴量抽出を行うモジュール."""
+
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+import cv2
+import numpy as np
+from scipy.ndimage import maximum_filter
+
+from .base import BaseFeatureExtractor
+from .registry import register_feature_extractor
+
+
+@register_feature_extractor("fft")
+class FFTFrequencyExtractor(BaseFeatureExtractor):
+    """
+    画像のFFT（高速フーリエ変換）周波数領域特徴量を抽出するクラス.
+
+    FFTは画像の周波数成分を解析し、テクスチャや周期性の特徴を抽出します。
+    空間領域の画像を周波数領域に変換することで、画像の周波数特性を定量化できます。
+
+    抽出する特徴量:
+    - high_low_ratio: 高周波/低周波エネルギー比
+    - spectral_std: スペクトルの標準偏差
+    - horizontal_energy: 水平方向エネルギー
+    - vertical_energy: 垂直方向エネルギー
+    - num_peaks: スペクトルピーク数
+    - max_peak_amp: 最大ピーク振幅
+    - band_energy: 周波数帯域別エネルギー
+    - spectral_centroid: スペクトル重心
+
+    設定により、周波数帯域、閾値、ピクセル解像度などを調整できます。
+    """
+
+    def __init__(
+        self,
+        name: str = "fft_frequency",
+        config: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """
+        FFTFrequencyExtractorのコンストラクタ.
+
+        Args:
+            name (str): 特徴量抽出器名. デフォルトは "fft_frequency".
+            config (dict, optional): 設定パラメータ. デフォルトは空の辞書.
+        """
+        super().__init__(name, config or {})
+
+        # 設定パラメータの取得
+        self.frequency_bands = self.config["frequency_bands"]
+        self.high_low_threshold = self.config["high_low_threshold"]
+        self.directional_tolerance = self.config["directional_tolerance"]
+        self.peak_threshold_ratio = self.config["peak_threshold_ratio"]
+        self.mm_per_pixel = self.config.get("mm_per_pixel")
+
+    def _compute_band_energy(
+        self, image: np.ndarray, bands: List[Tuple[float, float]]
+    ) -> Dict[str, float]:
+        """
+        周波数帯域ごとのエネルギーを計算する.
+
+        Args:
+            image (np.ndarray): グレースケール画像
+            bands (List[Tuple[float, float]]): 周波数帯域のリスト
+
+        Returns:
+            Dict[str, float]: 帯域別エネルギーの辞書
+        """
+        f = np.fft.fft2(image)
+        fshift = np.fft.fftshift(f)
+        magnitude = np.abs(fshift) ** 2
+
+        h, w = image.shape
+        cy, cx = h // 2, w // 2
+        max_radius = np.sqrt(cx**2 + cy**2)
+
+        y, x = np.ogrid[:h, :w]
+        dist = np.sqrt((x - cx) ** 2 + (y - cy) ** 2)
+        freq_norm = dist / max_radius / 2
+
+        total_energy = np.sum(magnitude)
+        energies = {}
+
+        for i, (fmin, fmax) in enumerate(bands):
+            mask = (freq_norm >= fmin) & (freq_norm < fmax)
+            energy = np.sum(magnitude[mask]) / total_energy if total_energy > 0 else 0.0
+            band_key = f"band_{i+1}_{fmin:.2f}_{fmax:.2f}"
+            energies[band_key] = energy
+
+        return energies
+
+    def _compute_spectral_centroid(self, image: np.ndarray) -> float:
+        """
+        2D画像のスペクトル重心を計算する.
+
+        Args:
+            image (np.ndarray): グレースケール画像
+
+        Returns:
+            float: スペクトル重心（正規化された空間周波数）
+        """
+        h, w = image.shape
+        cy, cx = h // 2, w // 2
+
+        # 2D FFTとスペクトル
+        f = np.fft.fft2(image)
+        fshift = np.fft.fftshift(f)
+        magnitude = np.abs(fshift)
+
+        # 距離ベースの周波数マップ（0〜0.5）
+        y, x = np.ogrid[:h, :w]
+        dist = np.sqrt((x - cx) ** 2 + (y - cy) ** 2)
+        max_radius = np.sqrt(cx**2 + cy**2)
+        norm_freq = dist / max_radius / 2  # 0〜0.5に正規化
+
+        # スペクトル重心の計算
+        numerator = np.sum(norm_freq * magnitude)
+        denominator = np.sum(magnitude)
+
+        return numerator / denominator if denominator != 0 else 0.0
+
+    def _compute_high_low_freq_ratio(
+        self, image: np.ndarray, threshold: float
+    ) -> float:
+        """
+        高周波/低周波エネルギー比を計算する.
+
+        Args:
+            image (np.ndarray): グレースケール画像
+            threshold (float): 高周波/低周波の境界閾値
+
+        Returns:
+            float: 高周波/低周波エネルギー比
+        """
+        h, w = image.shape
+        cy, cx = h // 2, w // 2
+        max_radius = np.sqrt(cx**2 + cy**2)
+
+        f = np.fft.fft2(image)
+        fshift = np.fft.fftshift(f)
+        magnitude = np.abs(fshift) ** 2  # パワースペクトル
+
+        y, x = np.ogrid[:h, :w]
+        dist = np.sqrt((x - cx) ** 2 + (y - cy) ** 2)
+        norm_freq = dist / max_radius / 2  # 0〜0.5
+
+        low_mask = norm_freq < threshold
+        high_mask = norm_freq >= threshold
+
+        low_energy = np.sum(magnitude[low_mask])
+        high_energy = np.sum(magnitude[high_mask])
+
+        return high_energy / low_energy if low_energy > 0 else np.inf
+
+    def _compute_spectral_std(self, image: np.ndarray) -> float:
+        """
+        スペクトルの標準偏差を計算する.
+
+        Args:
+            image (np.ndarray): グレースケール画像
+
+        Returns:
+            float: スペクトルの標準偏差
+        """
+        h, w = image.shape
+        cy, cx = h // 2, w // 2
+        max_radius = np.sqrt(cx**2 + cy**2)
+
+        f = np.fft.fft2(image)
+        fshift = np.fft.fftshift(f)
+        magnitude = np.abs(fshift)
+
+        y, x = np.ogrid[:h, :w]
+        dist = np.sqrt((x - cx) ** 2 + (y - cy) ** 2)
+        norm_freq = dist / max_radius / 2
+
+        weights = magnitude
+        total_weight = np.sum(weights)
+        if total_weight == 0:
+            return 0.0
+
+        mean = np.sum(norm_freq * weights) / total_weight
+        var = np.sum(((norm_freq - mean) ** 2) * weights) / total_weight
+        return np.sqrt(var)
+
+    def _compute_directional_energy(
+        self, image: np.ndarray, angle_deg: float, tolerance_deg: float
+    ) -> float:
+        """
+        指定方向のエネルギーを計算する.
+
+        Args:
+            image (np.ndarray): グレースケール画像
+            angle_deg (float): 角度（度）
+            tolerance_deg (float): 許容角度（度）
+
+        Returns:
+            float: 方向性エネルギー比
+        """
+        h, w = image.shape
+        f = np.fft.fft2(image)
+        fshift = np.fft.fftshift(f)
+        magnitude = np.abs(fshift) ** 2
+
+        cy, cx = h // 2, w // 2
+        y, x = np.ogrid[:h, :w]
+        dy = y - cy
+        dx = x - cx
+        angle = np.arctan2(dy, dx) * 180 / np.pi  # -180〜180度
+
+        angle = (angle + 360) % 180  # 0〜180度に正規化
+        diff = np.abs(angle - angle_deg)
+        mask = diff <= tolerance_deg
+
+        directional_energy = np.sum(magnitude[mask])
+        total_energy = np.sum(magnitude)
+        return directional_energy / total_energy if total_energy > 0 else 0.0
+
+    def _compute_spectral_peaks(
+        self, image: np.ndarray, threshold_ratio: float
+    ) -> Tuple[int, float]:
+        """
+        スペクトルピーク数と最大値を計算する.
+
+        Args:
+            image (np.ndarray): グレースケール画像
+            threshold_ratio (float): ピーク検出の閾値比
+
+        Returns:
+            Tuple[int, float]: (ピーク数, 最大ピーク振幅)
+        """
+        f = np.fft.fft2(image)
+        fshift = np.fft.fftshift(f)
+        magnitude = np.abs(fshift)
+
+        # 局所ピークを検出
+        max_local = maximum_filter(magnitude, size=3)
+        peaks = (magnitude == max_local) & (
+            magnitude > magnitude.max() * threshold_ratio
+        )
+
+        num_peaks = int(np.sum(peaks))
+        max_peak = float(magnitude.max())
+
+        return num_peaks, max_peak
+
+    def extract(self, image: np.ndarray) -> Dict[str, Union[float, int]]:
+        """
+        画像からFFT周波数領域特徴量を抽出する.
+
+        Args:
+            image (np.ndarray): 入力画像（BGR形式）.
+
+        Returns:
+            Dict[str, Union[float, int]]: 抽出された特徴量の辞書.
+
+        Raises:
+            ValueError: 画像が空の場合や無効な形状の場合.
+        """
+        if image is None or image.size == 0:
+            raise ValueError("Input image is empty or None")
+
+        # 画像の型を適切に変換
+        if image.dtype not in [np.uint8, np.uint16, np.float32, np.float64]:
+            if image.dtype in [np.int32, np.int64]:
+                image = np.clip(image, 0, 255).astype(np.uint8)
+            else:
+                image = image.astype(np.float32)
+                if image.max() <= 1.0:
+                    image = (image * 255).astype(np.uint8)
+                else:
+                    image = np.clip(image, 0, 255).astype(np.uint8)
+
+        # グレースケール変換
+        if len(image.shape) == 3:
+            gray_image = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+        elif len(image.shape) == 2:
+            gray_image = image.copy()
+        else:
+            raise ValueError(f"Input image must be 2D or 3D, got shape: {image.shape}")
+
+        # 画像を0-255の範囲に正規化
+        gray_image = cv2.normalize(
+            gray_image, None, 0, 255, cv2.NORM_MINMAX, dtype=cv2.CV_8U
+        )
+
+        results = {}
+
+        try:
+            # 周波数単位の変換係数
+            scale = 1.0
+            if self.mm_per_pixel is not None:
+                scale = 1.0 / self.mm_per_pixel
+
+            # 1. 高周波/低周波エネルギー比
+            high_low_ratio = self._compute_high_low_freq_ratio(
+                gray_image, self.high_low_threshold
+            )
+            # 無限大の値をチェック
+            if np.isinf(high_low_ratio):
+                high_low_ratio = 0.0
+            results["high_low_ratio"] = float(high_low_ratio)
+
+            # 2. スペクトルの標準偏差
+            spectral_std = self._compute_spectral_std(gray_image) * scale
+            results["spectral_std"] = float(spectral_std)
+
+            # 3. 方向性エネルギー（水平／垂直）
+            horizontal_energy = self._compute_directional_energy(
+                gray_image, 0.0, self.directional_tolerance
+            )
+            results["horizontal_energy"] = float(horizontal_energy)
+
+            vertical_energy = self._compute_directional_energy(
+                gray_image, 90.0, self.directional_tolerance
+            )
+            results["vertical_energy"] = float(vertical_energy)
+
+            # 4. スペクトルピーク数と最大値
+            num_peaks, max_peak_amp = self._compute_spectral_peaks(
+                gray_image, self.peak_threshold_ratio
+            )
+            results["num_peaks"] = int(num_peaks)
+            results["max_peak_amp"] = float(max_peak_amp)
+
+            # 5. 周波数帯エネルギー
+            band_energies = self._compute_band_energy(gray_image, self.frequency_bands)
+            results.update(band_energies)
+
+            # 6. スペクトル重心
+            spectral_centroid = self._compute_spectral_centroid(gray_image) * scale
+            results["spectral_centroid"] = float(spectral_centroid)
+
+            # NaNや無限大の値をチェックして修正
+            for key, value in results.items():
+                if isinstance(value, float) and (np.isnan(value) or np.isinf(value)):
+                    results[key] = 0.0
+
+        except Exception:
+            # エラーが発生した場合、すべて0で埋める
+            feature_names = self.get_feature_names()
+            results = {name: 0.0 for name in feature_names}
+
+        return results
+
+    @staticmethod
+    def get_default_config() -> Dict[str, Any]:
+        """
+        FFTFrequencyExtractorのデフォルト設定を返す.
+
+        Returns:
+            Dict[str, Any]: デフォルト設定.
+                - frequency_bands: 周波数帯域のリスト
+                - high_low_threshold: 高周波/低周波の境界閾値
+                - directional_tolerance: 方向性エネルギー計算の許容角度
+                - peak_threshold_ratio: ピーク検出の閾値比
+                - mm_per_pixel: ピクセルあたりのmm（Noneの場合はピクセル単位）
+        """
+        return {
+            "frequency_bands": [
+                [0.0, 0.1],  # 低周波帯域
+                [0.1, 0.3],  # 中周波帯域
+                [0.3, 0.5],  # 高周波帯域
+            ],
+            "high_low_threshold": 0.2,  # 高周波/低周波の境界
+            "directional_tolerance": 10.0,  # 方向性エネルギーの許容角度（度）
+            "peak_threshold_ratio": 0.1,  # ピーク検出の閾値比
+            "mm_per_pixel": None,  # ピクセル解像度（Noneの場合はピクセル単位）
+        }
+
+    @staticmethod
+    def get_feature_names() -> List[str]:
+        """
+        この特徴量抽出器が出力する特徴量名のリストを返す.
+
+        Returns:
+            List[str]: 特徴量名のリスト.
+        """
+        # デフォルト設定を使用して特徴量名を生成
+        default_config = FFTFrequencyExtractor.get_default_config()
+
+        feature_names = [
+            "high_low_ratio",
+            "spectral_std",
+            "horizontal_energy",
+            "vertical_energy",
+            "num_peaks",
+            "max_peak_amp",
+            "spectral_centroid",
+        ]
+
+        # 周波数帯域の特徴量名を追加
+        for i, (fmin, fmax) in enumerate(default_config["frequency_bands"]):
+            band_key = f"band_{i+1}_{fmin:.2f}_{fmax:.2f}"
+            feature_names.append(band_key)
+
+        return feature_names

--- a/feature_extractors/glcm_texture.py
+++ b/feature_extractors/glcm_texture.py
@@ -212,7 +212,7 @@ class GLCMTextureExtractor(BaseFeatureExtractor):
                 "homogeneity",  # 均質性
                 "energy",  # エネルギー
                 "correlation",  # 相関
-                "asm",  # Angular Second Moment
+                "ASM",  # Angular Second Moment
             ],
         }
 

--- a/feature_extractors/schema.py
+++ b/feature_extractors/schema.py
@@ -60,7 +60,33 @@ class GLCMTextureParams(BaseModel):
             "homogeneity",
             "energy",
             "correlation",
-            "asm",
+            "ASM",
         ],
         description="計算するプロパティのリスト",
+    )
+
+
+class FFTFrequencyParams(BaseModel):
+    """FFT周波数領域特徴量抽出のパラメータスキーマ."""
+
+    frequency_bands: Optional[List[List[StrictFloat]]] = Field(
+        default=[[0.0, 0.1], [0.1, 0.3], [0.3, 0.5]],
+        description="周波数帯域のリスト（各帯域は[最小周波数, 最大周波数]の形式）",
+    )
+    high_low_threshold: Optional[StrictFloat] = Field(
+        default=0.2, ge=0.0, le=0.5, description="高周波/低周波の境界閾値（0.0-0.5）"
+    )
+    directional_tolerance: Optional[StrictFloat] = Field(
+        default=10.0,
+        ge=0.0,
+        le=90.0,
+        description="方向性エネルギー計算の許容角度（度）",
+    )
+    peak_threshold_ratio: Optional[StrictFloat] = Field(
+        default=0.1, ge=0.0, le=1.0, description="ピーク検出の閾値比（0.0-1.0）"
+    )
+    mm_per_pixel: Optional[StrictFloat] = Field(
+        default=None,
+        gt=0.0,
+        description="ピクセルあたりのmm（Noneの場合はピクセル単位）",
     )

--- a/tests/extractors/test_fft_features.py
+++ b/tests/extractors/test_fft_features.py
@@ -1,0 +1,274 @@
+"""FFT周波数領域特徴量抽出器のテストモジュール."""
+
+import numpy as np
+import pytest
+
+from feature_extractors.fft_frequency import FFTFrequencyExtractor
+
+
+class TestFFTFrequencyExtractor:
+    """FFTFrequencyExtractorのテストクラス."""
+
+    def setup_method(self):
+        """各テストメソッドの前に実行される初期化処理."""
+        self.extractor = FFTFrequencyExtractor()
+
+    def test_init_default(self):
+        """デフォルト設定でのインスタンス化をテスト."""
+        extractor = FFTFrequencyExtractor()
+        assert extractor.name == "fft_frequency"
+        assert extractor.frequency_bands == [[0.0, 0.1], [0.1, 0.3], [0.3, 0.5]]
+        assert extractor.high_low_threshold == 0.2
+        assert extractor.directional_tolerance == 10.0
+        assert extractor.peak_threshold_ratio == 0.1
+        assert extractor.mm_per_pixel is None
+
+    def test_init_custom_config(self):
+        """カスタム設定でのインスタンス化をテスト."""
+        config = {
+            "frequency_bands": [[0.0, 0.2], [0.2, 0.4], [0.4, 0.5]],
+            "high_low_threshold": 0.3,
+            "directional_tolerance": 15.0,
+            "peak_threshold_ratio": 0.2,
+            "mm_per_pixel": 0.05,
+        }
+        extractor = FFTFrequencyExtractor(config=config)
+        assert extractor.frequency_bands == [[0.0, 0.2], [0.2, 0.4], [0.4, 0.5]]
+        assert extractor.high_low_threshold == 0.3
+        assert extractor.directional_tolerance == 15.0
+        assert extractor.peak_threshold_ratio == 0.2
+        assert extractor.mm_per_pixel == 0.05
+
+    def test_extract_grayscale_image(self):
+        """グレースケール画像からの特徴量抽出をテスト."""
+        # テスト用のグレースケール画像を作成（チェッカーボードパターン）
+        image = np.zeros((64, 64), dtype=np.uint8)
+        image[::8, ::8] = 255  # チェッカーボードパターン
+
+        features = self.extractor.extract(image)
+
+        # 期待される特徴量名が含まれているかチェック
+        expected_features = [
+            "high_low_ratio",
+            "spectral_std",
+            "horizontal_energy",
+            "vertical_energy",
+            "num_peaks",
+            "max_peak_amp",
+            "spectral_centroid",
+            "band_1_0.00_0.10",
+            "band_2_0.10_0.30",
+            "band_3_0.30_0.50",
+        ]
+
+        for feature_name in expected_features:
+            assert feature_name in features
+            assert isinstance(features[feature_name], (int, float))
+            assert not np.isnan(features[feature_name])
+            assert not np.isinf(features[feature_name])
+
+    def test_extract_color_image(self):
+        """カラー画像からの特徴量抽出をテスト（BGR→グレースケール変換）."""
+        # テスト用のカラー画像を作成
+        image = np.random.randint(0, 256, (64, 64, 3), dtype=np.uint8)
+
+        features = self.extractor.extract(image)
+
+        # 基本的な特徴量が抽出されているかチェック
+        assert "high_low_ratio" in features
+        assert "spectral_std" in features
+        assert "horizontal_energy" in features
+        assert "vertical_energy" in features
+
+    def test_extract_uniform_image(self):
+        """均一な画像からの特徴量抽出をテスト."""
+        # 均一な画像（すべて同じ値）
+        image = np.full((64, 64), 128, dtype=np.uint8)
+
+        features = self.extractor.extract(image)
+
+        # 均一な画像では多くの特徴量が0または特定の値になる
+        assert features["high_low_ratio"] >= 0
+        assert features["spectral_std"] >= 0
+        assert features["num_peaks"] >= 0
+
+    def test_extract_with_mm_per_pixel(self):
+        """mm_per_pixel設定での特徴量抽出をテスト."""
+        config = {"mm_per_pixel": 0.05}
+        extractor = FFTFrequencyExtractor(config=config)
+
+        image = np.random.randint(0, 256, (64, 64), dtype=np.uint8)
+        features = extractor.extract(image)
+
+        # スケールが適用された特徴量をチェック
+        assert "spectral_std" in features
+        assert "spectral_centroid" in features
+        assert features["spectral_std"] >= 0
+        assert features["spectral_centroid"] >= 0
+
+    def test_extract_empty_image(self):
+        """空の画像での例外処理をテスト."""
+        empty_image = np.array([])
+
+        with pytest.raises(ValueError, match="Input image is empty or None"):
+            self.extractor.extract(empty_image)
+
+    def test_extract_none_image(self):
+        """None画像での例外処理をテスト."""
+        with pytest.raises(ValueError, match="Input image is empty or None"):
+            self.extractor.extract(None)
+
+    def test_extract_invalid_shape(self):
+        """無効な形状の画像での例外処理をテスト."""
+        # 1次元配列
+        invalid_image = np.array([1, 2, 3, 4])
+
+        with pytest.raises(ValueError, match="Input image must be 2D or 3D"):
+            self.extractor.extract(invalid_image)
+
+    def test_extract_different_dtypes(self):
+        """異なるデータ型の画像での特徴量抽出をテスト."""
+        base_image = np.random.randint(0, 256, (32, 32), dtype=np.uint8)
+
+        # float32
+        float_image = base_image.astype(np.float32) / 255.0
+        features_float = self.extractor.extract(float_image)
+        assert "high_low_ratio" in features_float
+
+        # int32
+        int_image = base_image.astype(np.int32)
+        features_int = self.extractor.extract(int_image)
+        assert "high_low_ratio" in features_int
+
+    def test_compute_band_energy(self):
+        """周波数帯域エネルギー計算の内部メソッドをテスト."""
+        image = np.random.randint(0, 256, (32, 32), dtype=np.uint8)
+        bands = [[0.0, 0.1], [0.1, 0.3], [0.3, 0.5]]
+
+        energies = self.extractor._compute_band_energy(image, bands)
+
+        assert len(energies) == 3
+        assert "band_1_0.00_0.10" in energies
+        assert "band_2_0.10_0.30" in energies
+        assert "band_3_0.30_0.50" in energies
+
+        # エネルギーの合計は1に近い（正規化されているため）
+        total_energy = sum(energies.values())
+        assert 0.9 <= total_energy <= 1.1
+
+    def test_compute_spectral_centroid(self):
+        """スペクトル重心計算の内部メソッドをテスト."""
+        image = np.random.randint(0, 256, (32, 32), dtype=np.uint8)
+
+        centroid = self.extractor._compute_spectral_centroid(image)
+
+        assert isinstance(centroid, float)
+        assert 0 <= centroid <= 0.5  # 正規化された周波数範囲
+
+    def test_compute_high_low_freq_ratio(self):
+        """高周波/低周波比計算の内部メソッドをテスト."""
+        image = np.random.randint(0, 256, (32, 32), dtype=np.uint8)
+
+        ratio = self.extractor._compute_high_low_freq_ratio(image, 0.2)
+
+        assert isinstance(ratio, float)
+        assert ratio >= 0
+
+    def test_compute_spectral_std(self):
+        """スペクトル標準偏差計算の内部メソッドをテスト."""
+        image = np.random.randint(0, 256, (32, 32), dtype=np.uint8)
+
+        std = self.extractor._compute_spectral_std(image)
+
+        assert isinstance(std, float)
+        assert std >= 0
+
+    def test_compute_directional_energy(self):
+        """方向性エネルギー計算の内部メソッドをテスト."""
+        image = np.random.randint(0, 256, (32, 32), dtype=np.uint8)
+
+        # 水平方向
+        horizontal = self.extractor._compute_directional_energy(image, 0.0, 10.0)
+        assert isinstance(horizontal, float)
+        assert 0 <= horizontal <= 1
+
+        # 垂直方向
+        vertical = self.extractor._compute_directional_energy(image, 90.0, 10.0)
+        assert isinstance(vertical, float)
+        assert 0 <= vertical <= 1
+
+    def test_compute_spectral_peaks(self):
+        """スペクトルピーク計算の内部メソッドをテスト."""
+        image = np.random.randint(0, 256, (32, 32), dtype=np.uint8)
+
+        num_peaks, max_peak = self.extractor._compute_spectral_peaks(image, 0.1)
+
+        assert isinstance(num_peaks, int)
+        assert isinstance(max_peak, float)
+        assert num_peaks >= 0
+        assert max_peak >= 0
+
+    def test_get_default_config(self):
+        """デフォルト設定の取得をテスト."""
+        config = FFTFrequencyExtractor.get_default_config()
+
+        expected_keys = [
+            "frequency_bands",
+            "high_low_threshold",
+            "directional_tolerance",
+            "peak_threshold_ratio",
+            "mm_per_pixel",
+        ]
+
+        for key in expected_keys:
+            assert key in config
+
+        assert config["frequency_bands"] == [[0.0, 0.1], [0.1, 0.3], [0.3, 0.5]]
+        assert config["high_low_threshold"] == 0.2
+        assert config["directional_tolerance"] == 10.0
+        assert config["peak_threshold_ratio"] == 0.1
+        assert config["mm_per_pixel"] is None
+
+    def test_get_feature_names(self):
+        """特徴量名リストの取得をテスト."""
+        feature_names = FFTFrequencyExtractor.get_feature_names()
+
+        expected_features = [
+            "high_low_ratio",
+            "spectral_std",
+            "horizontal_energy",
+            "vertical_energy",
+            "num_peaks",
+            "max_peak_amp",
+            "spectral_centroid",
+            "band_1_0.00_0.10",
+            "band_2_0.10_0.30",
+            "band_3_0.30_0.50",
+        ]
+
+        assert len(feature_names) == len(expected_features)
+        for feature_name in expected_features:
+            assert feature_name in feature_names
+
+    def test_feature_consistency(self):
+        """同じ画像に対して一貫した結果が得られることをテスト."""
+        image = np.random.randint(0, 256, (64, 64), dtype=np.uint8)
+
+        features1 = self.extractor.extract(image)
+        features2 = self.extractor.extract(image)
+
+        # 同じ画像なので同じ結果が得られるはず
+        for key in features1:
+            assert abs(features1[key] - features2[key]) < 1e-10
+
+    def test_error_handling_in_extract(self):
+        """extract メソッドでのエラーハンドリングをテスト."""
+        # 正常な画像で一度テスト
+        normal_image = np.random.randint(0, 256, (32, 32), dtype=np.uint8)
+        features = self.extractor.extract(normal_image)
+
+        # すべての特徴量が数値であることを確認
+        for key, value in features.items():
+            assert isinstance(value, (int, float))
+            assert not np.isnan(value)
+            assert not np.isinf(value)

--- a/tools/fft_sample.ipynb
+++ b/tools/fft_sample.ipynb
@@ -1,0 +1,346 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import cv2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 周波数エネルギー（帯域別）"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "img = cv2.imread('../image_aggregated/20250524_2/pipeline/pipeline_20250524094314_Tokyo_Lab_id1_image1.bmp', cv2.IMREAD_GRAYSCALE)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def compute_band_energy(image, bands=((0, 0.1), (0.1, 0.3), (0.3, 0.5))):\n",
+    "    \"\"\"\n",
+    "    周波数帯域ごとのエネルギーを辞書で返す\n",
+    "    \"\"\"\n",
+    "    f = np.fft.fft2(image)\n",
+    "    fshift = np.fft.fftshift(f)\n",
+    "    magnitude = np.abs(fshift) ** 2\n",
+    "\n",
+    "    h, w = image.shape\n",
+    "    cy, cx = h // 2, w // 2\n",
+    "    max_radius = np.sqrt(cx**2 + cy**2)\n",
+    "\n",
+    "    y, x = np.ogrid[:h, :w]\n",
+    "    dist = np.sqrt((x - cx)**2 + (y - cy)**2)\n",
+    "    freq_norm = dist / max_radius / 2\n",
+    "\n",
+    "    total_energy = np.sum(magnitude)\n",
+    "    energies = {}\n",
+    "\n",
+    "    for i, (fmin, fmax) in enumerate(bands):\n",
+    "        mask = (freq_norm >= fmin) & (freq_norm < fmax)\n",
+    "        energy = np.sum(magnitude[mask]) / total_energy\n",
+    "        band_key = f\"band_{i+1}_{fmin:.2f}_{fmax:.2f}\"\n",
+    "        energies[band_key] = energy\n",
+    "\n",
+    "    return energies\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    " ## スペクトル重心（Spectral Centroid)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def compute_spectral_centroid(image):\n",
+    "    \"\"\"\n",
+    "    2D画像のスペクトル重心を計算する（正規化された空間周波数ベース）\n",
+    "\n",
+    "    Parameters:\n",
+    "        image : 2D ndarray\n",
+    "            グレースケール画像（正方形が望ましい）\n",
+    "\n",
+    "    Returns:\n",
+    "        centroid : float\n",
+    "            スペクトル重心（0〜0.5の範囲, Nyquist単位）\n",
+    "    \"\"\"\n",
+    "    h, w = image.shape\n",
+    "    cy, cx = h // 2, w // 2\n",
+    "\n",
+    "    # 2D FFTとスペクトル\n",
+    "    f = np.fft.fft2(image)\n",
+    "    fshift = np.fft.fftshift(f)\n",
+    "    magnitude = np.abs(fshift)\n",
+    "\n",
+    "    # 距離ベースの周波数マップ（0〜0.5）\n",
+    "    y, x = np.ogrid[:h, :w]\n",
+    "    dist = np.sqrt((x - cx)**2 + (y - cy)**2)\n",
+    "    max_radius = np.sqrt(cx**2 + cy**2)\n",
+    "    norm_freq = dist / max_radius / 2  # 0〜0.5に正規化\n",
+    "\n",
+    "    # スペクトル重心の計算\n",
+    "    numerator = np.sum(norm_freq * magnitude)\n",
+    "    denominator = np.sum(magnitude)\n",
+    "\n",
+    "    centroid = numerator / denominator if denominator != 0 else 0\n",
+    "    return centroid\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 高周波／低周波の比率（High / Low Frequency Ratio）"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def compute_high_low_freq_ratio(image, threshold=0.2):\n",
+    "    h, w = image.shape\n",
+    "    cy, cx = h // 2, w // 2\n",
+    "    max_radius = np.sqrt(cx**2 + cy**2)\n",
+    "\n",
+    "    f = np.fft.fft2(image)\n",
+    "    fshift = np.fft.fftshift(f)\n",
+    "    magnitude = np.abs(fshift)**2  # パワースペクトル\n",
+    "\n",
+    "    y, x = np.ogrid[:h, :w]\n",
+    "    dist = np.sqrt((x - cx)**2 + (y - cy)**2)\n",
+    "    norm_freq = dist / max_radius / 2  # 0〜0.5\n",
+    "\n",
+    "    low_mask = norm_freq < threshold\n",
+    "    high_mask = norm_freq >= threshold\n",
+    "\n",
+    "    low_energy = np.sum(magnitude[low_mask])\n",
+    "    high_energy = np.sum(magnitude[high_mask])\n",
+    "\n",
+    "    return high_energy / low_energy if low_energy > 0 else np.inf\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## スペクトルの分散 / 標準偏差"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def compute_spectral_std(image):\n",
+    "    h, w = image.shape\n",
+    "    cy, cx = h // 2, w // 2\n",
+    "    max_radius = np.sqrt(cx**2 + cy**2)\n",
+    "\n",
+    "    f = np.fft.fft2(image)\n",
+    "    fshift = np.fft.fftshift(f)\n",
+    "    magnitude = np.abs(fshift)\n",
+    "\n",
+    "    y, x = np.ogrid[:h, :w]\n",
+    "    dist = np.sqrt((x - cx)**2 + (y - cy)**2)\n",
+    "    norm_freq = dist / max_radius / 2\n",
+    "\n",
+    "    weights = magnitude\n",
+    "    mean = np.sum(norm_freq * weights) / np.sum(weights)\n",
+    "    var = np.sum(((norm_freq - mean)**2) * weights) / np.sum(weights)\n",
+    "    return np.sqrt(var)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 方向性エネルギー（Directional Energy）水平"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def compute_directional_energy(image, angle_deg=0, tolerance_deg=10):\n",
+    "    h, w = image.shape\n",
+    "    f = np.fft.fft2(image)\n",
+    "    fshift = np.fft.fftshift(f)\n",
+    "    magnitude = np.abs(fshift)**2\n",
+    "\n",
+    "    cy, cx = h // 2, w // 2\n",
+    "    y, x = np.ogrid[:h, :w]\n",
+    "    dy = y - cy\n",
+    "    dx = x - cx\n",
+    "    angle = np.arctan2(dy, dx) * 180 / np.pi  # -180〜180度\n",
+    "\n",
+    "    angle = (angle + 360) % 180  # 0〜180度に正規化\n",
+    "    diff = np.abs(angle - angle_deg)\n",
+    "    mask = diff <= tolerance_deg\n",
+    "\n",
+    "    directional_energy = np.sum(magnitude[mask])\n",
+    "    total_energy = np.sum(magnitude)\n",
+    "    return directional_energy / total_energy\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## スペクトルピーク数／最大値"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from scipy.ndimage import maximum_filter\n",
+    "\n",
+    "def compute_spectral_peaks(image, threshold_ratio=0.1):\n",
+    "    f = np.fft.fft2(image)\n",
+    "    fshift = np.fft.fftshift(f)\n",
+    "    magnitude = np.abs(fshift)\n",
+    "\n",
+    "    # 局所ピークを検出\n",
+    "    max_local = maximum_filter(magnitude, size=3)\n",
+    "    peaks = (magnitude == max_local) & (magnitude > magnitude.max() * threshold_ratio)\n",
+    "\n",
+    "    num_peaks = np.sum(peaks)\n",
+    "    max_peak = magnitude.max()\n",
+    "\n",
+    "    return num_peaks, max_peak\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def extract_fft_features_with_units(image, mm_per_pixel=None):\n",
+    "    features = {}\n",
+    "\n",
+    "    # 変換係数（Noneなら pixel単位のまま）\n",
+    "    freq_unit = \"cycle/pixel\"\n",
+    "    scale = 1.0\n",
+    "    if mm_per_pixel is not None:\n",
+    "        freq_unit = \"cycle/mm\"\n",
+    "        scale = 1.0 / mm_per_pixel\n",
+    "\n",
+    "    # 1. 高周波/低周波エネルギー比（スケール影響なし）\n",
+    "    high_low_ratio = compute_high_low_freq_ratio(image)\n",
+    "    features[\"high_low_ratio\"] = (high_low_ratio, \"ratio\")\n",
+    "\n",
+    "    # 2. スペクトルの分散（標準偏差）\n",
+    "    spectral_std = compute_spectral_std(image) * scale\n",
+    "    features[\"spectral_std\"] = (spectral_std, freq_unit)\n",
+    "\n",
+    "    # 3. 方向性エネルギー（水平／垂直）\n",
+    "    horizontal_energy = compute_directional_energy(image, angle_deg=0)\n",
+    "    features[\"horizontal_energy\"] = (horizontal_energy, \"ratio\")\n",
+    "\n",
+    "    vertical_energy = compute_directional_energy(image, angle_deg=90)\n",
+    "    features[\"vertical_energy\"] = (vertical_energy, \"ratio\")\n",
+    "\n",
+    "    # 4. スペクトルピーク数と最大値\n",
+    "    num_peaks, max_peak_amp = compute_spectral_peaks(image)\n",
+    "    features[\"num_peaks\"] = (num_peaks, \"count\")\n",
+    "    features[\"max_peak_amp\"] = (max_peak_amp, \"power\")\n",
+    "\n",
+    "    # 5. 周波数帯エネルギー\n",
+    "    band_energies = compute_band_energy(image)\n",
+    "    for k, v in band_energies.items():\n",
+    "        features[k] = (v, \"ratio\")\n",
+    "\n",
+    "    # 6. スペクトル重心\n",
+    "    spectral_centroid = compute_spectral_centroid(image) * scale\n",
+    "    features[\"spectral_centroid\"] = (spectral_centroid, freq_unit)\n",
+    "\n",
+    "    return features\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "high_low_ratio: 0.0052 [ratio]\n",
+      "spectral_std: 2.2859 [cycle/mm]\n",
+      "horizontal_energy: 0.4995 [ratio]\n",
+      "vertical_energy: 0.1032 [ratio]\n",
+      "num_peaks: 7.0000 [count]\n",
+      "max_peak_amp: 34999978.0000 [power]\n",
+      "band_1_0.00_0.10: 0.9831 [ratio]\n",
+      "band_2_0.10_0.30: 0.0159 [ratio]\n",
+      "band_3_0.30_0.50: 0.0010 [ratio]\n",
+      "spectral_centroid: 3.1382 [cycle/mm]\n"
+     ]
+    }
+   ],
+   "source": [
+    "features = extract_fft_features_with_units(img, mm_per_pixel=0.050)\n",
+    "for key, (val, unit) in features.items():\n",
+    "    print(f\"{key}: {val:.4f} [{unit}]\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "vcc",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
- Add FFTFrequencyExtractor with 8 frequency domain features
- Extract spectral centroid, band energies, directional energies
- Support mm_per_pixel scaling for frequency units
- Fix GLCM ASM property name from 'asm' to 'ASM' (scikit-image requirement)
- Add comprehensive tests for FFT extractor
- Update configuration schemas and default settings