### PR TITLE
chore: v0.1.0 リリース準備

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,23 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/),
-and this project adheres to [Semantic Versioning](https://semver.org/).
+このファイルは最新の changelog を保持します.
+最新でなくなった履歴は `changelogs/` 配下へ移動して管理します.
 
 ## [Unreleased]
+
+### Added
+- 無し
+
+### Changed
+- 無し
+
+### Fixed
+- 無し
+
+### Removed
+- 無し
+
+## [0.1.0] - 2026-03-24
 
 ### Added
 - `MaskCompositionProcessor`, `ConfigHandler`, `LogManager` のテストを新規作成. `tests/conftest.py` で共通 fixture を集約. ([#95](https://github.com/kurorosu/pochivision/pull/95))
@@ -115,4 +127,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## Archived Changelogs
 
-Older version histories are archived in the [`changelogs/`](changelogs/) directory.
+過去のバージョン履歴は [`changelogs/`](changelogs/) ディレクトリに保管しています.

--- a/changelogs/README.md
+++ b/changelogs/README.md
@@ -1,8 +1,8 @@
 # Archived Changelogs
 
-This directory contains archived changelog entries for older versions.
+このディレクトリには, 過去バージョンの changelog エントリをアーカイブしています.
 
-When the main `CHANGELOG.md` grows too long, move completed version entries here grouped by minor version series.
+メインの `CHANGELOG.md` が長くなったら, 完了したバージョンのエントリをマイナーバージョン系列ごとにここへ移動します.
 
 ## Files
 
@@ -10,9 +10,9 @@ When the main `CHANGELOG.md` grows too long, move completed version entries here
 |---|---|
 | `0.1.x.md` | 0.1.0 - 0.1.x |
 
-## How to Archive
+## アーカイブ手順
 
-1. Cut the version entries from `CHANGELOG.md` (keep `[Unreleased]` and the latest release)
-2. Create a new file named `X.Y.x.md` (e.g. `1.3.x.md`)
-3. Paste the entries into the new file
-4. Update the table above
+1. `CHANGELOG.md` からバージョンエントリを切り取る (`[Unreleased]` と最新リリースは残す)
+2. `X.Y.x.md` という名前で新しいファイルを作成する (例: `1.3.x.md`)
+3. 切り取ったエントリを新しいファイルに貼り付ける
+4. 上記のテーブルを更新する


### PR DESCRIPTION
## Summary

- v0.1.0 リリースに向けた CHANGELOG とドキュメントの整備.

## Related Issue

無し

## Changes

- `CHANGELOG.md`: `[Unreleased]` の下に `[0.1.0] - 2026-03-24` セクションを追加. `[Unreleased]` に空カテゴリ (`無し`) を設定. 冒頭の説明文とアーカイブ案内を日本語に統一.
- `changelogs/README.md`: 英語から日本語に変更.

## Test Plan

- [x] `uv run pytest` が通る

## Checklist

- [x] `pyproject.toml` のバージョンが `0.1.0` である
- [x] `uv lock` を実行済み (変更なし)
- [x] CHANGELOG.md が更新されている
