### PR TITLE
fix: FFT 前の uint8 正規化を削除しコントラスト情報を保持

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@
 
 ### Fixed
 - FFT 周波数正規化を対角線距離基準から軸方向最大距離基準に修正し, 帯域カバレッジを改善. ([#135](https://github.com/kurorosu/pochivision/pull/135))
-- FFT 計算前に Hanning 窓関数を適用し, 画像境界のスペクトルリークを抑制. (NA.)
+- FFT 計算前に Hanning 窓関数を適用し, 画像境界のスペクトルリークを抑制. ([#136](https://github.com/kurorosu/pochivision/pull/136))
+- FFT 前の uint8 正規化を削除し, float64 のまま処理するよう変更. コントラスト情報が保持される. (NA.)
 
 ### Removed
 - 無し

--- a/pochivision/feature_extractors/fft_frequency.py
+++ b/pochivision/feature_extractors/fft_frequency.py
@@ -351,17 +351,6 @@ class FFTFrequencyExtractor(BaseFeatureExtractor):
         if image is None or image.size == 0:
             raise ValueError("Input image is empty or None")
 
-        # 画像の型を適切に変換
-        if image.dtype not in [np.uint8, np.uint16, np.float32, np.float64]:
-            if image.dtype in [np.int32, np.int64]:
-                image = np.clip(image, 0, 255).astype(np.uint8)
-            else:
-                image = image.astype(np.float32)
-                if image.max() <= 1.0:
-                    image = (image * 255).astype(np.uint8)
-                else:
-                    image = np.clip(image, 0, 255).astype(np.uint8)
-
         if len(image.shape) == 3:
             gray_image = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
         elif len(image.shape) == 2:
@@ -369,9 +358,8 @@ class FFTFrequencyExtractor(BaseFeatureExtractor):
         else:
             raise ValueError(f"Input image must be 2D or 3D, got shape: {image.shape}")
 
-        gray_image = cv2.normalize(
-            gray_image, None, 0, 255, cv2.NORM_MINMAX, dtype=cv2.CV_8U
-        )
+        # コントラスト情報を保持するため float64 のまま FFT に渡す
+        gray_image = gray_image.astype(np.float64)
 
         results = {}
 

--- a/tests/extractors/test_fft_features.py
+++ b/tests/extractors/test_fft_features.py
@@ -520,9 +520,13 @@ class TestFFTFrequencyExtractor:
     # --- spectral_std ---
 
     def test_spectral_std_uniform_is_near_zero(self):
-        """単色画像のスペクトル標準偏差は ~0."""
-        features = self.extractor.extract(self._make_uniform())
-        assert features["spectral_std"] < 0.01
+        """単色画像のスペクトル標準偏差はランダム画像より十分小さい."""
+        features_uniform = self.extractor.extract(self._make_uniform())
+        np.random.seed(42)
+        features_random = self.extractor.extract(
+            np.random.randint(0, 256, (64, 64), dtype=np.uint8)
+        )
+        assert features_uniform["spectral_std"] < features_random["spectral_std"]
 
     def test_spectral_std_random_is_positive(self):
         """ランダム画像のスペクトル標準偏差は > 0."""


### PR DESCRIPTION
## Summary

- `extract` メソッドの `cv2.normalize(..., cv2.CV_8U)` と冗長な型変換を削除し, `float64` のまま FFT に渡すよう変更した.
- コントラストが異なる画像間で特徴量の差が出るようになった.

## Related Issue

Closes #130

## Changes

- `pochivision/feature_extractors/fft_frequency.py`:
  - `cv2.normalize(gray_image, None, 0, 255, cv2.NORM_MINMAX, dtype=cv2.CV_8U)` を削除
  - 冗長な dtype 変換ロジック (int32/int64/float32 分岐) を削除
  - `gray_image = gray_image.astype(np.float64)` に簡素化
- `tests/extractors/test_fft_features.py`:
  - `spectral_std` の閾値テストをランダム画像との比較に変更

## Test Plan

- [x] `uv run pytest tests/extractors/test_fft_features.py` で 38 テストがパス
- [x] `uv run pytest` で全 311 テストがパス

## Checklist

- [x] `cv2.normalize` が削除されている
- [x] コントラスト情報が FFT に渡される
- [x] `uv run pytest` が通る