### PR TITLE
fix: FFT 方向エネルギーの 0/180 度境界処理とエントロピー計算のバイアス修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@
 - HSV 特徴量抽出の Hue チャンネルに循環統計 (`scipy.stats.circmean` / `circstd`) を適用し, 0/180 境界付近の統計値を修正. 単位ラベルを `hue_0_179` に変更. ([#119](https://github.com/kurorosu/pochivision/pull/119))
 - CircleCounter の真円度フィルタを合成円ではなく実画像のエッジ輪郭に基づく評価に修正. ([#120](https://github.com/kurorosu/pochivision/pull/120))
 - `(H,W,1)` 形状画像で CLAHE/Equalize がクラッシュする問題を修正. `to_grayscale` で BGRA 画像に `COLOR_BGRA2GRAY` を使用するよう修正. ([#121](https://github.com/kurorosu/pochivision/pull/121))
-- モーションブラーカーネル構築を `cv2.line` 方式に変更し, 斜め角度でのギャップを解消. (NA.)
+- モーションブラーカーネル構築を `cv2.line` 方式に変更し, 斜め角度でのギャップを解消. ([#122](https://github.com/kurorosu/pochivision/pull/122))
+- FFT 方向エネルギーの角度ラップアラウンド (0/180 境界) に対応. スペクトルエントロピーのゼロ要素バイアスを修正. (NA.)
 
 ### Removed
 - 無し

--- a/pochivision/feature_extractors/fft_frequency.py
+++ b/pochivision/feature_extractors/fft_frequency.py
@@ -233,6 +233,9 @@ class FFTFrequencyExtractor(BaseFeatureExtractor):
 
         angle = (angle + 360) % 180  # 0〜180度に正規化
         diff = np.abs(angle - angle_deg)
+        diff = np.minimum(
+            diff, 180 - diff
+        )  # 0度と180度は同一方向のため短い方の角度差を採用
         mask = diff <= tolerance_deg
 
         directional_energy = np.sum(magnitude[mask])
@@ -283,9 +286,9 @@ class FFTFrequencyExtractor(BaseFeatureExtractor):
             return 0.0
 
         prob = magnitude / total
-        # エントロピー計算（0 log 0 = 0として処理）
-        prob_safe = prob + 1e-12  # 数値安定性のための小さな値
-        entropy = -np.sum(prob * np.log2(prob_safe))
+        # エントロピー計算（0 log 0 = 0 として処理: ゼロ要素を除外）
+        nonzero = prob > 0
+        entropy = -np.sum(prob[nonzero] * np.log2(prob[nonzero]))
         return float(entropy)
 
     def _compute_directional_entropy(
@@ -315,6 +318,9 @@ class FFTFrequencyExtractor(BaseFeatureExtractor):
 
         angle = (angle + 360) % 180  # 0〜180度に正規化
         diff = np.abs(angle - angle_deg)
+        diff = np.minimum(
+            diff, 180 - diff
+        )  # 0度と180度は同一方向のため短い方の角度差を採用
         mask = diff <= tolerance_deg
 
         # 指定方向のスペクトラムを抽出


### PR DESCRIPTION
## Summary

- 方向エネルギー計算で 0/180 度境界のラップアラウンドに対応し, 水平エネルギーの過小評価を修正した.
- スペクトルエントロピー計算で `prob * log2(prob + eps)` の混在バイアスを, ゼロ要素除外方式に修正した.

## Related Issue

Closes #108

## Changes

- `pochivision/feature_extractors/fft_frequency.py`:
  - `_compute_directional_energy`: `diff = np.minimum(diff, 180 - diff)` でラップアラウンド対応
  - `_compute_directional_entropy`: 同様のラップアラウンド対応
  - `_compute_spectral_entropy`: ゼロ要素を除外してからエントロピーを計算

## Code Changes

```python
# 方向エネルギー: ラップアラウンド対応
diff = np.abs(angle - angle_deg)
diff = np.minimum(diff, 180 - diff)  # 追加

# エントロピー: ゼロ要素除外
nonzero = prob > 0
entropy = -np.sum(prob[nonzero] * np.log2(prob[nonzero]))
```

## Test Plan

- [x] `uv run pytest tests/extractors/test_fft_features.py` で 24 テストがパス
- [x] `uv run pytest` で全 297 テストがパス

## Checklist

- [x] 水平方向エネルギーが 0/180 境界付近のピクセルを正しく含む
- [x] エントロピー計算にバイアスがない
- [x] `uv run pytest` が通る