### PR TITLE
refactor: 価値の低いDoコメントを削除

### DIFF
--- a/.github/ISSUE_TEMPLATE/refactor_request.md
+++ b/.github/ISSUE_TEMPLATE/refactor_request.md
@@ -1,7 +1,7 @@
 ---
 name: Refactor Request
 about: Propose a code refactoring
-labels: refactoring
+labels: refactor
 ---
 
 ## Summary

--- a/pochivision/capturelib/camera_setup.py
+++ b/pochivision/capturelib/camera_setup.py
@@ -39,19 +39,14 @@ class CameraSetup:
     def load_camera_config(self) -> None:
         """設定からカメラ設定を読み込む. CLIで指定されたカメラインデックスとプロファイル名を優先する."""
         try:
-            # カメラインデックスが指定されていない場合は設定ファイルから取得
             # argsでデフォルト0にしたから不要かも
             if self.camera_index is None:
                 self.camera_index = self.config.get("selected_camera_index", 0)
 
-            # カメラプロファイルが指定されていない場合は常にプロファイル "0" を使用
             if self.profile_name is None:
                 self.profile_name = "0"
 
-            # プロファイルキーを設定
             profile_key = self.profile_name
-
-            # カメラの設定をcameras辞書から取得
             camera_config = self.config.get("cameras", {}).get(profile_key, {})
 
             if not camera_config:
@@ -60,7 +55,6 @@ class CameraSetup:
                     f"not found in config, using default settings"
                 )
 
-            # カメラの解像度設定を取得
             self.width = camera_config.get("width", 640)
             self.height = camera_config.get("height", 480)
             self.fps = camera_config.get("fps", 30)
