### PR TITLE
fix: モーションブラーカーネルを cv2.line 方式に変更し斜め角度のギャップを解消

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@
 ### Fixed
 - HSV 特徴量抽出の Hue チャンネルに循環統計 (`scipy.stats.circmean` / `circstd`) を適用し, 0/180 境界付近の統計値を修正. 単位ラベルを `hue_0_179` に変更. ([#119](https://github.com/kurorosu/pochivision/pull/119))
 - CircleCounter の真円度フィルタを合成円ではなく実画像のエッジ輪郭に基づく評価に修正. ([#120](https://github.com/kurorosu/pochivision/pull/120))
-- `(H,W,1)` 形状画像で CLAHE/Equalize がクラッシュする問題を修正. `to_grayscale` で BGRA 画像に `COLOR_BGRA2GRAY` を使用するよう修正. (NA.)
+- `(H,W,1)` 形状画像で CLAHE/Equalize がクラッシュする問題を修正. `to_grayscale` で BGRA 画像に `COLOR_BGRA2GRAY` を使用するよう修正. ([#121](https://github.com/kurorosu/pochivision/pull/121))
+- モーションブラーカーネル構築を `cv2.line` 方式に変更し, 斜め角度でのギャップを解消. (NA.)
 
 ### Removed
 - 無し

--- a/pochivision/processors/blur.py
+++ b/pochivision/processors/blur.py
@@ -372,17 +372,13 @@ class MotionBlurProcessor(BaseProcessor):
             kernel = np.zeros((kernel_size, kernel_size), dtype=np.float32)
             center = kernel_size // 2
             rad = np.deg2rad(angle)
-            cos_a = np.cos(rad)
-            sin_a = np.sin(rad)
-            for i in range(kernel_size):
-                x = int(center + (i - center) * cos_a)
-                y = int(center + (i - center) * sin_a)
-                if 0 <= x < kernel_size and 0 <= y < kernel_size:
-                    kernel[y, x] = 1
-            if np.sum(kernel) == 0:  # 全要素が0の場合、ゼロ除算を避ける
-                # 例えば、kernel_sizeが非常に小さい場合や特定の角度で発生しうる
-                # この場合、元画像をそのまま返すか、エラーとするか、あるいは小さな単位行列カーネルを適用するか
-                # ここでは元画像を返すことにする
+            half = (kernel_size - 1) / 2.0
+            dx = np.cos(rad) * half
+            dy = np.sin(rad) * half
+            pt1 = (int(np.round(center - dx)), int(np.round(center - dy)))
+            pt2 = (int(np.round(center + dx)), int(np.round(center + dy)))
+            cv2.line(kernel, pt1, pt2, 1.0, 1)
+            if np.sum(kernel) == 0:
                 return image
             kernel /= np.sum(kernel)
             return cv2.filter2D(image, -1, kernel)


### PR DESCRIPTION
## Summary

- モーションブラーカーネル構築で `int()` 切り捨てによるピクセルのギャップ・重複を, `cv2.line` による描画に置き換えて解消した.

## Related Issue

Closes #106

## Changes

- `pochivision/processors/blur.py`: カーネル構築のループを `cv2.line` による端点間のライン描画に置換

## Code Changes

```python
# pochivision/processors/blur.py (修正後)
kernel = np.zeros((kernel_size, kernel_size), dtype=np.float32)
center = kernel_size // 2
half = (kernel_size - 1) / 2.0
dx = np.cos(rad) * half
dy = np.sin(rad) * half
pt1 = (int(np.round(center - dx)), int(np.round(center - dy)))
pt2 = (int(np.round(center + dx)), int(np.round(center + dy)))
cv2.line(kernel, pt1, pt2, 1.0, 1)
```

## Test Plan

- [x] `uv run pytest` で全 297 テストがパス

## Checklist

- [x] 任意の角度でカーネルが均一な直線になる
- [x] `uv run pytest` が通る