### PR TITLE
fix: PipelineExecutor に mode 検証を追加しプロセッサ例外でパイプラインが中断しないよう修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@
 - CircleCounter の真円度フィルタを合成円ではなく実画像のエッジ輪郭に基づく評価に修正. ([#120](https://github.com/kurorosu/pochivision/pull/120))
 - `(H,W,1)` 形状画像で CLAHE/Equalize がクラッシュする問題を修正. `to_grayscale` で BGRA 画像に `COLOR_BGRA2GRAY` を使用するよう修正. ([#121](https://github.com/kurorosu/pochivision/pull/121))
 - モーションブラーカーネル構築を `cv2.line` 方式に変更し, 斜め角度でのギャップを解消. ([#122](https://github.com/kurorosu/pochivision/pull/122))
-- FFT 方向エネルギーの角度ラップアラウンド (0/180 境界) に対応. スペクトルエントロピーのゼロ要素バイアスを修正. (NA.)
+- FFT 方向エネルギーの 0/180 度境界処理に対応. スペクトルエントロピーのゼロ要素バイアスを修正. ([#123](https://github.com/kurorosu/pochivision/pull/123))
+- `PipelineExecutor` に `mode` 値の検証を追加し, 個別プロセッサの例外でパイプライン全体が中断しないよう修正. (NA.)
 
 ### Removed
 - 無し

--- a/pochivision/core/pipeline_executor.py
+++ b/pochivision/core/pipeline_executor.py
@@ -46,6 +46,12 @@ class PipelineExecutor:
             id_interval (int): ID値が増加する画像数の間隔 デフォルトは1.
             config_fps (float): 設定ファイルから取得したFPS値. デフォルトは30.0.
         """
+        valid_modes = ("parallel", "pipeline")
+        if mode not in valid_modes:
+            raise ValueError(
+                f"Invalid pipeline mode: '{mode}'. Must be one of {valid_modes}."
+            )
+
         self.processors = processors
         self.capture_manager = capture_manager
         self.mode = mode
@@ -163,46 +169,56 @@ class PipelineExecutor:
         processed_images = {"original": image.copy()}
         if self.mode == "parallel":
             for processor in self.processors:
-                proc_start = time.time()
-                result = processor.process(image)
-                proc_time = time.time() - proc_start
-                self.logger.info(
-                    f"Processing time ({processor.name}): {proc_time:.3f} sec"
-                )
-                processed_images[processor.name] = result
-                self._save(result, processor.name)
+                try:
+                    proc_start = time.time()
+                    result = processor.process(image)
+                    proc_time = time.time() - proc_start
+                    self.logger.info(
+                        f"Processing time ({processor.name}): {proc_time:.3f} sec"
+                    )
+                    processed_images[processor.name] = result
+                    self._save(result, processor.name)
+                except Exception as e:
+                    self.logger.error(
+                        f"Processor '{processor.name}' failed, skipping: {e}"
+                    )
 
         elif self.mode == "pipeline":
             result = image
 
             for processor in self.processors:
-                proc_start = time.time()
+                try:
+                    proc_start = time.time()
 
-                # マスク合成プロセッサの場合、ターゲット画像を設定
-                if hasattr(processor, "target_image_name") and hasattr(
-                    processor, "set_target_image"
-                ):
-                    target_name = processor.target_image_name  # type: ignore
-                    if target_name in processed_images:
-                        processor.set_target_image(
-                            processed_images[target_name]
-                        )  # type: ignore
-                    else:
-                        self.logger.warning(
-                            f"Target image '{target_name}' not found "
-                            f"for {processor.name}"
-                        )
-                        # fallback to original
-                        processor.set_target_image(
-                            processed_images["original"]
-                        )  # type: ignore
+                    # マスク合成プロセッサの場合、ターゲット画像を設定
+                    if hasattr(processor, "target_image_name") and hasattr(
+                        processor, "set_target_image"
+                    ):
+                        target_name = processor.target_image_name  # type: ignore
+                        if target_name in processed_images:
+                            processor.set_target_image(
+                                processed_images[target_name]
+                            )  # type: ignore
+                        else:
+                            self.logger.warning(
+                                f"Target image '{target_name}' not found "
+                                f"for {processor.name}"
+                            )
+                            # fallback to original
+                            processor.set_target_image(
+                                processed_images["original"]
+                            )  # type: ignore
 
-                result = processor.process(result)
-                proc_time = time.time() - proc_start
-                self.logger.info(
-                    f"Processing time ({processor.name}): {proc_time:.3f} sec"
-                )
-                processed_images[processor.name] = result
+                    result = processor.process(result)
+                    proc_time = time.time() - proc_start
+                    self.logger.info(
+                        f"Processing time ({processor.name}): {proc_time:.3f} sec"
+                    )
+                    processed_images[processor.name] = result
+                except Exception as e:
+                    self.logger.error(
+                        f"Processor '{processor.name}' failed, skipping: {e}"
+                    )
 
             self._save(result, "pipeline")
 


### PR DESCRIPTION
## Summary

- `mode` パラメータにタイポがあると全処理がサイレントにスキップされる問題を, 初期化時のバリデーションで修正した.
- 個別プロセッサの例外がパイプライン全体を中断する問題を, try/except で各プロセッサを保護して修正した.

## Related Issue

Closes #107

## Changes

- `pochivision/core/pipeline_executor.py`:
  - `__init__` で `mode` が `"parallel"` / `"pipeline"` 以外の場合に `ValueError` を送出
  - parallel / pipeline 両モードで各プロセッサの `process()` を try/except で囲み, 失敗時はエラーログを出力してスキップ

## Code Changes

```python
# pochivision/core/pipeline_executor.py
valid_modes = ("parallel", "pipeline")
if mode not in valid_modes:
    raise ValueError(
        f"Invalid pipeline mode: '{mode}'. Must be one of {valid_modes}."
    )
```

## Test Plan

- [x] `uv run pytest` で全 297 テストがパス

## Checklist

- [x] 不正な `mode` 値で明確なエラーが発生する
- [x] 個別プロセッサの失敗がパイプライン全体を中断しない
- [x] `uv run pytest` が通る