### PR TITLE
fix: CircleCounter の真円度フィルタを実画像のエッジ輪郭で評価するよう修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@
 - `test_blur_processors.py` のモックテスト 2 件を削除し, 全テストを古典派テストに統一. ([#118](https://github.com/kurorosu/pochivision/pull/118))
 
 ### Fixed
-- HSV 特徴量抽出の Hue チャンネルに循環統計 (`scipy.stats.circmean` / `circstd`) を適用し, 0/180 境界付近の統計値を修正. 単位ラベルを `hue_0_179` に変更. (NA.)
+- HSV 特徴量抽出の Hue チャンネルに循環統計 (`scipy.stats.circmean` / `circstd`) を適用し, 0/180 境界付近の統計値を修正. 単位ラベルを `hue_0_179` に変更. ([#119](https://github.com/kurorosu/pochivision/pull/119))
+- CircleCounter の真円度フィルタを合成円ではなく実画像のエッジ輪郭に基づく評価に修正. (NA.)
 
 ### Removed
 - 無し

--- a/pochivision/feature_extractors/circle_counter.py
+++ b/pochivision/feature_extractors/circle_counter.py
@@ -143,7 +143,10 @@ class CircleCounterExtractor(BaseFeatureExtractor):
         self, gray: np.ndarray, circles: np.ndarray
     ) -> np.ndarray:
         """
-        検出された円を真円度でフィルタリングする.
+        検出された円を実画像のエッジに基づく真円度でフィルタリングする.
+
+        各候補円の周辺領域 (ROI) でエッジ検出・輪郭抽出を行い,
+        実際の輪郭形状の真円度 (4*pi*area / perimeter^2) で評価する.
 
         Args:
             gray (np.ndarray): グレースケール画像.
@@ -159,29 +162,44 @@ class CircleCounterExtractor(BaseFeatureExtractor):
         height, width = gray.shape
 
         for x, y, r in circles:
-            # 円の輪郭を作成
-            mask = np.zeros((height, width), dtype=np.uint8)
-            cv2.circle(mask, (x, y), r, 255, 1)
+            # ROI の範囲を計算 (円を囲む矩形 + マージン)
+            margin = max(r // 4, 2)
+            x1 = max(0, x - r - margin)
+            y1 = max(0, y - r - margin)
+            x2 = min(width, x + r + margin)
+            y2 = min(height, y + r + margin)
 
-            # 輪郭を取得
+            roi = gray[y1:y2, x1:x2]
+            if roi.size == 0:
+                continue
+
+            # ROI 内でエッジ検出
+            edges = cv2.Canny(roi, self.param1 // 2, self.param1)
+
+            # 円領域のマスクを作成し, ROI 外のエッジを除外
+            roi_mask = np.zeros_like(edges)
+            cx_roi, cy_roi = x - x1, y - y1
+            cv2.circle(roi_mask, (cx_roi, cy_roi), r + margin // 2, 255, -1)
+            edges = cv2.bitwise_and(edges, roi_mask)
+
+            # エッジから輪郭を抽出
             contours, _ = cv2.findContours(
-                mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE
+                edges, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE
             )
 
-            if contours:
-                contour = contours[0]
+            if not contours:
+                continue
 
-                # 面積と周囲長の計算
-                area = cv2.contourArea(contour)
-                perimeter = cv2.arcLength(contour, True)
+            # 最大輪郭を選択
+            contour = max(contours, key=cv2.contourArea)
 
-                if perimeter > 0:
-                    # 真円度の計算: 4π × 面積 / 周囲長²
-                    circularity = 4 * np.pi * area / (perimeter * perimeter)
+            area = cv2.contourArea(contour)
+            perimeter = cv2.arcLength(contour, True)
 
-                    # 閾値を満たす場合のみ保持
-                    if circularity >= self.circularity_threshold:
-                        filtered_circles.append([x, y, r])
+            if perimeter > 0 and area > 0:
+                circularity = 4 * np.pi * area / (perimeter * perimeter)
+                if circularity >= self.circularity_threshold:
+                    filtered_circles.append([x, y, r])
 
         return np.array(filtered_circles) if filtered_circles else np.array([])
 


### PR DESCRIPTION
## Summary

- `_filter_by_circularity` が合成円 (`cv2.circle` で描画した完全な円) の真円度を測定していた問題を修正した.
- 各候補円の ROI でエッジ検出・輪郭抽出を行い, 実画像の輪郭形状に基づいて真円度を評価するよう変更した.

## Related Issue

Closes #104

## Changes

- `pochivision/feature_extractors/circle_counter.py`:
  - `_filter_by_circularity` を実画像ベースの評価に書き換え
  - 各候補円の周辺 ROI を切り出し, `cv2.Canny` でエッジ検出
  - 円領域マスクで ROI 外のエッジを除外し, 最大輪郭の真円度で判定

## Code Changes

```python
# pochivision/feature_extractors/circle_counter.py
def _filter_by_circularity(self, gray, circles):
    for x, y, r in circles:
        roi = gray[y1:y2, x1:x2]
        edges = cv2.Canny(roi, self.param1 // 2, self.param1)
        # 円領域マスクで ROI 外を除外
        edges = cv2.bitwise_and(edges, roi_mask)
        contours, _ = cv2.findContours(edges, ...)
        contour = max(contours, key=cv2.contourArea)
        circularity = 4 * np.pi * area / (perimeter ** 2)
```

## Test Plan

- [x] `uv run pytest tests/extractors/test_circle_counter.py` で 12 テストがパス
- [x] `uv run pytest` で全 297 テストがパス

## Checklist

- [x] 真円度フィルタが実画像のエッジに基づいて動作する
- [x] `uv run pytest` が通る
