### PR TITLE
fix: (H,W,1) 形状画像の CLAHE/Equalize クラッシュと to_grayscale の BGRA 対応を修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@
 
 ### Fixed
 - HSV 特徴量抽出の Hue チャンネルに循環統計 (`scipy.stats.circmean` / `circstd`) を適用し, 0/180 境界付近の統計値を修正. 単位ラベルを `hue_0_179` に変更. ([#119](https://github.com/kurorosu/pochivision/pull/119))
-- CircleCounter の真円度フィルタを合成円ではなく実画像のエッジ輪郭に基づく評価に修正. (NA.)
+- CircleCounter の真円度フィルタを合成円ではなく実画像のエッジ輪郭に基づく評価に修正. ([#120](https://github.com/kurorosu/pochivision/pull/120))
+- `(H,W,1)` 形状画像で CLAHE/Equalize がクラッシュする問題を修正. `to_grayscale` で BGRA 画像に `COLOR_BGRA2GRAY` を使用するよう修正. (NA.)
 
 ### Removed
 - 無し

--- a/pochivision/processors/clahe.py
+++ b/pochivision/processors/clahe.py
@@ -77,8 +77,10 @@ class CLAHEProcessor(BaseProcessor):
         self.validator.validate_image(image)
 
         try:
-            if len(image.shape) == 2 or image.shape[2] == 1:
+            if len(image.shape) == 2:
                 return self.clahe.apply(image)
+            if image.shape[2] == 1:
+                return self.clahe.apply(image.squeeze(axis=2))
 
             # カラー画像の処理
             if self.color_mode == "gray":

--- a/pochivision/processors/equalize.py
+++ b/pochivision/processors/equalize.py
@@ -67,8 +67,10 @@ class EqualizeProcessor(BaseProcessor):
         self.validator.validate_image(image)
 
         try:
-            if len(image.shape) == 2 or image.shape[2] == 1:
+            if len(image.shape) == 2:
                 return cv2.equalizeHist(image)
+            if image.shape[2] == 1:
+                return cv2.equalizeHist(image.squeeze(axis=2))
 
             # カラー画像の処理
             if self.color_mode == "gray":

--- a/pochivision/utils/image.py
+++ b/pochivision/utils/image.py
@@ -24,9 +24,12 @@ def to_grayscale(image: np.ndarray) -> np.ndarray:
         if image.shape[2] == 1:
             # 3次元1チャンネル → 2次元グレースケール
             return image.squeeze(axis=2)
-        elif image.shape[2] in (3, 4):
-            # カラー画像（3または4チャンネル）
+        elif image.shape[2] == 3:
+            # BGR画像
             return cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+        elif image.shape[2] == 4:
+            # BGRA画像
+            return cv2.cvtColor(image, cv2.COLOR_BGRA2GRAY)
         else:
             raise ValueError(
                 f"Unsupported channel count: {image.shape[2]}. "


### PR DESCRIPTION
## Summary

- `clahe.py` と `equalize.py` が `(H,W,1)` 形状の入力でクラッシュする問題を `squeeze` で修正した.
- `to_grayscale` で 4ch (BGRA) 画像に `COLOR_BGR2GRAY` を使用していた誤りを `COLOR_BGRA2GRAY` に修正した.

## Related Issue

Closes #105

## Changes

- `pochivision/processors/clahe.py`: `(H,W,1)` 入力を `squeeze(axis=2)` で 2D に変換してから `clahe.apply` に渡す
- `pochivision/processors/equalize.py`: 同様に `squeeze(axis=2)` で 2D に変換してから `cv2.equalizeHist` に渡す
- `pochivision/utils/image.py`: 4ch 画像の変換フラグを `COLOR_BGR2GRAY` → `COLOR_BGRA2GRAY` に修正

## Test Plan

- [x] `uv run pytest` で全 297 テストがパス

## Checklist

- [x] `(H,W,1)` 形状画像が正常に処理される
- [x] BGRA 画像が正しくグレースケール変換される
- [x] `uv run pytest` が通る