### PR TITLE
refactor: FFT の冗長計算を解消し HLAC 2次パターンの自己ペアを除外

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Changed
 - `pochivision/tools/` をプロジェクトルートの `tools/` に移動し, パッケージから分離. 未使用の dev 依存 `flake8`, `pylint` を削除. ([#117](https://github.com/kurorosu/pochivision/pull/117))
 - `test_blur_processors.py` のモックテスト 2 件を削除し, 全テストを古典派テストに統一. ([#118](https://github.com/kurorosu/pochivision/pull/118))
+- FFT を1回計算して全ヘルパーで共有するようリファクタリング. HLAC 2次パターンの自己ペアを除外し特徴次元を 45→37 に修正. (NA.)
 
 ### Fixed
 - HSV 特徴量抽出の Hue チャンネルに循環統計 (`scipy.stats.circmean` / `circstd`) を適用し, 0/180 境界付近の統計値を修正. 単位ラベルを `hue_0_179` に変更. ([#119](https://github.com/kurorosu/pochivision/pull/119))
@@ -19,7 +20,7 @@
 - モーションブラーカーネル構築を `cv2.line` 方式に変更し, 斜め角度でのギャップを解消. ([#122](https://github.com/kurorosu/pochivision/pull/122))
 - FFT 方向エネルギーの 0/180 度境界処理に対応. スペクトルエントロピーのゼロ要素バイアスを修正. ([#123](https://github.com/kurorosu/pochivision/pull/123))
 - `PipelineExecutor` に `mode` 値の検証を追加し, 個別プロセッサの例外でパイプライン全体が中断しないよう修正. ([#124](https://github.com/kurorosu/pochivision/pull/124))
-- resize の補間方法を拡大時に `INTER_LINEAR` に切替, edge_detection の float 判定を `np.floating` に修正, CLAHE バリデータで tuple を許容. (NA.)
+- resize の補間方法を拡大時に `INTER_LINEAR` に切替, edge_detection の float 判定を `np.floating` に修正, CLAHE バリデータで tuple を許容. ([#125](https://github.com/kurorosu/pochivision/pull/125))
 
 ### Removed
 - 無し

--- a/pochivision/feature_extractors/fft_frequency.py
+++ b/pochivision/feature_extractors/fft_frequency.py
@@ -76,22 +76,26 @@ class FFTFrequencyExtractor(BaseFeatureExtractor):
         self.peak_threshold_ratio = self.config["peak_threshold_ratio"]
         self.mm_per_pixel = self.config.get("mm_per_pixel")
 
-    def _compute_band_energy(
-        self, image: np.ndarray, bands: List[Tuple[float, float]]
-    ) -> Dict[str, float]:
+    def _compute_fft_data(
+        self, image: np.ndarray
+    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
         """
-        周波数帯域ごとのエネルギーを計算する.
+        FFT を1回計算し, 各ヘルパーで共有するデータを返す.
 
         Args:
             image (np.ndarray): グレースケール画像
-            bands (List[Tuple[float, float]]): 周波数帯域のリスト
 
         Returns:
-            Dict[str, float]: 帯域別エネルギーの辞書
+            Tuple: (magnitude, power_spectrum, freq_norm, angle_map)
+                - magnitude: 振幅スペクトル |F|
+                - power_spectrum: パワースペクトル |F|^2
+                - freq_norm: 正規化周波数マップ (0〜0.5)
+                - angle_map: 角度マップ (0〜180度)
         """
         f = np.fft.fft2(image)
         fshift = np.fft.fftshift(f)
-        magnitude = np.abs(fshift) ** 2
+        magnitude = np.abs(fshift)
+        power_spectrum = magnitude**2
 
         h, w = image.shape
         cy, cx = h // 2, w // 2
@@ -101,174 +105,150 @@ class FFTFrequencyExtractor(BaseFeatureExtractor):
         dist = np.sqrt((x - cx) ** 2 + (y - cy) ** 2)
         freq_norm = dist / max_radius / 2
 
-        total_energy = np.sum(magnitude)
+        dy = y - cy
+        dx = x - cx
+        angle = np.arctan2(dy, dx) * 180 / np.pi
+        angle_map = (angle + 360) % 180
+
+        return magnitude, power_spectrum, freq_norm, angle_map
+
+    def _compute_band_energy(
+        self,
+        power_spectrum: np.ndarray,
+        freq_norm: np.ndarray,
+        bands: List[Tuple[float, float]],
+    ) -> Dict[str, float]:
+        """
+        周波数帯域ごとのエネルギーを計算する.
+
+        Args:
+            power_spectrum (np.ndarray): パワースペクトル
+            freq_norm (np.ndarray): 正規化周波数マップ
+            bands (List[Tuple[float, float]]): 周波数帯域のリスト
+
+        Returns:
+            Dict[str, float]: 帯域別エネルギーの辞書
+        """
+        total_energy = np.sum(power_spectrum)
         energies = {}
 
         for i, (fmin, fmax) in enumerate(bands):
             mask = (freq_norm >= fmin) & (freq_norm < fmax)
-            energy = np.sum(magnitude[mask]) / total_energy if total_energy > 0 else 0.0
+            energy = (
+                np.sum(power_spectrum[mask]) / total_energy if total_energy > 0 else 0.0
+            )
             band_key = f"band_{i+1}_{fmin:.2f}_{fmax:.2f}"
             energies[band_key] = energy
 
         return energies
 
-    def _compute_spectral_centroid(self, image: np.ndarray) -> float:
+    def _compute_spectral_centroid(
+        self, magnitude: np.ndarray, freq_norm: np.ndarray
+    ) -> float:
         """
         2D画像のスペクトル重心を計算する.
 
         Args:
-            image (np.ndarray): グレースケール画像
+            magnitude (np.ndarray): 振幅スペクトル
+            freq_norm (np.ndarray): 正規化周波数マップ
 
         Returns:
             float: スペクトル重心（正規化された空間周波数）
         """
-        h, w = image.shape
-        cy, cx = h // 2, w // 2
-
-        # 2D FFTとスペクトル
-        f = np.fft.fft2(image)
-        fshift = np.fft.fftshift(f)
-        magnitude = np.abs(fshift)
-
-        # 距離ベースの周波数マップ（0〜0.5）
-        y, x = np.ogrid[:h, :w]
-        dist = np.sqrt((x - cx) ** 2 + (y - cy) ** 2)
-        max_radius = np.sqrt(cx**2 + cy**2)
-        norm_freq = dist / max_radius / 2  # 0〜0.5に正規化
-
-        # スペクトル重心の計算
-        numerator = np.sum(norm_freq * magnitude)
         denominator = np.sum(magnitude)
-
-        return numerator / denominator if denominator != 0 else 0.0
+        if denominator == 0:
+            return 0.0
+        return float(np.sum(freq_norm * magnitude) / denominator)
 
     def _compute_high_low_freq_ratio(
-        self, image: np.ndarray, threshold: float
+        self, power_spectrum: np.ndarray, freq_norm: np.ndarray, threshold: float
     ) -> float:
         """
         高周波/低周波エネルギー比を計算する.
 
         Args:
-            image (np.ndarray): グレースケール画像
+            power_spectrum (np.ndarray): パワースペクトル
+            freq_norm (np.ndarray): 正規化周波数マップ
             threshold (float): 高周波/低周波の境界閾値
 
         Returns:
-            float: 高周波/低周波エネルギー比
+            float: 高周波/低周波エネルギー比. 低周波が 0 の場合は 0.0.
         """
-        h, w = image.shape
-        cy, cx = h // 2, w // 2
-        max_radius = np.sqrt(cx**2 + cy**2)
+        low_energy = np.sum(power_spectrum[freq_norm < threshold])
+        high_energy = np.sum(power_spectrum[freq_norm >= threshold])
+        return float(high_energy / low_energy) if low_energy > 0 else 0.0
 
-        f = np.fft.fft2(image)
-        fshift = np.fft.fftshift(f)
-        magnitude = np.abs(fshift) ** 2  # パワースペクトル
-
-        y, x = np.ogrid[:h, :w]
-        dist = np.sqrt((x - cx) ** 2 + (y - cy) ** 2)
-        norm_freq = dist / max_radius / 2  # 0〜0.5
-
-        low_mask = norm_freq < threshold
-        high_mask = norm_freq >= threshold
-
-        low_energy = np.sum(magnitude[low_mask])
-        high_energy = np.sum(magnitude[high_mask])
-
-        return float(high_energy / low_energy) if low_energy > 0 else np.inf
-
-    def _compute_spectral_std(self, image: np.ndarray) -> float:
+    def _compute_spectral_std(
+        self, magnitude: np.ndarray, freq_norm: np.ndarray
+    ) -> float:
         """
         スペクトルの標準偏差を計算する.
 
         Args:
-            image (np.ndarray): グレースケール画像
+            magnitude (np.ndarray): 振幅スペクトル
+            freq_norm (np.ndarray): 正規化周波数マップ
 
         Returns:
             float: スペクトルの標準偏差
         """
-        h, w = image.shape
-        cy, cx = h // 2, w // 2
-        max_radius = np.sqrt(cx**2 + cy**2)
-
-        f = np.fft.fft2(image)
-        fshift = np.fft.fftshift(f)
-        magnitude = np.abs(fshift)
-
-        y, x = np.ogrid[:h, :w]
-        dist = np.sqrt((x - cx) ** 2 + (y - cy) ** 2)
-        norm_freq = dist / max_radius / 2
-
-        weights = magnitude
-        total_weight = np.sum(weights)
+        total_weight = np.sum(magnitude)
         if total_weight == 0:
             return 0.0
 
-        mean = np.sum(norm_freq * weights) / total_weight
-        var = np.sum(((norm_freq - mean) ** 2) * weights) / total_weight
+        mean = np.sum(freq_norm * magnitude) / total_weight
+        var = np.sum(((freq_norm - mean) ** 2) * magnitude) / total_weight
         return float(np.sqrt(var))
 
     def _compute_directional_energy(
-        self, image: np.ndarray, angle_deg: float, tolerance_deg: float
+        self,
+        power_spectrum: np.ndarray,
+        angle_map: np.ndarray,
+        angle_deg: float,
+        tolerance_deg: float,
     ) -> float:
         """
         指定方向のエネルギーを計算する.
 
         Args:
-            image (np.ndarray): グレースケール画像
+            power_spectrum (np.ndarray): パワースペクトル
+            angle_map (np.ndarray): 角度マップ (0〜180度)
             angle_deg (float): 角度（度）
             tolerance_deg (float): 許容角度（度）
 
         Returns:
             float: 方向性エネルギー比
         """
-        h, w = image.shape
-        f = np.fft.fft2(image)
-        fshift = np.fft.fftshift(f)
-        magnitude = np.abs(fshift) ** 2
-
-        cy, cx = h // 2, w // 2
-        y, x = np.ogrid[:h, :w]
-        dy = y - cy
-        dx = x - cx
-        angle = np.arctan2(dy, dx) * 180 / np.pi  # -180〜180度
-
-        angle = (angle + 360) % 180  # 0〜180度に正規化
-        diff = np.abs(angle - angle_deg)
+        diff = np.abs(angle_map - angle_deg)
         diff = np.minimum(
             diff, 180 - diff
         )  # 0度と180度は同一方向のため短い方の角度差を採用
         mask = diff <= tolerance_deg
 
-        directional_energy = np.sum(magnitude[mask])
-        total_energy = np.sum(magnitude)
-        return directional_energy / total_energy if total_energy > 0 else 0.0
+        total_energy = np.sum(power_spectrum)
+        return (
+            float(np.sum(power_spectrum[mask]) / total_energy)
+            if total_energy > 0
+            else 0.0
+        )
 
     def _compute_spectral_peaks(
-        self, image: np.ndarray, threshold_ratio: float
+        self, magnitude: np.ndarray, threshold_ratio: float
     ) -> Tuple[int, float]:
         """
         スペクトルピーク数と最大値を計算する.
 
         Args:
-            image (np.ndarray): グレースケール画像
+            magnitude (np.ndarray): 振幅スペクトル
             threshold_ratio (float): ピーク検出の閾値比
 
         Returns:
             Tuple[int, float]: (ピーク数, 最大ピーク振幅)
         """
-        f = np.fft.fft2(image)
-        fshift = np.fft.fftshift(f)
-        magnitude = np.abs(fshift)
-
-        # 局所ピークを検出
         max_local = maximum_filter(magnitude, size=3)
         peaks = (magnitude == max_local) & (
             magnitude > magnitude.max() * threshold_ratio
         )
-
-        num_peaks = int(np.sum(peaks))
-        max_peak = float(magnitude.max())
-
-        return num_peaks, max_peak
+        return int(np.sum(peaks)), float(magnitude.max())
 
     def _compute_spectral_entropy(self, magnitude: np.ndarray) -> float:
         """
@@ -280,7 +260,6 @@ class FFTFrequencyExtractor(BaseFeatureExtractor):
         Returns:
             float: スペクトラルエントロピー
         """
-        # 正規化してプロバビリティ分布に変換
         total = np.sum(magnitude)
         if total == 0:
             return 0.0
@@ -292,38 +271,30 @@ class FFTFrequencyExtractor(BaseFeatureExtractor):
         return float(entropy)
 
     def _compute_directional_entropy(
-        self, image: np.ndarray, angle_deg: float, tolerance_deg: float
+        self,
+        magnitude: np.ndarray,
+        angle_map: np.ndarray,
+        angle_deg: float,
+        tolerance_deg: float,
     ) -> float:
         """
         指定方向のスペクトラムエントロピーを計算する.
 
         Args:
-            image (np.ndarray): グレースケール画像
+            magnitude (np.ndarray): 振幅スペクトル
+            angle_map (np.ndarray): 角度マップ (0〜180度)
             angle_deg (float): 角度（度）
             tolerance_deg (float): 許容角度（度）
 
         Returns:
             float: 方向性スペクトラルエントロピー
         """
-        h, w = image.shape
-        f = np.fft.fft2(image)
-        fshift = np.fft.fftshift(f)
-        magnitude = np.abs(fshift)
-
-        cy, cx = h // 2, w // 2
-        y, x = np.ogrid[:h, :w]
-        dy = y - cy
-        dx = x - cx
-        angle = np.arctan2(dy, dx) * 180 / np.pi  # -180〜180度
-
-        angle = (angle + 360) % 180  # 0〜180度に正規化
-        diff = np.abs(angle - angle_deg)
+        diff = np.abs(angle_map - angle_deg)
         diff = np.minimum(
             diff, 180 - diff
         )  # 0度と180度は同一方向のため短い方の角度差を採用
         mask = diff <= tolerance_deg
 
-        # 指定方向のスペクトラムを抽出
         directional_magnitude = magnitude[mask]
         if directional_magnitude.size == 0:
             return 0.0
@@ -331,30 +302,22 @@ class FFTFrequencyExtractor(BaseFeatureExtractor):
         return self._compute_spectral_entropy(directional_magnitude)
 
     def _compute_band_entropy(
-        self, image: np.ndarray, bands: List[Tuple[float, float]]
+        self,
+        magnitude: np.ndarray,
+        freq_norm: np.ndarray,
+        bands: List[Tuple[float, float]],
     ) -> Dict[str, float]:
         """
         周波数帯域ごとのエントロピーを計算する.
 
         Args:
-            image (np.ndarray): グレースケール画像
+            magnitude (np.ndarray): 振幅スペクトル
+            freq_norm (np.ndarray): 正規化周波数マップ
             bands (List[Tuple[float, float]]): 周波数帯域のリスト
 
         Returns:
             Dict[str, float]: 帯域別エントロピーの辞書
         """
-        f = np.fft.fft2(image)
-        fshift = np.fft.fftshift(f)
-        magnitude = np.abs(fshift)
-
-        h, w = image.shape
-        cy, cx = h // 2, w // 2
-        max_radius = np.sqrt(cx**2 + cy**2)
-
-        y, x = np.ogrid[:h, :w]
-        dist = np.sqrt((x - cx) ** 2 + (y - cy) ** 2)
-        freq_norm = dist / max_radius / 2
-
         entropies = {}
 
         for i, (fmin, fmax) in enumerate(bands):
@@ -417,68 +380,63 @@ class FFTFrequencyExtractor(BaseFeatureExtractor):
             if self.mm_per_pixel is not None:
                 scale = 1.0 / self.mm_per_pixel
 
-            # 1. 高周波/低周波エネルギー比
-            high_low_ratio = self._compute_high_low_freq_ratio(
-                gray_image, self.high_low_threshold
+            # FFT を1回だけ計算し, 全ヘルパーで共有
+            magnitude, power_spectrum, freq_norm, angle_map = self._compute_fft_data(
+                gray_image
             )
-            # 無限大の値をチェック
-            if np.isinf(high_low_ratio):
-                high_low_ratio = 0.0
-            results["high_low_ratio"] = float(high_low_ratio)
+
+            # 1. 高周波/低周波エネルギー比
+            results["high_low_ratio"] = self._compute_high_low_freq_ratio(
+                power_spectrum, freq_norm, self.high_low_threshold
+            )
 
             # 2. スペクトルの標準偏差
-            spectral_std = self._compute_spectral_std(gray_image) * scale
-            results["spectral_std"] = float(spectral_std)
+            results["spectral_std"] = (
+                self._compute_spectral_std(magnitude, freq_norm) * scale
+            )
 
             # 3. 方向性エネルギー（水平／垂直）
-            horizontal_energy = self._compute_directional_energy(
-                gray_image, 0.0, self.directional_tolerance
+            results["horizontal_energy"] = self._compute_directional_energy(
+                power_spectrum, angle_map, 0.0, self.directional_tolerance
             )
-            results["horizontal_energy"] = float(horizontal_energy)
-
-            vertical_energy = self._compute_directional_energy(
-                gray_image, 90.0, self.directional_tolerance
+            results["vertical_energy"] = self._compute_directional_energy(
+                power_spectrum, angle_map, 90.0, self.directional_tolerance
             )
-            results["vertical_energy"] = float(vertical_energy)
 
             # 4. スペクトルピーク数と最大値
             num_peaks, max_peak_amp = self._compute_spectral_peaks(
-                gray_image, self.peak_threshold_ratio
+                magnitude, self.peak_threshold_ratio
             )
             results["num_peaks"] = int(num_peaks)
             results["max_peak_amp"] = float(max_peak_amp)
 
             # 5. 周波数帯エネルギー
-            band_energies = self._compute_band_energy(gray_image, self.frequency_bands)
-            results.update(band_energies)
+            results.update(
+                self._compute_band_energy(
+                    power_spectrum, freq_norm, self.frequency_bands
+                )
+            )
 
             # 6. スペクトル重心
-            spectral_centroid = self._compute_spectral_centroid(gray_image) * scale
-            results["spectral_centroid"] = float(spectral_centroid)
+            results["spectral_centroid"] = (
+                self._compute_spectral_centroid(magnitude, freq_norm) * scale
+            )
 
             # 7. スペクトラル全体エントロピー
-            f = np.fft.fft2(gray_image)
-            fshift = np.fft.fftshift(f)
-            magnitude = np.abs(fshift)
-            spectral_entropy = self._compute_spectral_entropy(magnitude)
-            results["spectral_entropy"] = float(spectral_entropy)
+            results["spectral_entropy"] = self._compute_spectral_entropy(magnitude)
 
             # 8. 方向性エントロピー（水平／垂直）
-            horizontal_entropy = self._compute_directional_entropy(
-                gray_image, 0.0, self.directional_tolerance
+            results["horizontal_entropy"] = self._compute_directional_entropy(
+                magnitude, angle_map, 0.0, self.directional_tolerance
             )
-            results["horizontal_entropy"] = float(horizontal_entropy)
-
-            vertical_entropy = self._compute_directional_entropy(
-                gray_image, 90.0, self.directional_tolerance
+            results["vertical_entropy"] = self._compute_directional_entropy(
+                magnitude, angle_map, 90.0, self.directional_tolerance
             )
-            results["vertical_entropy"] = float(vertical_entropy)
 
             # 9. 周波数帯域エントロピー
-            band_entropies = self._compute_band_entropy(
-                gray_image, self.frequency_bands
+            results.update(
+                self._compute_band_entropy(magnitude, freq_norm, self.frequency_bands)
             )
-            results.update(band_entropies)
 
             # NaNや無限大の値をチェックして修正
             for key, value in results.items():

--- a/pochivision/feature_extractors/hlac_texture.py
+++ b/pochivision/feature_extractors/hlac_texture.py
@@ -24,7 +24,7 @@ class HLACTextureExtractor(BaseFeatureExtractor):
     高次の空間的相関パターンを定量化できます。
 
     抽出する特徴量:
-    - 標準HLAC: 45次元の特徴量（0次、1次、2次自己相関） [correlation_coefficient]
+    - 標準HLAC: 37次元の特徴量（0次1 + 1次8 + 2次28） [correlation_coefficient]
     - 回転不変HLAC: 11次元の特徴量（回転に対して不変） [correlation_coefficient]
     - スケール不変性: 複数スケールでの特徴抽出 [correlation_coefficient]
     - 正規化: 特徴量の正規化による明度変化への頑健性 [normalized_correlation]
@@ -163,10 +163,10 @@ class HLACTextureExtractor(BaseFeatureExtractor):
             k[1 + dy, 1 + dx] = 1  # 隣接画素
             patterns.append(k)
 
-        # 2次: 2つの隣接画素の組み合わせ
+        # 2次: 2つの異なる隣接画素の組み合わせ (自己ペア i==j は1次と重複するため除外)
         if self.order >= 2:
             for i in range(len(offsets)):
-                for j in range(i, len(offsets)):
+                for j in range(i + 1, len(offsets)):
                     dx1, dy1 = offsets[i]
                     dx2, dy2 = offsets[j]
                     k = np.zeros((3, 3), dtype=np.uint8)
@@ -324,7 +324,7 @@ class HLACTextureExtractor(BaseFeatureExtractor):
             if default_config["order"] == 1:
                 num_features = 9  # 0次(1) + 1次(8)
             else:  # order == 2
-                num_features = 45  # 0次(1) + 1次(8) + 2次(36)
+                num_features = 37  # 0次(1) + 1次(8) + 2次(28)
 
         return [f"hlac_feature_{i:02d}" for i in range(num_features)]
 

--- a/tests/extractors/test_fft_features.py
+++ b/tests/extractors/test_fft_features.py
@@ -150,8 +150,11 @@ class TestFFTFrequencyExtractor:
         """周波数帯域エネルギー計算の内部メソッドをテスト."""
         image = np.random.randint(0, 256, (32, 32), dtype=np.uint8)
         bands = [[0.0, 0.1], [0.1, 0.3], [0.3, 0.5]]
+        magnitude, power_spectrum, freq_norm, angle_map = (
+            self.extractor._compute_fft_data(image)
+        )
 
-        energies = self.extractor._compute_band_energy(image, bands)
+        energies = self.extractor._compute_band_energy(power_spectrum, freq_norm, bands)
 
         assert len(energies) == 3
         assert "band_1_0.00_0.10" in energies
@@ -165,8 +168,9 @@ class TestFFTFrequencyExtractor:
     def test_compute_spectral_centroid(self):
         """スペクトル重心計算の内部メソッドをテスト."""
         image = np.random.randint(0, 256, (32, 32), dtype=np.uint8)
+        magnitude, _, freq_norm, _ = self.extractor._compute_fft_data(image)
 
-        centroid = self.extractor._compute_spectral_centroid(image)
+        centroid = self.extractor._compute_spectral_centroid(magnitude, freq_norm)
 
         assert isinstance(centroid, float)
         assert 0 <= centroid <= 0.5  # 正規化された周波数範囲
@@ -174,8 +178,11 @@ class TestFFTFrequencyExtractor:
     def test_compute_high_low_freq_ratio(self):
         """高周波/低周波比計算の内部メソッドをテスト."""
         image = np.random.randint(0, 256, (32, 32), dtype=np.uint8)
+        _, power_spectrum, freq_norm, _ = self.extractor._compute_fft_data(image)
 
-        ratio = self.extractor._compute_high_low_freq_ratio(image, 0.2)
+        ratio = self.extractor._compute_high_low_freq_ratio(
+            power_spectrum, freq_norm, 0.2
+        )
 
         assert isinstance(ratio, float)
         assert ratio >= 0
@@ -183,8 +190,9 @@ class TestFFTFrequencyExtractor:
     def test_compute_spectral_std(self):
         """スペクトル標準偏差計算の内部メソッドをテスト."""
         image = np.random.randint(0, 256, (32, 32), dtype=np.uint8)
+        magnitude, _, freq_norm, _ = self.extractor._compute_fft_data(image)
 
-        std = self.extractor._compute_spectral_std(image)
+        std = self.extractor._compute_spectral_std(magnitude, freq_norm)
 
         assert isinstance(std, float)
         assert std >= 0
@@ -192,22 +200,28 @@ class TestFFTFrequencyExtractor:
     def test_compute_directional_energy(self):
         """方向性エネルギー計算の内部メソッドをテスト."""
         image = np.random.randint(0, 256, (32, 32), dtype=np.uint8)
+        _, power_spectrum, _, angle_map = self.extractor._compute_fft_data(image)
 
         # 水平方向
-        horizontal = self.extractor._compute_directional_energy(image, 0.0, 10.0)
+        horizontal = self.extractor._compute_directional_energy(
+            power_spectrum, angle_map, 0.0, 10.0
+        )
         assert isinstance(horizontal, float)
         assert 0 <= horizontal <= 1
 
         # 垂直方向
-        vertical = self.extractor._compute_directional_energy(image, 90.0, 10.0)
+        vertical = self.extractor._compute_directional_energy(
+            power_spectrum, angle_map, 90.0, 10.0
+        )
         assert isinstance(vertical, float)
         assert 0 <= vertical <= 1
 
     def test_compute_spectral_peaks(self):
         """スペクトルピーク計算の内部メソッドをテスト."""
         image = np.random.randint(0, 256, (32, 32), dtype=np.uint8)
+        magnitude, _, _, _ = self.extractor._compute_fft_data(image)
 
-        num_peaks, max_peak = self.extractor._compute_spectral_peaks(image, 0.1)
+        num_peaks, max_peak = self.extractor._compute_spectral_peaks(magnitude, 0.1)
 
         assert isinstance(num_peaks, int)
         assert isinstance(max_peak, float)
@@ -237,17 +251,18 @@ class TestFFTFrequencyExtractor:
     def test_compute_directional_entropy(self):
         """方向性エントロピー計算の内部メソッドをテスト."""
         image = np.random.randint(0, 256, (32, 32), dtype=np.uint8)
+        magnitude, _, _, angle_map = self.extractor._compute_fft_data(image)
 
         # 水平方向エントロピー
         horizontal_entropy = self.extractor._compute_directional_entropy(
-            image, 0.0, 10.0
+            magnitude, angle_map, 0.0, 10.0
         )
         assert isinstance(horizontal_entropy, float)
         assert horizontal_entropy >= 0
 
         # 垂直方向エントロピー
         vertical_entropy = self.extractor._compute_directional_entropy(
-            image, 90.0, 10.0
+            magnitude, angle_map, 90.0, 10.0
         )
         assert isinstance(vertical_entropy, float)
         assert vertical_entropy >= 0
@@ -256,8 +271,9 @@ class TestFFTFrequencyExtractor:
         """周波数帯域エントロピー計算の内部メソッドをテスト."""
         image = np.random.randint(0, 256, (32, 32), dtype=np.uint8)
         bands = [[0.0, 0.1], [0.1, 0.3], [0.3, 0.5]]
+        magnitude, _, freq_norm, _ = self.extractor._compute_fft_data(image)
 
-        entropies = self.extractor._compute_band_entropy(image, bands)
+        entropies = self.extractor._compute_band_entropy(magnitude, freq_norm, bands)
 
         assert len(entropies) == 3
         assert "band_1_0.00_0.10_entropy" in entropies

--- a/tests/extractors/test_hlac_features.py
+++ b/tests/extractors/test_hlac_features.py
@@ -27,11 +27,11 @@ def test_hlac_texture_basic():
     for name, value in features.items():
         print(f"  {name}: {value:.6f}")
 
-    # 基本的な特徴量が含まれているかチェック（45次元）
-    assert len(features) == 45, f"特徴量数が45ではありません: {len(features)}"
+    # 基本的な特徴量が含まれているかチェック（37次元）
+    assert len(features) == 37, f"特徴量数が37ではありません: {len(features)}"
 
     # 特徴量名の形式チェック（ゼロパディング対応）
-    for i in range(45):
+    for i in range(37):
         feature_name = f"hlac_feature_{i:02d}"
         assert feature_name in features, f"特徴量 {feature_name} が見つかりません"
 
@@ -59,8 +59,8 @@ def test_hlac_rotation_invariant():
     np.random.seed(42)
     test_image = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)
 
-    # 1. 標準HLAC（45次元）
-    print("\n--- 標準HLAC (45次元) ---")
+    # 1. 標準HLAC（37次元）
+    print("\n--- 標準HLAC (37次元) ---")
     extractor_standard = HLACTextureExtractor()
     features_standard = extractor_standard.extract(test_image)
     print(f"特徴量数: {len(features_standard)}")
@@ -79,8 +79,8 @@ def test_hlac_rotation_invariant():
 
     # 特徴量数の確認
     assert (
-        len(features_standard) == 45
-    ), f"標準HLACの特徴量数が45ではありません: {len(features_standard)}"
+        len(features_standard) == 37
+    ), f"標準HLACの特徴量数が37ではありません: {len(features_standard)}"
     assert (
         len(features_ri) == 11
     ), f"回転不変HLACの特徴量数が11ではありません: {len(features_ri)}"
@@ -119,8 +119,8 @@ def test_hlac_different_orders():
         len(features_order1) == 9
     ), f"1次HLACの特徴量数が9ではありません: {len(features_order1)}"
     assert (
-        len(features_order2) == 45
-    ), f"2次HLACの特徴量数が45ではありません: {len(features_order2)}"
+        len(features_order2) == 37
+    ), f"2次HLACの特徴量数が37ではありません: {len(features_order2)}"
 
 
 def test_hlac_multiscale():
@@ -390,7 +390,7 @@ def test_feature_names_and_units():
 
     # 基本特徴量名の確認
     base_names = HLACTextureExtractor.get_base_feature_names()
-    expected_base_names = [f"hlac_feature_{i:02d}" for i in range(45)]
+    expected_base_names = [f"hlac_feature_{i:02d}" for i in range(37)]
     print(f"基本特徴量名の数: {len(base_names)}")
     print(f"基本特徴量名の例: {base_names[:5]}")
     assert (
@@ -400,7 +400,7 @@ def test_feature_names_and_units():
     # 単位付き特徴量名の確認
     unit_names = HLACTextureExtractor.get_feature_names()
     expected_unit_names = [
-        f"hlac_feature_{i:02d}[correlation_coefficient]" for i in range(45)
+        f"hlac_feature_{i:02d}[correlation_coefficient]" for i in range(37)
     ]
     print(f"単位付き特徴量名の数: {len(unit_names)}")
     print(f"単位付き特徴量名の例: {unit_names[:5]}")
@@ -411,7 +411,7 @@ def test_feature_names_and_units():
     # 単位辞書の確認
     units = HLACTextureExtractor.get_feature_units()
     expected_units = {
-        f"hlac_feature_{i:02d}": "correlation_coefficient" for i in range(45)
+        f"hlac_feature_{i:02d}": "correlation_coefficient" for i in range(37)
     }
     print(f"特徴量単位辞書のサイズ: {len(units)}")
     print(f"特徴量単位辞書の例: {dict(list(units.items())[:5])}")


### PR DESCRIPTION
## Summary

- FFT を `_compute_fft_data` で1回計算し, 全ヘルパーメソッドで共有するようリファクタリングした (従来 ~9回計算).
- `high_low_ratio` の `np.inf` → `0.0` 置換を, メソッド内で直接 `0.0` を返すよう修正.
- HLAC 2次パターンの自己ペア (i==j) を除外し, 1次と重複する8特徴を削除 (45→37次元).

## Related Issue

Closes #115

## Changes

- `pochivision/feature_extractors/fft_frequency.py`:
  - `_compute_fft_data` メソッドを追加 (magnitude, power_spectrum, freq_norm, angle_map を1回計算)
  - 全ヘルパーメソッドのシグネチャを事前計算データを受け取る形に変更
  - `_compute_high_low_freq_ratio` で低周波 0 の場合に直接 `0.0` を返すよう変更
- `pochivision/feature_extractors/hlac_texture.py`:
  - 2次パターンのループを `range(i, ...)` → `range(i + 1, ...)` に変更
  - 特徴次元数を 45→37 に更新
- テスト: FFT ヘルパーのシグネチャ変更に追従, HLAC の次元数期待値を 37 に更新

## Test Plan

- [x] `uv run pytest tests/extractors/test_fft_features.py` で 24 テストがパス
- [x] `uv run pytest tests/extractors/test_hlac_features.py` で 13 テストがパス
- [x] `uv run pytest` で全 297 テストがパス

## Checklist

- [x] FFT が1回のみ計算される
- [x] inf の扱いが適切
- [x] HLAC の2次パターンに自己ペアが含まれない (37次元)
- [x] `uv run pytest` が通る