### PR TITLE
feat: CLI エントリーポイントを `vcc` コマンドに変更

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- CLI エントリーポイント `vcc` コマンドを追加. `uv run vcc -c 0 -p 0` でアプリケーションを起動可能に. ([#N/A](https://github.com/kurorosu/vision-capture-core/pull/N/A))
 - `config.json` の `preview` セクションでライブプレビューウィンドウの表示サイズを設定可能に. デフォルト 1280x720. アスペクト比を維持してリサイズ. ([#N/A](https://github.com/kurorosu/vision-capture-core/pull/N/A))
 - `.github/ISSUE_TEMPLATE/` に 5 種類の Issue テンプレートと `config.yml` を追加. ([#82](https://github.com/kurorosu/vision-capture-core/pull/82))
 - `.github/pull_request_template.md` を追加. ([#82](https://github.com/kurorosu/vision-capture-core/pull/82))
@@ -70,6 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - PCA コンポーネントの CSV エクスポート機能を追加. ([#76](https://github.com/kurorosu/vision-capture-core/pull/76))
 
 ### Changed
+- `app.py` を `src/cli/` パッケージに統合し, `sys.path` の手動操作を除去. ([#N/A](https://github.com/kurorosu/vision-capture-core/pull/N/A))
 - ログフォーマットを pochidetection と統一したパイプ区切り形式に変更. colorlog 未インストール時のフォールバックにも対応. ([#N/A](https://github.com/kurorosu/vision-capture-core/pull/N/A))
 - 画像処理ループのリファクタリングによる簡素化. ([#3](https://github.com/kurorosu/vision-capture-core/pull/3))
 - 関数への型ヒントの追加. ([#4](https://github.com/kurorosu/vision-capture-core/pull/4))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,9 @@ dependencies = [
     "seaborn>=0.13.2",
 ]
 
+[project.scripts]
+vcc = "cli:main"
+
 [tool.setuptools.packages.find]
 where = ["src"]
 
@@ -59,6 +62,10 @@ ignore_missing_imports = true
 [tool.pydocstyle]
 convention = "google"
 add_ignore = ["D212"]
+
+[build-system]
+requires = ["setuptools>=68.0"]
+build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/cli/__init__.py
+++ b/src/cli/__init__.py
@@ -1,0 +1,5 @@
+"""CLI エントリーポイントパッケージ."""
+
+from cli.main import main
+
+__all__ = ["main"]

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -1,17 +1,6 @@
-"""
-Vision Capture Coreのメインアプリケーションモジュール.
+"""Vision Capture Coreのメインエントリーポイント."""
 
-このモジュールは画像処理パイプラインを実行するためのエントリーポイントを提供する.
-コマンドライン引数を解析して、カメラの初期化、設定のロード、画像処理パイプラインの
-実行など、アプリケーションの主要な機能を制御する.
-"""
-
-# cap_app.py
 import argparse
-import sys
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).resolve().parent / "src"))
 
 from capture_runner import LivePreviewRunner
 from capturelib.camera_setup import CameraSetup
@@ -62,8 +51,8 @@ def parse_arguments():
     return parser.parse_args()
 
 
-# メイン処理
-if __name__ == "__main__":
+def main():
+    """アプリケーションのメインエントリーポイント."""
     # コマンドライン引数の解析
     args = parse_arguments()
 

--- a/uv.lock
+++ b/uv.lock
@@ -1440,7 +1440,7 @@ wheels = [
 [[package]]
 name = "vision-capture-core"
 version = "0.1.0"
-source = { virtual = "." }
+source = { editable = "." }
 dependencies = [
     { name = "click" },
     { name = "colorlog" },


### PR DESCRIPTION
## Summary

- `src/cli/` パッケージを新規作成し, `app.py` のロジックを `src/cli/main.py` に移動.
- `pyproject.toml` に `[project.scripts]` と `[build-system]` を追加し, `uv run vcc` で起動可能にした.
- `app.py` を削除し, `sys.path` の手動操作を不要にした.

## Related Issue

Closes #XX

## Changes

- `app.py` を削除し, `src/cli/__init__.py` と `src/cli/main.py` に統合.
- `pyproject.toml` に `[project.scripts] vcc = "cli:main"` を追加.
- `pyproject.toml` に `[build-system]` セクションを追加 (setuptools).

```python
# src/cli/__init__.py
from cli.main import main
```

```python
# src/cli/main.py
def main():
    """アプリケーションのメインエントリーポイント."""
    args = parse_arguments()
    ...
```

```toml
# pyproject.toml
[project.scripts]
vcc = "cli:main"

[build-system]
requires = ["setuptools>=68.0"]
build-backend = "setuptools.build_meta"
```

## Test Plan

- `uv run vcc --help` でヘルプが表示されること
- `uv run vcc -l` でプロファイル一覧が表示されること
- `uv run vcc -c 0 -p 0` でアプリケーションが起動すること
- `uv run pytest` 全テスト passed (246 tests)

## Checklist

- [x] `uv run pytest` 全テスト passed (246 tests)
- [x] `uv run pre-commit run --all-files` 全フック passed
- [x] `uv run vcc --help` / `uv run vcc -l` 動作確認済み