@@ -84,7 +78,6 @@ class CameraSetup:
         """
         self.logger.info(f"Initializing camera {self.camera_index}")
 
-        # バックエンドが指定されている場合は適用
         if self.backend:
             backend_constant = getattr(cv2, f"CAP_{self.backend}", None)
             if backend_constant is not None:
@@ -99,14 +92,10 @@ class CameraSetup:
             self.logger.error(f"Failed to open camera {self.camera_index}")
             return cap
 
-        # 解像度の設定
         cap.set(cv2.CAP_PROP_FRAME_WIDTH, self.width)
         cap.set(cv2.CAP_PROP_FRAME_HEIGHT, self.height)
-
-        # FPSの設定
         cap.set(cv2.CAP_PROP_FPS, self.fps)
 
-        # 実際に設定された解像度を取得
         actual_width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
         actual_height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
         actual_fps = int(cap.get(cv2.CAP_PROP_FPS))
@@ -117,7 +106,6 @@ class CameraSetup:
                 f"Actual resolution: {actual_width}x{actual_height}"
             )
 
-            # 実際の解像度で更新
             self.width = actual_width
             self.height = actual_height
 

--- a/pochivision/cli/main.py
+++ b/pochivision/cli/main.py
@@ -53,20 +53,16 @@ def parse_arguments():
 
 def main():
     """アプリケーションのメインエントリーポイント."""
-    # コマンドライン引数の解析
     args = parse_arguments()
 
-    # ロギングの初期化
     log_manager = LogManager()
     logger = log_manager.get_logger()
     logger.info("Starting pochivision application")
 
-    # 設定ファイルの読み込み
     try:
         config = ConfigHandler.load(args.config)
         logger.info("Configuration loaded successfully")
 
-        # プロファイル一覧表示モードの場合
         if args.list_profiles:
             logger.info("Available camera profiles:")
             for profile in config.get("cameras", {}).keys():
@@ -87,21 +83,17 @@ def main():
         logger.error(f"Failed to load configuration: {e}")
         exit(1)
 
-    # CameraSetupを使用したカメラの設定
     try:
-        # カメラセットアップの初期化（コマンドライン引数を反映）
         camera_setup = CameraSetup(
             config, log_manager, camera_index=args.camera, profile_name=args.profile
         )
         camera_setup.load_camera_config()
         cap = camera_setup.initialize_camera()
 
-        # カメラが正常に開かれたか確認
         if not cap.isOpened():
             logger.error(f"Failed to open camera {camera_setup.camera_index}. Exiting.")
             exit(1)
 
-        # camera_setupの解像度情報を使用してカメラ情報をログに記録
         log_manager.log_camera_info(
             cap,
             camera_setup.camera_index,
@@ -114,9 +106,7 @@ def main():
         logger.error(f"Error setting up camera: {e}")
         exit(1)
 
-    # キャプチャマネージャとパイプラインの作成
     try:
-        # ここで初期化＆ログファイル設定
         capture_manager = CaptureManager()
         log_manager.setup_file_logging(
             capture_manager.get_log_file_path(camera_index=camera_setup.camera_index)
@@ -125,10 +115,8 @@ def main():
             f"Capture manager initialized for camera {camera_setup.camera_index}"
         )
 
-        # システム情報のログ出力（ここに移動）
         log_manager.log_system_info()
 
-        # 実際に使用したプロファイルのみを含むconfigを作成
         used_profile = camera_setup.profile_name
         minimal_config = {
             "cameras": {used_profile: config["cameras"][used_profile]},
@@ -139,7 +127,6 @@ def main():
             capture_manager.get_output_dir(camera_index=camera_setup.camera_index),
         )
 
-        # パイプラインエグゼキューターの初期化（カメラインデックスとプロファイル名を渡す）
         pipeline = PipelineExecutor.from_config(
             config,
             capture_manager=capture_manager,
@@ -147,10 +134,8 @@ def main():
             profile_name=camera_setup.profile_name,
         )
 
-        # 録画マネージャーの初期化（オプション）
         recording_manager = None
         if not args.no_recording:
-            # 設定ファイルから録画形式を取得
             recording_config = config.get("recording", {})
             select_format = recording_config.get("select_format", "mjpg")
 
@@ -159,14 +144,12 @@ def main():
         else:
             logger.info("Recording functionality disabled")
 
-        # プレビューサイズの取得
         preview_config = config.get("preview", {})
         preview_size = (
             preview_config.get("width", 1280),
             preview_config.get("height", 720),
         )
 
-        # アプリケーションの作成と実行
         app = LivePreviewRunner(cap, pipeline, recording_manager, preview_size)
         logger.info("Starting application main loop")
         app.run()
@@ -175,5 +158,4 @@ def main():
         logger.error(f"Error during execution: {e}")
 
     finally:
-        # アプリケーション終了ログ
         logger.info("Application shutdown complete")

--- a/pochivision/core/pipeline_executor.py
+++ b/pochivision/core/pipeline_executor.py
@@ -54,26 +54,20 @@ class PipelineExecutor:
         self.config_fps = config_fps
         self.logger = LogManager().get_logger()
 
-        # モード制限のあるプロセッサに対して実行モードを設定
         for processor in processors:
             if hasattr(processor, "set_pipeline_mode"):
                 processor.set_pipeline_mode(mode)
 
-        # ID間隔を設定
         file_naming_manager = get_file_naming_manager()
-        # original用の間隔設定
         file_naming_manager.set_id_interval("original", camera_index, id_interval)
-        # pipeline用の間隔設定（パイプラインモードの場合）
         if mode == "pipeline":
             file_naming_manager.set_id_interval("pipeline", camera_index, id_interval)
-        # 各プロセッサ用の間隔設定（parallelモードの場合）
         if mode == "parallel":
             for processor in processors:
                 file_naming_manager.set_id_interval(
                     processor.name, camera_index, id_interval
                 )
 
-        # プロセッサ情報をログに記録
         self.logger.info(f"Pipeline mode: {mode}")
         self.logger.info(f"Processors: {', '.join([p.name for p in processors])}")
         self.logger.info(f"ID interval: {id_interval}")
@@ -104,12 +98,10 @@ class PipelineExecutor:
             Exception: カメラプロファイルのプロセッサ設定が取得できない場合.
         """
         try:
-            # カメラプロファイルからプロセッサ設定を取得
             processor_names, processor_configs, mode = (
                 CameraConfigHandler.get_camera_processors(config, profile_name)
             )
 
-            # カメラごとのid_intervalを参照
             camera_config = config.get("cameras", {}).get(profile_name, {})
             id_interval = camera_config.get("id_interval", config.get("id_interval", 1))
             config_fps = camera_config.get("fps", 30.0)
@@ -118,7 +110,6 @@ class PipelineExecutor:
             file_naming_manager = get_file_naming_manager()
             file_naming_manager.set_label(camera_index, label)
 
-            # プロセッサインスタンスの生成
             processors: List[BaseProcessor] = []
             for name in processor_names:
                 if name not in PROCESSOR_REGISTRY:
@@ -130,7 +121,6 @@ class PipelineExecutor:
                 )
                 processors.append(processor)
 
