### PR TITLE
docs: GitHub Issue/PR テンプレートを設置

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,37 @@
+---
+name: Bug Report
+about: Report a bug or unexpected behavior
+labels: bug
+---
+
+## Summary
+
+<!-- A clear and concise description of the bug. -->
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+
+## Expected Behavior
+
+<!-- What you expected to happen. -->
+
+## Actual Behavior
+
+<!-- What actually happened. -->
+
+## Environment
+
+- OS:
+- Runtime:
+- Version:
+
+## Additional Context
+
+<!-- Screenshots, logs, or any other relevant information. -->
+
+---
+
+> **Branch prefix**: `fix/`

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/documentation_request.md
+++ b/.github/ISSUE_TEMPLATE/documentation_request.md
@@ -1,0 +1,25 @@
+---
+name: Documentation Request
+about: Request new or improved documentation
+labels: documentation
+---
+
+## Summary
+
+<!-- Brief description of the documentation improvement. -->
+
+## Target Documents
+
+<!-- Which files or sections need to be updated? -->
+
+## Proposed Changes
+
+<!-- What should be added, changed, or clarified? -->
+
+## Acceptance Criteria
+
+- [ ]
+
+---
+
+> **Branch prefix**: `docs/`

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,33 @@
+---
+name: Feature Request
+about: Suggest a new feature or enhancement
+labels: enhancement
+---
+
+## Summary
+
+<!-- Brief description of the feature. -->
+
+## Background
+
+<!-- Why is this feature needed? What problem does it solve? -->
+
+## Scope
+
+<!-- What should be included in the implementation? -->
+
+## Out of Scope
+
+<!-- What is explicitly NOT included? -->
+
+## Acceptance Criteria
+
+- [ ]
+
+## Additional Context
+
+<!-- Any other context, references, or screenshots. -->
+
+---
+
+> **Branch prefix**: `feature/`

--- a/.github/ISSUE_TEMPLATE/refactor_request.md
+++ b/.github/ISSUE_TEMPLATE/refactor_request.md
@@ -1,0 +1,29 @@
+---
+name: Refactor Request
+about: Propose a code refactoring
+labels: refactoring
+---
+
+## Summary
+
+<!-- Brief description of the refactoring. -->
+
+## Background
+
+<!-- Why is this refactoring needed? -->
+
+## Current Implementation
+
+<!-- What are the problems with the current code? -->
+
+## Proposed Changes
+
+<!-- What changes do you propose? -->
+
+## Acceptance Criteria
+
+- [ ]
+
+---
+
+> **Branch prefix**: `refactor/`

--- a/.github/ISSUE_TEMPLATE/test_request.md
+++ b/.github/ISSUE_TEMPLATE/test_request.md
@@ -1,0 +1,25 @@
+---
+name: Test Request
+about: Request new or improved tests
+labels: test
+---
+
+## Summary
+
+<!-- Brief description of the test improvement. -->
+
+## Target Code
+
+<!-- Which modules or functions need test coverage? -->
+
+## Test Cases
+
+<!-- What test cases should be added or improved? -->
+
+## Acceptance Criteria
+
+- [ ]
+
+---
+
+> **Branch prefix**: `test/`

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+## Summary
+
+<!-- Brief description of what this PR does. -->
+
+-
+
+## Related Issue
+
+<!-- Link the related issue. Use `Closes #XX` to auto-close on merge. -->
+
+Closes #
+
+## Changes
+
+<!-- List the main changes. -->
+
+-
+
+## Test Plan
+
+- [ ]
+
+## Checklist
+
+- [ ]


### PR DESCRIPTION
## Summary

- `.github/ISSUE_TEMPLATE/` に 5 種類の Issue テンプレートと `config.yml` を設置.
- `.github/pull_request_template.md` を設置.

## Related Issue

Closes #80

## Changes

- `.github/ISSUE_TEMPLATE/bug_report.md`: バグ報告テンプレート.
- `.github/ISSUE_TEMPLATE/feature_request.md`: 機能要望テンプレート.
- `.github/ISSUE_TEMPLATE/refactor_request.md`: リファクタリング要望テンプレート.
- `.github/ISSUE_TEMPLATE/test_request.md`: テスト要望テンプレート.
- `.github/ISSUE_TEMPLATE/documentation_request.md`: ドキュメント要望テンプレート.
- `.github/ISSUE_TEMPLATE/config.yml`: blank issues 有効化.
- `.github/pull_request_template.md`: PR テンプレート.

## Test Plan

無し

## Checklist

無し