### PR TITLE
fix: LBP ヒストグラムのビン数を理論値に固定し特徴ベクトル長を統一

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@
 - FFT 方向エネルギーの 0/180 度境界処理に対応. スペクトルエントロピーのゼロ要素バイアスを修正. ([#123](https://github.com/kurorosu/pochivision/pull/123))
 - `PipelineExecutor` に `mode` 値の検証を追加し, 個別プロセッサの例外でパイプライン全体が中断しないよう修正. ([#124](https://github.com/kurorosu/pochivision/pull/124))
 - resize の補間方法を拡大時に `INTER_LINEAR` に切替, edge_detection の float 判定を `np.floating` に修正, CLAHE バリデータで tuple を許容. ([#125](https://github.com/kurorosu/pochivision/pull/125))
-- SWT のサイズ調整を `2^max_level` の倍数に対応. 正規化判定を値ベースから `dtype` ベースに変更. (NA.)
+- SWT のサイズ調整を `2^max_level` の倍数に対応. 正規化判定を値ベースから `dtype` ベースに変更. ([#132](https://github.com/kurorosu/pochivision/pull/132))
+- LBP ヒストグラムのビン数を理論値 (uniform: P+2, default: 2^P) に固定し, 画像依存の特徴ベクトル長不定を解消. (NA.)
 
 ### Removed
 - 無し

--- a/pochivision/feature_extractors/lbp_texture.py
+++ b/pochivision/feature_extractors/lbp_texture.py
@@ -137,7 +137,11 @@ class LBPTextureExtractor(BaseFeatureExtractor):
 
             lbp = local_binary_pattern(gray_image, self.P, self.R, method=self.method)
 
-            n_bins = int(lbp.max() + 1)  # 実際のラベル数で固定次元化
+            # 理論的ビン数を使用 (画像内容に依存しない固定次元)
+            if self.method == "uniform":
+                n_bins = self.P + 2
+            else:
+                n_bins = 2**self.P
             hist, _ = np.histogram(
                 lbp.ravel(), bins=n_bins, range=(0, n_bins), density=True
             )


### PR DESCRIPTION
## Summary

- `lbp.max() + 1` (データ依存) を理論的ビン数 (uniform: `P + 2`, default: `2**P`) に変更し, 画像によって特徴ベクトル長が変わる問題を修正した.

## Related Issue

Closes #110

## Changes

- `pochivision/feature_extractors/lbp_texture.py`:
  - `n_bins = int(lbp.max() + 1)` → method に応じた理論的ビン数に変更

## Code Changes

```python
# pochivision/feature_extractors/lbp_texture.py (修正後)
if self.method == "uniform":
    n_bins = self.P + 2
else:
    n_bins = 2**self.P
hist, _ = np.histogram(
    lbp.ravel(), bins=n_bins, range=(0, n_bins), density=True
)
```

## Test Plan

- [x] `uv run pytest tests/extractors/test_lbp_features.py` で 10 テストがパス
- [x] `uv run pytest` で全 297 テストがパス

## Checklist

- [x] 全画像で特徴ベクトル長が一定
- [x] `uv run pytest` が通る