-            # インスタンス生成
             return cls(
                 processors=processors,
                 capture_manager=capture_manager,
@@ -153,7 +143,6 @@ class PipelineExecutor:
         """
         start_time = time.time()
 
-        # オリジナル画像を保存
         original_dir = self.capture_manager.get_processing_dir(
             "original", self.camera_index
         )
@@ -171,7 +160,6 @@ class PipelineExecutor:
         except Exception as e:
             self.logger.error(f"Failed to save original image: {e}")
 
-        # 処理された画像を保存する辞書
         processed_images = {"original": image.copy()}
         if self.mode == "parallel":
             for processor in self.processors:
@@ -229,13 +217,11 @@ class PipelineExecutor:
             image (np.ndarray): 処理済み画像.
             processor_name (str): 処理に使われたプロセッサの名前.
         """
-        # パイプラインモード時は"pipeline"ディレクトリに保存
         save_dir_name = processor_name
         save_dir = self.capture_manager.get_processing_dir(
             save_dir_name, self.camera_index
         )
 
-        # 新しいファイル命名規則を使用
         filename, id_index, image_index = get_file_naming_manager().get_filename(
             save_dir_name, self.camera_index
         )

--- a/pochivision/feature_extractors/brightness_statistics.py
+++ b/pochivision/feature_extractors/brightness_statistics.py
@@ -75,10 +75,7 @@ class BrightnessStatisticsExtractor(BaseFeatureExtractor):
         if image is None or image.size == 0:
             raise ValueError("Input image is empty or None")
 
-        # 輝度画像の取得
         brightness_image = self._get_brightness_image(image)
-
-        # 統計値の計算
         pixels = brightness_image.flatten().astype(np.float64)
 
         # ゼロピクセル除外の処理

--- a/pochivision/feature_extractors/circle_counter.py
+++ b/pochivision/feature_extractors/circle_counter.py
@@ -91,7 +91,6 @@ class CircleCounterExtractor(BaseFeatureExtractor):
         if image is None or image.size == 0:
             raise ValueError("Input image is empty or None")
 
-        # グレースケール変換
         gray = to_grayscale(image)
 
         # ガウシアンブラーでノイズ除去
@@ -100,7 +99,6 @@ class CircleCounterExtractor(BaseFeatureExtractor):
                 gray, (self.blur_kernel_size, self.blur_kernel_size), 0
             )
 
-        # 画像サイズから動的パラメータ計算
         height, width = gray.shape
         image_area = height * width
 
@@ -118,10 +116,7 @@ class CircleCounterExtractor(BaseFeatureExtractor):
             # 自動計算: 画像短辺の1/4（一般的に適切なデフォルト値）
             max_radius = min(height, width) // 4
 
-        # 最小距離の計算
         min_dist = max(1, int(max_radius * self.min_dist_ratio))
-
-        # HoughCircles検出
         circles = cv2.HoughCircles(
             gray,
             cv2.HOUGH_GRADIENT,
@@ -133,7 +128,6 @@ class CircleCounterExtractor(BaseFeatureExtractor):
             maxRadius=max_radius,
         )
 
-        # 検出結果の処理
         if circles is not None:
             circles = np.round(circles[0, :]).astype("int")
 
@@ -143,7 +137,6 @@ class CircleCounterExtractor(BaseFeatureExtractor):
         else:
             circles = np.array([])
 
