### PR TITLE
fix: SWT のサイズ調整を 2^level 対応に修正し正規化判定を dtype ベースに変更

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### Changed
 - `pochivision/tools/` をプロジェクトルートの `tools/` に移動し, パッケージから分離. 未使用の dev 依存 `flake8`, `pylint` を削除. ([#117](https://github.com/kurorosu/pochivision/pull/117))
 - `test_blur_processors.py` のモックテスト 2 件を削除し, 全テストを古典派テストに統一. ([#118](https://github.com/kurorosu/pochivision/pull/118))
-- FFT を1回計算して全ヘルパーで共有するようリファクタリング. HLAC 2次パターンの自己ペアを除外し特徴次元を 45→37 に修正. (NA.)
+- FFT を1回計算して全ヘルパーで共有するようリファクタリング. HLAC 2次パターンの自己ペアを除外し特徴次元を 45→37 に修正. ([#126](https://github.com/kurorosu/pochivision/pull/126))
 
 ### Fixed
 - HSV 特徴量抽出の Hue チャンネルに循環統計 (`scipy.stats.circmean` / `circstd`) を適用し, 0/180 境界付近の統計値を修正. 単位ラベルを `hue_0_179` に変更. ([#119](https://github.com/kurorosu/pochivision/pull/119))
@@ -21,6 +21,7 @@
 - FFT 方向エネルギーの 0/180 度境界処理に対応. スペクトルエントロピーのゼロ要素バイアスを修正. ([#123](https://github.com/kurorosu/pochivision/pull/123))
 - `PipelineExecutor` に `mode` 値の検証を追加し, 個別プロセッサの例外でパイプライン全体が中断しないよう修正. ([#124](https://github.com/kurorosu/pochivision/pull/124))
 - resize の補間方法を拡大時に `INTER_LINEAR` に切替, edge_detection の float 判定を `np.floating` に修正, CLAHE バリデータで tuple を許容. ([#125](https://github.com/kurorosu/pochivision/pull/125))
+- SWT のサイズ調整を `2^max_level` の倍数に対応. 正規化判定を値ベースから `dtype` ベースに変更. (NA.)
 
 ### Removed
 - 無し

--- a/pochivision/feature_extractors/swt_frequency.py
+++ b/pochivision/feature_extractors/swt_frequency.py
@@ -199,8 +199,8 @@ class SWTFrequencyExtractor(BaseFeatureExtractor):
         """
         SWT変換のために画像サイズを調整する.
 
-        SWTは各軸のデータ長が偶数である必要があるため、
-        奇数サイズの場合は1ピクセル追加して偶数サイズにする。
+        pywt.swt2 は level=N で各軸のデータ長が 2^N の倍数である必要がある.
+        不足分をパディングで補う.
 
         Args:
             image (np.ndarray): 入力画像
@@ -208,17 +208,17 @@ class SWTFrequencyExtractor(BaseFeatureExtractor):
         Returns:
             np.ndarray: サイズ調整された画像
         """
+        max_level = self.config.get("max_level", 1)
+        divisor = 2**max_level
         height, width = image.shape[:2]
 
-        # 調整が必要かチェック
-        height_adjustment = 1 if height % 2 == 1 else 0
-        width_adjustment = 1 if width % 2 == 1 else 0
+        # 2^max_level の倍数に切り上げ
+        height_adjustment = (divisor - height % divisor) % divisor
+        width_adjustment = (divisor - width % divisor) % divisor
 
         if height_adjustment == 0 and width_adjustment == 0:
-            # 調整不要
             return image
 
-        # 新しいサイズを計算
         new_height = height + height_adjustment
         new_width = width + width_adjustment
 
@@ -281,7 +281,7 @@ class SWTFrequencyExtractor(BaseFeatureExtractor):
             # SWT変換のために画像サイズを調整（奇数サイズを偶数サイズに）
             gray_image = self._adjust_image_size_for_swt(gray_image)
 
-            if gray_image.max() > 1.0:
+            if np.issubdtype(gray_image.dtype, np.integer):
                 gray_image = gray_image.astype(np.float32) / 255.0
             else:
                 gray_image = gray_image.astype(np.float32)


### PR DESCRIPTION
## Summary

- `_adjust_image_size_for_swt` のパディングを 2 の倍数から `2^max_level` の倍数に修正し, `level > 1` でのエラーを解消した.
- グレースケール正規化の判定を `gray_image.max() > 1.0` から `np.issubdtype(dtype, np.integer)` に変更し, 最大値が 1 以下の uint8 画像が誤って正規化済みと判定される問題を修正した.

## Related Issue

Closes #109

## Changes

- `pochivision/feature_extractors/swt_frequency.py`:
  - `_adjust_image_size_for_swt`: `divisor = 2**max_level` で必要なパディング量を計算
  - `extract`: `gray_image.max() > 1.0` → `np.issubdtype(gray_image.dtype, np.integer)` に変更

## Code Changes

```python
# サイズ調整: 2^max_level の倍数に切り上げ
divisor = 2**max_level
height_adjustment = (divisor - height % divisor) % divisor
width_adjustment = (divisor - width % divisor) % divisor

# 正規化: dtype ベースで判定
if np.issubdtype(gray_image.dtype, np.integer):
    gray_image = gray_image.astype(np.float32) / 255.0
```

## Test Plan

- [x] `uv run pytest tests/extractors/test_swt_frequency.py` で 20 テストがパス
- [x] `uv run pytest` で全 297 テストがパス

## Checklist

- [x] `level > 1` でも画像サイズエラーが発生しない
- [x] uint8 画像が常に正しく正規化される
- [x] `uv run pytest` が通る
