### PR TITLE
fix: HSV Hue 統計に循環統計を適用し単位ラベルを修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,10 @@
 
 ### Changed
 - `pochivision/tools/` をプロジェクトルートの `tools/` に移動し, パッケージから分離. 未使用の dev 依存 `flake8`, `pylint` を削除. ([#117](https://github.com/kurorosu/pochivision/pull/117))
-- `test_blur_processors.py` のモックテスト 2 件を削除し, 全テストを古典派テストに統一. (NA.)
+- `test_blur_processors.py` のモックテスト 2 件を削除し, 全テストを古典派テストに統一. ([#118](https://github.com/kurorosu/pochivision/pull/118))
 
 ### Fixed
-- 無し
+- HSV 特徴量抽出の Hue チャンネルに循環統計 (`scipy.stats.circmean` / `circstd`) を適用し, 0/180 境界付近の統計値を修正. 単位ラベルを `hue_0_179` に変更. (NA.)
 
 ### Removed
 - 無し

--- a/pochivision/feature_extractors/hsv_statistics.py
+++ b/pochivision/feature_extractors/hsv_statistics.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Optional, Union
 
 import cv2
 import numpy as np
+from scipy.stats import circmean, circstd
 
 from pochivision.utils.image import to_bgr
 
@@ -29,12 +30,15 @@ class HSVStatisticsExtractor(BaseFeatureExtractor):
     設定により、RGB値がすべて0のピクセルを計算から除外することができます。
     """
 
+    # OpenCV の HSV Hue 範囲 (0-179)
+    _HUE_HIGH = 180
+
     # 特徴量の単位定義
     _FEATURE_UNITS = {
-        "hue_mean": "degree",
-        "hue_median": "degree",
-        "hue_variance": "squared_degree",
-        "hue_std_dev": "degree",
+        "hue_mean": "hue_0_179",
+        "hue_median": "hue_0_179",
+        "hue_variance": "hue_0_179_squared",
+        "hue_std_dev": "hue_0_179",
         "hue_cv": "ratio",
         "saturation_mean": "intensity",
         "saturation_median": "intensity",
@@ -122,6 +126,11 @@ class HSVStatisticsExtractor(BaseFeatureExtractor):
                 variance_val = 0.0
                 std_dev_val = 0.0
                 cv_val = float("inf")
+            elif channel_name == "hue":
+                # Hue は循環データのため循環統計を使用
+                mean_val, median_val, variance_val, std_dev_val, cv_val = (
+                    self._compute_circular_stats(pixels)
+                )
             else:
                 mean_val = float(np.mean(pixels))
                 median_val = float(np.median(pixels))
@@ -141,6 +150,44 @@ class HSVStatisticsExtractor(BaseFeatureExtractor):
             results[f"{channel_name}_cv"] = cv_val
 
         return results
+
+    def _compute_circular_stats(
+        self, pixels: np.ndarray
+    ) -> tuple[float, float, float, float, float]:
+        """
+        Hue チャンネル用の循環統計を計算する.
+
+        OpenCV の Hue は [0, 180) の循環量であり, 線形統計では
+        境界付近 (赤付近: H~0 と H~179) で不正確になるため,
+        循環統計 (circular statistics) を使用する.
+
+        Args:
+            pixels: Hue ピクセル値の配列 (float64, 範囲 [0, 180)).
+
+        Returns:
+            (mean, median, variance, std_dev, cv) のタプル.
+        """
+        high = self._HUE_HIGH
+
+        # ラジアンに変換して循環統計を計算
+        radians = pixels * (2 * np.pi / high)
+        mean_rad = circmean(radians, high=2 * np.pi, low=0)
+        std_rad = circstd(radians, high=2 * np.pi, low=0)
+
+        # Hue スケール [0, 180) に戻す
+        mean_val = float(mean_rad * high / (2 * np.pi))
+        std_dev_val = float(std_rad * high / (2 * np.pi))
+        variance_val = std_dev_val**2
+
+        # 循環中央値: 循環平均を中心にシフトして線形中央値を取り, 戻す
+        shift = high / 2 - mean_val
+        shifted = (pixels + shift) % high
+        median_shifted = float(np.median(shifted))
+        median_val = (median_shifted - shift) % high
+
+        cv_val = float(std_dev_val / mean_val) if mean_val != 0 else float("inf")
+
+        return mean_val, median_val, variance_val, std_dev_val, cv_val
 
     @staticmethod
     def get_default_config() -> Dict[str, Any]:

--- a/tests/extractors/test_hsv_features.py
+++ b/tests/extractors/test_hsv_features.py
@@ -328,10 +328,10 @@ def test_feature_names_and_units():
     # 単位付き特徴量名の確認
     unit_names = HSVStatisticsExtractor.get_feature_names()
     expected_unit_names = [
-        "hue_mean[degree]",
-        "hue_median[degree]",
-        "hue_variance[squared_degree]",
-        "hue_std_dev[degree]",
+        "hue_mean[hue_0_179]",
+        "hue_median[hue_0_179]",
+        "hue_variance[hue_0_179_squared]",
+        "hue_std_dev[hue_0_179]",
         "hue_cv[ratio]",
         "saturation_mean[intensity]",
         "saturation_median[intensity]",
@@ -353,10 +353,10 @@ def test_feature_names_and_units():
     # 単位辞書の確認
     units = HSVStatisticsExtractor.get_feature_units()
     expected_units = {
-        "hue_mean": "degree",
-        "hue_median": "degree",
-        "hue_variance": "squared_degree",
-        "hue_std_dev": "degree",
+        "hue_mean": "hue_0_179",
+        "hue_median": "hue_0_179",
+        "hue_variance": "hue_0_179_squared",
+        "hue_std_dev": "hue_0_179",
         "hue_cv": "ratio",
         "saturation_mean": "intensity",
         "saturation_median": "intensity",
@@ -394,8 +394,8 @@ def test_unit_for_feature_method():
 
     # 正常なHSV特徴量名
     test_cases = [
-        ("hue_mean", "degree"),
-        ("hue_variance", "squared_degree"),
+        ("hue_mean", "hue_0_179"),
+        ("hue_variance", "hue_0_179_squared"),
         ("saturation_mean", "intensity"),
         ("saturation_variance", "squared_intensity"),
         ("value_cv", "ratio"),
@@ -416,6 +416,44 @@ def test_unit_for_feature_method():
         assert unit == "unknown", f"Expected 'unknown', got {unit} for {invalid_name}"
 
     print("単位取得メソッドテスト: 成功")
+
+
+def test_hue_circular_statistics():
+    """Hue チャンネルの循環統計が正しく計算されることをテスト."""
+    extractor = HSVStatisticsExtractor()
+
+    # Hue が 0/180 境界付近の赤ピクセルで構成される画像を作成
+    # HSV で H=5 と H=175 はどちらも赤付近
+    hsv_image = np.zeros((100, 100, 3), dtype=np.uint8)
+    hsv_image[:50, :, :] = [5, 255, 255]  # H=5 (赤)
+    hsv_image[50:, :, :] = [175, 255, 255]  # H=175 (赤)
+    bgr_image = cv2.cvtColor(hsv_image, cv2.COLOR_HSV2BGR)
+
+    features = extractor.extract(bgr_image)
+
+    # 循環平均は 0 付近 (赤) であるべき, 90 (緑) ではない
+    hue_mean = features["hue_mean"]
+    assert (
+        hue_mean < 10 or hue_mean > 170
+    ), f"Hue mean should be near 0/180 (red), got {hue_mean}"
+
+    # 循環標準偏差は小さいはず (両方とも赤付近)
+    hue_std = features["hue_std_dev"]
+    assert hue_std < 30, f"Hue std_dev should be small for similar hues, got {hue_std}"
+
+
+def test_hue_circular_vs_linear_difference():
+    """循環統計と線形統計で結果が異なるケースをテスト."""
+    extractor = HSVStatisticsExtractor()
+
+    # 全ピクセルが同じ Hue の場合, 循環統計でも分散は 0
+    hsv_uniform = np.zeros((50, 50, 3), dtype=np.uint8)
+    hsv_uniform[:, :, :] = [90, 200, 200]  # H=90 (緑)
+    bgr_uniform = cv2.cvtColor(hsv_uniform, cv2.COLOR_HSV2BGR)
+
+    features = extractor.extract(bgr_uniform)
+    assert features["hue_variance"] < 0.1, "Uniform hue should have ~0 variance"
+    assert features["hue_std_dev"] < 0.1, "Uniform hue should have ~0 std_dev"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Hue チャンネルの統計計算に `scipy.stats.circmean` / `circstd` を適用し, 0/180 境界付近で不正確だった統計値を修正した.
- 単位ラベルを "degree" から "hue_0_179" に変更し, 実際の値範囲と一致させた.

## Related Issue

Closes #103

## Changes

- `pochivision/feature_extractors/hsv_statistics.py`:
  - `_compute_circular_stats` メソッドを追加 (循環平均, 循環標準偏差, 循環中央値を計算)
  - Hue チャンネルの統計計算で `_compute_circular_stats` を使用するよう変更
  - 単位ラベルを `degree` → `hue_0_179`, `squared_degree` → `hue_0_179_squared` に変更
- `tests/extractors/test_hsv_features.py`:
  - `test_hue_circular_statistics`: H=5 と H=175 の画像で循環平均が赤付近になることを検証
  - `test_hue_circular_vs_linear_difference`: 均一 Hue 画像で分散が ~0 になることを検証
  - 既存テストの単位アサーションを更新

## Code Changes

```python
# pochivision/feature_extractors/hsv_statistics.py
def _compute_circular_stats(
    self, pixels: np.ndarray
) -> tuple[float, float, float, float, float]:
    high = self._HUE_HIGH
    radians = pixels * (2 * np.pi / high)
    mean_rad = circmean(radians, high=2 * np.pi, low=0)
    std_rad = circstd(radians, high=2 * np.pi, low=0)
    mean_val = float(mean_rad * high / (2 * np.pi))
    std_dev_val = float(std_rad * high / (2 * np.pi))
    ...
```

## Test Plan

- [x] `uv run pytest tests/extractors/test_hsv_features.py` で 10 テストがパス
- [x] `uv run pytest` で全 297 テストがパス

## Checklist

- [x] Hue チャンネルに循環統計が適用されている
- [x] 単位ラベルが実際の値範囲と一致している
- [x] `uv run pytest` が通る