### PR TITLE
docs: Issue テンプレートの Branch/Label セクションを統一

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -32,6 +32,10 @@ labels: bug
 
 <!-- Screenshots, logs, or any other relevant information. -->
 
----
+## Branch
 
-> **Branch prefix**: `fix/`
+`fix/`
+
+## Label
+
+`bug`

--- a/.github/ISSUE_TEMPLATE/documentation_request.md
+++ b/.github/ISSUE_TEMPLATE/documentation_request.md
@@ -20,6 +20,10 @@ labels: documentation
 
 - [ ]
 
----
+## Branch
 
-> **Branch prefix**: `docs/`
+`docs/`
+
+## Label
+
+`documentation`

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -28,6 +28,10 @@ labels: enhancement
 
 <!-- Any other context, references, or screenshots. -->
 
----
+## Branch
 
-> **Branch prefix**: `feature/`
+`feat/`
+
+## Label
+
+`enhancement`

--- a/.github/ISSUE_TEMPLATE/refactor_request.md
+++ b/.github/ISSUE_TEMPLATE/refactor_request.md
@@ -24,6 +24,10 @@ labels: refactor
 
 - [ ]
 
----
+## Branch
 
-> **Branch prefix**: `refactor/`
+`refactor/`
+
+## Label
+
+`refactor`

--- a/.github/ISSUE_TEMPLATE/test_request.md
+++ b/.github/ISSUE_TEMPLATE/test_request.md
@@ -20,6 +20,10 @@ labels: test
 
 - [ ]
 
----
+## Branch
 
-> **Branch prefix**: `test/`
+`test/`
+
+## Label
+
+`test`


### PR DESCRIPTION
## Summary

- 5 種類の Issue テンプレートの末尾を `## Branch` / `## Label` 形式に統一した.

## Related Issue

無し

## Changes

- `.github/ISSUE_TEMPLATE/bug_report.md`: `> **Branch prefix**: \`fix/\`` → `## Branch` / `## Label` 形式に変更
- `.github/ISSUE_TEMPLATE/feature_request.md`: 同上
- `.github/ISSUE_TEMPLATE/refactor_request.md`: 同上
- `.github/ISSUE_TEMPLATE/test_request.md`: 同上
- `.github/ISSUE_TEMPLATE/documentation_request.md`: 同上

## Test Plan

- [x] テンプレートファイルの構文が正しいことを確認

## Checklist

- [x] 全 5 テンプレートが `## Branch` / `## Label` 形式に統一されている