-        # 特徴量計算
         return self._calculate_features(circles, image_area, max_radius)
 
     def _filter_by_circularity(

--- a/pochivision/feature_extractors/fft_frequency.py
+++ b/pochivision/feature_extractors/fft_frequency.py
@@ -392,7 +392,6 @@ class FFTFrequencyExtractor(BaseFeatureExtractor):
                 else:
                     image = np.clip(image, 0, 255).astype(np.uint8)
 
-        # グレースケール変換
         if len(image.shape) == 3:
             gray_image = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
         elif len(image.shape) == 2:
@@ -400,7 +399,6 @@ class FFTFrequencyExtractor(BaseFeatureExtractor):
         else:
             raise ValueError(f"Input image must be 2D or 3D, got shape: {image.shape}")
 
-        # 画像を0-255の範囲に正規化
         gray_image = cv2.normalize(
             gray_image, None, 0, 255, cv2.NORM_MINMAX, dtype=cv2.CV_8U
         )

--- a/pochivision/feature_extractors/glcm_texture.py
+++ b/pochivision/feature_extractors/glcm_texture.py
@@ -121,7 +121,6 @@ class GLCMTextureExtractor(BaseFeatureExtractor):
                 else:
                     image = np.clip(image, 0, 255).astype(np.uint8)
 
-        # グレースケール変換
         if len(image.shape) == 3:
             gray_image = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
         elif len(image.shape) == 2:
@@ -144,7 +143,6 @@ class GLCMTextureExtractor(BaseFeatureExtractor):
         results = {}
 
         try:
-            # GLCM行列の計算
             glcm = graycomatrix(
                 gray_image,
                 distances=self.distances,

--- a/pochivision/feature_extractors/hlac_texture.py
+++ b/pochivision/feature_extractors/hlac_texture.py
@@ -115,7 +115,6 @@ class HLACTextureExtractor(BaseFeatureExtractor):
                     else:
                         image = np.clip(image, 0, 255).astype(np.uint8)
 
-            # グレースケール変換
             if len(image.shape) == 3:
                 gray_image = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
             elif len(image.shape) == 2:
@@ -130,7 +129,6 @@ class HLACTextureExtractor(BaseFeatureExtractor):
                 # リサイズプロセッサーを使用してリサイズ
                 gray_image = self.resize_processor.process(gray_image)
 
-            # HLAC特徴量抽出
             features = self._extract_hlac_features(gray_image)
 
             # 結果の辞書作成（ゼロパディングで正しい順序を保証）

--- a/pochivision/feature_extractors/hsv_statistics.py
+++ b/pochivision/feature_extractors/hsv_statistics.py
@@ -90,7 +90,6 @@ class HSVStatisticsExtractor(BaseFeatureExtractor):
         # 任意の形状の画像をBGR形式に変換（グレースケール対応）
         bgr_image = to_bgr(image)
 
-        # BGR to HSV変換
         hsv_image = cv2.cvtColor(bgr_image, cv2.COLOR_BGR2HSV)
 
         results = {}
@@ -106,7 +105,6 @@ class HSVStatisticsExtractor(BaseFeatureExtractor):
         # チャンネル名の定義
         channel_names = ["hue", "saturation", "value"]
 
-        # 各チャンネルについて統計値を計算
         for i, channel_name in enumerate(channel_names):
             channel_data = hsv_image[:, :, i]
 

--- a/pochivision/feature_extractors/lbp_texture.py
+++ b/pochivision/feature_extractors/lbp_texture.py
@@ -121,7 +121,6 @@ class LBPTextureExtractor(BaseFeatureExtractor):
                     else:
                         image = np.clip(image, 0, 255).astype(np.uint8)
 
-            # グレースケール変換
             if len(image.shape) == 3:
                 gray_image = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
             elif len(image.shape) == 2:
@@ -136,16 +135,13 @@ class LBPTextureExtractor(BaseFeatureExtractor):
                 # リサイズプロセッサーを使用してリサイズ
                 gray_image = self.resize_processor.process(gray_image)
 
-            # LBP計算
             lbp = local_binary_pattern(gray_image, self.P, self.R, method=self.method)
 
-            # ヒストグラム計算
             n_bins = int(lbp.max() + 1)  # 実際のラベル数で固定次元化
             hist, _ = np.histogram(
                 lbp.ravel(), bins=n_bins, range=(0, n_bins), density=True
             )
 
-            # 統計量計算
             results = self._calculate_statistics(hist, lbp)
 
             # ヒストグラムの各ビンを特徴量として追加（オプション）

--- a/pochivision/feature_extractors/rgb_statistics.py
+++ b/pochivision/feature_extractors/rgb_statistics.py
@@ -92,7 +92,6 @@ class RGBStatisticsExtractor(BaseFeatureExtractor):
         # チャンネル名の定義
         channel_names = ["red", "green", "blue"]
 
-        # 各チャンネルについて統計値を計算
         for i, channel_name in enumerate(channel_names):
             channel_data = rgb_image[:, :, i]
 

--- a/pochivision/feature_extractors/swt_frequency.py
+++ b/pochivision/feature_extractors/swt_frequency.py
@@ -276,13 +276,11 @@ class SWTFrequencyExtractor(BaseFeatureExtractor):
             RuntimeError: SWT変換に失敗した場合
         """
         try:
-            # 画像をグレースケールに変換（既にグレースケールの場合はそのまま）
             gray_image = to_grayscale(image)
 
             # SWT変換のために画像サイズを調整（奇数サイズを偶数サイズに）
             gray_image = self._adjust_image_size_for_swt(gray_image)
 
-            # 画像を0-1の範囲に正規化
             if gray_image.max() > 1.0:
                 gray_image = gray_image.astype(np.float32) / 255.0
             else:

--- a/pochivision/processors/blur.py
+++ b/pochivision/processors/blur.py
@@ -43,11 +43,8 @@ class GaussianBlurProcessor(BaseProcessor):
             config (Dict[str, Any]): 設定パラメータ.
         """
         super().__init__(name, config)
-        # パラメータのバリデーション
         self.validator = GaussianBlurValidator(config)
         self.validator.validate_config()
-
-        # バリデータから検証済みの値を取得
         self.kernel_size = (self.validator.kernel_width, self.validator.kernel_height)
         self.sigma_x = self.validator.sigma_x
         self.sigma_y = self.validator.sigma_y
@@ -66,10 +63,8 @@ class GaussianBlurProcessor(BaseProcessor):
             ProcessorValidationError: 入力画像が不正な場合.
             ProcessorRuntimeError: OpenCV処理中にエラーが発生した場合.
         """
-        # 入力画像のバリデーション
         self.validator.validate_image(image)
 
-        # ガウシアンブラー処理
         try:
             return cv2.GaussianBlur(
                 image, self.kernel_size, self.sigma_x, sigmaY=self.sigma_y
@@ -120,11 +115,8 @@ class AverageBlurProcessor(BaseProcessor):
             config (Dict[str, Any]): 設定パラメータ.
         """
         super().__init__(name, config)
-        # パラメータのバリデーション
         self.validator = AverageBlurValidator(config)
         self.validator.validate_config()
-
-        # バリデータから検証済みの値を取得
         self.kernel_size = (self.validator.kernel_width, self.validator.kernel_height)
 
     def process(self, image: np.ndarray) -> np.ndarray:
@@ -141,10 +133,8 @@ class AverageBlurProcessor(BaseProcessor):
             ProcessorValidationError: 入力画像が不正な場合.
             ProcessorRuntimeError: OpenCV処理中にエラーが発生した場合.
         """
-        # 入力画像のバリデーション
         self.validator.validate_image(image)
 
-        # 平均値ブラー処理
         try:
             return cv2.blur(image, self.kernel_size)
         except cv2.error as e:
@@ -194,11 +184,8 @@ class MedianBlurProcessor(BaseProcessor):
             config (Dict[str, Any]): 設定パラメータ.
         """
         super().__init__(name, config)
-        # パラメータのバリデーション
         self.validator = MedianBlurValidator(config)
         self.validator.validate_config()
-
-        # バリデータから検証済みの値を取得
         self.kernel_size = self.validator.kernel_size
 
     def process(self, image: np.ndarray) -> np.ndarray:
@@ -215,10 +202,8 @@ class MedianBlurProcessor(BaseProcessor):
             ProcessorValidationError: 入力画像が不正な場合.
             ProcessorRuntimeError: OpenCV処理中にエラーが発生した場合.
         """
-        # 入力画像のバリデーション
         self.validator.validate_image(image)
 
-        # メディアンブラー処理
         try:
             return cv2.medianBlur(image, self.kernel_size)
         except cv2.error as e:
@@ -269,11 +254,8 @@ class BilateralFilterProcessor(BaseProcessor):
             config (Dict[str, Any]): 設定パラメータ.
         """
         super().__init__(name, config)
-        # パラメータのバリデーション
         self.validator = BilateralFilterValidator(config)
         self.validator.validate_config()
-
-        # バリデータから検証済みの値を取得
         self.d = self.validator.d
         self.sigma_color = self.validator.sigma_color
         self.sigma_space = self.validator.sigma_space
@@ -292,10 +274,8 @@ class BilateralFilterProcessor(BaseProcessor):
             ProcessorValidationError: 入力画像が不正な場合.
             ProcessorRuntimeError: OpenCV処理中にエラーが発生した場合.
         """
-        # 入力画像のバリデーション
         self.validator.validate_image(image)
 
-        # バイラテラルフィルタ処理
         try:
             # パラメータを確実に利用可能にする（バリデーションが成功していれば通常はNoneではない）
             d = self.d
@@ -356,11 +336,8 @@ class MotionBlurProcessor(BaseProcessor):
             config (Dict[str, Any]): 設定パラメータ.
         """
         super().__init__(name, config)
-        # パラメータのバリデーション
         self.validator = MotionBlurValidator(config)
         self.validator.validate_config()
-
-        # バリデータから検証済みの値を取得
         self.kernel_size = self.validator.kernel_size
         self.angle = self.validator.angle
 
@@ -378,7 +355,6 @@ class MotionBlurProcessor(BaseProcessor):
             ProcessorValidationError: 入力画像が不正な場合.
             ProcessorRuntimeError: OpenCV処理中にエラーが発生した場合.
         """
-        # 入力画像のバリデーション
         self.validator.validate_image(image)
 
         try:
@@ -393,7 +369,6 @@ class MotionBlurProcessor(BaseProcessor):
                 )
                 raise ProcessorRuntimeError(error_msg)
 
-            # カーネル生成
             kernel = np.zeros((kernel_size, kernel_size), dtype=np.float32)
             center = kernel_size // 2
             rad = np.deg2rad(angle)

--- a/pochivision/processors/clahe.py
+++ b/pochivision/processors/clahe.py
@@ -53,12 +53,9 @@ class CLAHEProcessor(BaseProcessor):
         self.validator = CLAHEInputValidator(self.config)
         self.validator.validate_config()
 
-        # デフォルト値の設定
         self.color_mode = self.config.get("color_mode", "gray")
         self.clip_limit = float(self.config.get("clip_limit", 2.0))
         self.tile_grid_size = tuple(self.config.get("tile_grid_size", [8, 8]))
-
-        # CLAHEインスタンスの作成
         self.clahe = cv2.createCLAHE(
             clipLimit=self.clip_limit, tileGridSize=self.tile_grid_size
         )
@@ -77,34 +74,26 @@ class CLAHEProcessor(BaseProcessor):
             ProcessorValidationError: 入力画像が不正な場合.
             ProcessorRuntimeError: 処理中にエラーが発生した場合.
         """
-        # 入力画像のバリデーション
         self.validator.validate_image(image)
 
         try:
-            # 画像がグレースケールの場合は直接処理
             if len(image.shape) == 2 or image.shape[2] == 1:
                 return self.clahe.apply(image)
 
             # カラー画像の処理
             if self.color_mode == "gray":
-                # グレースケール変換してから処理
                 gray = to_grayscale(image)
                 clahe_img = self.clahe.apply(gray)
-                # 3チャンネルに戻す
                 return cv2.cvtColor(clahe_img, cv2.COLOR_GRAY2BGR)
 
             elif self.color_mode == "lab":
-                # LAB色空間に変換
                 lab = cv2.cvtColor(image, cv2.COLOR_BGR2LAB)
-                # Lチャンネルのみ処理
                 l, a, b = cv2.split(lab)
                 clahe_l = self.clahe.apply(l)
-                # チャンネルを結合してBGRに戻す
                 clahe_lab = cv2.merge([clahe_l, a, b])
                 return cv2.cvtColor(clahe_lab, cv2.COLOR_LAB2BGR)
 
             elif self.color_mode == "bgr":
-                # 各チャンネルを個別に処理
                 b, g, r = cv2.split(image)
                 clahe_b = self.clahe.apply(b)
                 clahe_g = self.clahe.apply(g)

--- a/pochivision/processors/contour.py
+++ b/pochivision/processors/contour.py
@@ -31,21 +31,18 @@ class ContourProcessor(BaseProcessor):
 
         default_vals = self.get_default_config()
 
-        # retrieval_modeの設定と変換
         retrieval_mode_str = self.config.get(
             "retrieval_mode", default_vals["retrieval_mode"]
         )
         self._retrieval_mode = self._get_retrieval_mode(retrieval_mode_str)
         self._retrieval_mode_str = retrieval_mode_str
 
-        # approximation_methodの設定と変換
         approx_method_str = self.config.get(
             "approximation_method", default_vals["approximation_method"]
         )
         self._approximation_method = self._get_approximation_method(approx_method_str)
         self._approx_method_str = approx_method_str
 
-        # その他のパラメータ設定
         self._min_area = self.config.get("min_area", default_vals["min_area"])
         self._select_mode = self.config.get("select_mode", default_vals["select_mode"])
         self._contour_rank = self.config.get(
@@ -112,7 +109,6 @@ class ContourProcessor(BaseProcessor):
         if not contours:
             return None
 
-        # 最小面積でフィルタリング
         if self._min_area > 0:
             filtered_contours = [
                 c for c in contours if cv2.contourArea(c) >= self._min_area
@@ -123,7 +119,6 @@ class ContourProcessor(BaseProcessor):
         if not filtered_contours:
             return None
 
-        # 面積順にソート（降順）
         sorted_contours = sorted(filtered_contours, key=cv2.contourArea, reverse=True)
 
         # 指定されたランク（0から始まる）の輪郭を選択
@@ -147,10 +142,8 @@ class ContourProcessor(BaseProcessor):
         Raises:
             ProcessorRuntimeError: 画像処理中にエラーが発生した場合.
         """
-        # 入力画像の検証 - 二値化されているかのチェックを含む
         is_valid, _ = self.validator.validate_image_for_contour(image)
 
-        # 二値化されていない場合は元の画像を返す
         if not is_valid:
             # 色空間の変換（グレースケール→BGR）が必要な場合は対応
             if image.ndim == 2:
@@ -158,7 +151,6 @@ class ContourProcessor(BaseProcessor):
             return image.copy()
 
         try:
-            # 画像をグレースケールに変換（入力がカラー画像の場合）
             gray_image = to_grayscale(image)
 
             # 画像がfloat32の場合はuint8に変換
@@ -168,12 +160,10 @@ class ContourProcessor(BaseProcessor):
                 else:
                     gray_image = gray_image.astype(np.uint8)
 
-            # 輪郭検出（前段で処理された二値画像を直接使用）
             contours, _ = cv2.findContours(
                 gray_image, self._retrieval_mode, self._approximation_method
             )
 
-            # 選択モードに応じて輪郭を選択
             if self._select_mode == "rank":
                 # ランクによる選択
                 selected_contour = self._select_contour_by_rank(contours)
@@ -188,22 +178,15 @@ class ContourProcessor(BaseProcessor):
                         c for c in contours if cv2.contourArea(c) >= self._min_area
                     ]
 
-            # 出力画像を準備（初期状態は外側色）
             output_image = np.full(
                 (image.shape[0], image.shape[1], 3),
                 self._outside_color,
                 dtype=np.uint8,
             )
 
-            # 輪郭が見つかった場合は、内側を内側色で塗る
             if contours:
-                # マスク画像を作成
                 mask = np.zeros(image.shape[:2], dtype=np.uint8)
-
-                # 輪郭内部を塗りつぶす
                 cv2.drawContours(mask, contours, -1, 255, cv2.FILLED)
-
-                # マスクを適用して内側色を設定
                 output_image[mask > 0] = self._inside_color
 
             return output_image

--- a/pochivision/processors/equalize.py
+++ b/pochivision/processors/equalize.py
@@ -64,34 +64,26 @@ class EqualizeProcessor(BaseProcessor):
             ProcessorValidationError: 入力画像が不正な場合.
             ProcessorRuntimeError: 処理中にエラーが発生した場合.
         """
-        # 入力画像のバリデーション
         self.validator.validate_image(image)
 
         try:
-            # 画像がグレースケールの場合は直接処理
             if len(image.shape) == 2 or image.shape[2] == 1:
                 return cv2.equalizeHist(image)
 
             # カラー画像の処理
             if self.color_mode == "gray":
-                # グレースケール変換してから処理
                 gray = to_grayscale(image)
                 equalized = cv2.equalizeHist(gray)
-                # 3チャンネルに戻す
                 return cv2.cvtColor(equalized, cv2.COLOR_GRAY2BGR)
 
             elif self.color_mode == "lab":
-                # LAB色空間に変換
                 lab = cv2.cvtColor(image, cv2.COLOR_BGR2LAB)
-                # Lチャンネルのみ平坦化
                 l, a, b = cv2.split(lab)
                 equalized_l = cv2.equalizeHist(l)
-                # チャンネルを結合してBGRに戻す
                 equalized_lab = cv2.merge([equalized_l, a, b])
                 return cv2.cvtColor(equalized_lab, cv2.COLOR_LAB2BGR)
 
             elif self.color_mode == "bgr":
-                # 各チャンネルを個別に平坦化
                 b, g, r = cv2.split(image)
                 equalized_b = cv2.equalizeHist(b)
                 equalized_g = cv2.equalizeHist(g)

--- a/pochivision/processors/grayscale.py
+++ b/pochivision/processors/grayscale.py
@@ -37,7 +37,6 @@ class GrayscaleProcessor(BaseProcessor):
             config (Dict[str, Any]): 設定パラメータ.
         """
         super().__init__(name, config)
-        # パラメータのバリデーション
         self.validator = GrayscaleValidator(config)
         self.validator.validate_config()
 
@@ -55,10 +54,8 @@ class GrayscaleProcessor(BaseProcessor):
             ProcessorValidationError: 入力画像が不正な場合.
             ProcessorRuntimeError: 画像変換に失敗した場合.
         """
-        # 入力画像のバリデーション
         self.validator.validate_image(image)
 
-        # グレースケール変換処理
         try:
             return to_grayscale(image)
         except Exception as e:

--- a/pochivision/processors/mask_composition.py
+++ b/pochivision/processors/mask_composition.py
@@ -210,13 +210,9 @@ class MaskCompositionProcessor(BaseProcessor):
                 # 黒ピクセル部分（0）をマスクとして使用
                 mask = cv2.bitwise_not(mask_gray)
 
-            # マスク部分にターゲット画像を適用
             result = cv2.bitwise_and(target_image, target_image, mask=mask)
-
-            # マスク以外の部分をマスク画像で埋める
             inv_mask = cv2.bitwise_not(mask)
 
-            # マスク画像がグレースケールの場合、3チャンネルに変換
             if len(mask_image.shape) == 2:
                 mask_to_use = cv2.cvtColor(mask_image, cv2.COLOR_GRAY2BGR)
             else:
@@ -225,12 +221,9 @@ class MaskCompositionProcessor(BaseProcessor):
             mask_part = cv2.bitwise_and(mask_to_use, mask_to_use, mask=inv_mask)
             result = cv2.add(result, mask_part)
 
-            # トリミング処理（オプション）
             if self.enable_cropping:
-                # トリミング範囲を計算（白ピクセル領域に基づく）
                 crop_bounds = self._find_crop_bounds(mask_gray)
                 if crop_bounds is not None:
-                    # 結果画像をトリミング
                     result = self._crop_image(result, crop_bounds)
 
             return result

--- a/pochivision/processors/resize.py
+++ b/pochivision/processors/resize.py
@@ -31,11 +31,8 @@ class ResizeProcessor(BaseProcessor):
                 - aspect_ratio_mode (str, optional): アスペクト比保持モード ('width' or 'height')
         """
         super().__init__(name, config)
-        # パラメータのバリデーション
         self.validator = ResizeConfigValidator(config)
         self.validator.validate_config()
-
-        # デフォルト設定を取得してDRY原則に従う
         default_config = self.get_default_config()
         self.width = config.get("width", default_config["width"])
         self.height = config.get("height", default_config["height"])
@@ -56,16 +53,10 @@ class ResizeProcessor(BaseProcessor):
         Returns:
             np.ndarray: リサイズされた画像.
         """
-        # 入力画像のバリデーション
         self.validator.validate_image(image)
 
-        # 元の画像サイズを取得
         h, w = image.shape[:2]
-
-        # リサイズ後のサイズを計算
         target_w, target_h = self._calculate_target_size(w, h)
-
-        # リサイズ処理
         return cv2.resize(image, (target_w, target_h), interpolation=cv2.INTER_AREA)
 
     def _calculate_target_size(self, orig_width: int, orig_height: int) -> tuple:
@@ -88,7 +79,6 @@ class ResizeProcessor(BaseProcessor):
                 self.height if self.height is not None else orig_height,
             )
 
-        # アスペクト比を保持する場合
         aspect_ratio = orig_width / orig_height
 
         if self.aspect_ratio_mode == "width" and self.width is not None:

--- a/pochivision/tools/profile_processor.py
+++ b/pochivision/tools/profile_processor.py
@@ -95,7 +95,6 @@ class ProfileProcessor:
 
         for processor_name in processor_names:
             try:
-                # プロセッサ固有の設定を取得
                 processor_config = self.profile_config.get(processor_name, {})
                 processor = get_processor(processor_name, processor_config)
                 processors.append(processor)


### PR DESCRIPTION
## Summary

- コード処理内容をそのまま繰り返すだけのDoコメントを21ファイルから約90件削除した.
- 「なぜ」を説明するWhyコメントやdocstringは保持した.

## Related Issue

Closes #98

## Changes

- `pochivision/cli/main.py`: `# コマンドライン引数の解析`, `# ロギングの初期化` 等14件を削除
- `pochivision/capturelib/camera_setup.py`: `# 解像度の設定`, `# FPSの設定` 等10件を削除
- `pochivision/core/pipeline_executor.py`: `# プロセッサインスタンスの生成`, `# オリジナル画像を保存` 等14件を削除
- `pochivision/processors/blur.py`: `# パラメータのバリデーション`, `# 入力画像のバリデーション` 等のパターンを5つのプロセッサクラスから削除
- `pochivision/processors/clahe.py`: `# CLAHEインスタンスの作成`, `# LAB色空間に変換` 等を削除
- `pochivision/processors/contour.py`: `# 輪郭検出`, `# マスク画像を作成`, `# 面積順にソート` 等を削除
- `pochivision/processors/equalize.py`: `# グレースケール変換してから処理`, `# Lチャンネルのみ平坦化` 等を削除
- `pochivision/processors/grayscale.py`: `# パラメータのバリデーション`, `# グレースケール変換処理` を削除
- `pochivision/processors/mask_composition.py`: `# マスク部分にターゲット画像を適用`, `# トリミング処理` 等を削除
- `pochivision/processors/resize.py`: `# 入力画像のバリデーション`, `# リサイズ処理` 等を削除
- `pochivision/feature_extractors/`: 9ファイルから `# グレースケール変換`, `# LBP計算`, `# GLCM行列の計算` 等を削除
- `pochivision/tools/profile_processor.py`: `# プロセッサ固有の設定を取得` を削除

## Test Plan

- [x] `uv run pytest` で全297テストがパスすることを確認済み

## Checklist

- [x] Doコメントが削除されている
- [x] Whyコメントは残っている
- [x] `uv run pytest` が通る