### PR TITLE
fix: resize 補間方法, edge_detection float 判定, CLAHE tuple 許容の修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@
 - `(H,W,1)` 形状画像で CLAHE/Equalize がクラッシュする問題を修正. `to_grayscale` で BGRA 画像に `COLOR_BGRA2GRAY` を使用するよう修正. ([#121](https://github.com/kurorosu/pochivision/pull/121))
 - モーションブラーカーネル構築を `cv2.line` 方式に変更し, 斜め角度でのギャップを解消. ([#122](https://github.com/kurorosu/pochivision/pull/122))
 - FFT 方向エネルギーの 0/180 度境界処理に対応. スペクトルエントロピーのゼロ要素バイアスを修正. ([#123](https://github.com/kurorosu/pochivision/pull/123))
-- `PipelineExecutor` に `mode` 値の検証を追加し, 個別プロセッサの例外でパイプライン全体が中断しないよう修正. (NA.)
+- `PipelineExecutor` に `mode` 値の検証を追加し, 個別プロセッサの例外でパイプライン全体が中断しないよう修正. ([#124](https://github.com/kurorosu/pochivision/pull/124))
+- resize の補間方法を拡大時に `INTER_LINEAR` に切替, edge_detection の float 判定を `np.floating` に修正, CLAHE バリデータで tuple を許容. (NA.)
 
 ### Removed
 - 無し

--- a/pochivision/processors/edge_detection.py
+++ b/pochivision/processors/edge_detection.py
@@ -58,7 +58,9 @@ class CannyEdgeProcessor(BaseProcessor):
         gray_image = to_grayscale(image)
 
         if gray_image.dtype != np.uint8:
-            if np.max(gray_image) <= 1.0 and gray_image.dtype == np.float32:
+            if np.max(gray_image) <= 1.0 and np.issubdtype(
+                gray_image.dtype, np.floating
+            ):
                 gray_image = (gray_image * 255).astype(np.uint8)
             elif np.max(gray_image) <= 255:
                 gray_image = gray_image.astype(np.uint8)

--- a/pochivision/processors/resize.py
+++ b/pochivision/processors/resize.py
@@ -57,7 +57,12 @@ class ResizeProcessor(BaseProcessor):
 
         h, w = image.shape[:2]
         target_w, target_h = self._calculate_target_size(w, h)
-        return cv2.resize(image, (target_w, target_h), interpolation=cv2.INTER_AREA)
+        # 縮小時は INTER_AREA, 拡大時は INTER_LINEAR が適切
+        if target_w * target_h < w * h:
+            interpolation = cv2.INTER_AREA
+        else:
+            interpolation = cv2.INTER_LINEAR
+        return cv2.resize(image, (target_w, target_h), interpolation=interpolation)
 
     def _calculate_target_size(self, orig_width: int, orig_height: int) -> tuple:
         """

--- a/pochivision/processors/validators/clahe/clahe.py
+++ b/pochivision/processors/validators/clahe/clahe.py
@@ -48,7 +48,7 @@ class CLAHEInputValidator(BaseValidator):
 
         # tile_grid_sizeのチェック
         tile_grid_size = self.config.get("tile_grid_size", [8, 8])
-        if not isinstance(tile_grid_size, list) or len(tile_grid_size) != 2:
+        if not isinstance(tile_grid_size, (list, tuple)) or len(tile_grid_size) != 2:
             raise ProcessorValidationError(
                 f"Invalid tile_grid_size '{tile_grid_size}'. "
                 "Must be a list of 2 positive integers."


### PR DESCRIPTION
## Summary

- resize プロセッサで拡大時に `INTER_LINEAR` を使用するよう修正した.
- edge_detection で float64 の [0,1] 画像が float32 チェックに引っかからない問題を `np.floating` 判定に修正した.
- CLAHE バリデータで `tile_grid_size` に `tuple` も受け入れるよう修正した.

## Related Issue

Closes #114

## Changes

- `pochivision/processors/resize.py`: 縮小時は `INTER_AREA`, 拡大時は `INTER_LINEAR` に切替
- `pochivision/processors/edge_detection.py`: `gray_image.dtype == np.float32` → `np.issubdtype(gray_image.dtype, np.floating)`
- `pochivision/processors/validators/clahe/clahe.py`: `isinstance(tile_grid_size, list)` → `isinstance(tile_grid_size, (list, tuple))`

## Test Plan

- [x] `uv run pytest` で全 297 テストがパス

## Checklist

- [x] 拡大時に適切な補間方法が使用される
- [x] float64 画像が正しく処理される
- [x] CLAHE バリデータが tuple を受け入れる
- [x] `uv run pytest` が通る