### PR TITLE
fix: FFT 帯域エネルギーの最終帯域を上限なしにし非正方形画像の合計を修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@
 - FFT 周波数正規化を対角線距離基準から軸方向最大距離基準に修正し, 帯域カバレッジを改善. ([#135](https://github.com/kurorosu/pochivision/pull/135))
 - FFT 計算前に Hanning 窓関数を適用し, 画像境界のスペクトルリークを抑制. ([#136](https://github.com/kurorosu/pochivision/pull/136))
 - FFT 前の uint8 正規化を削除し, float64 のまま処理するよう変更. コントラスト情報が保持される. ([#137](https://github.com/kurorosu/pochivision/pull/137))
-- FFT のエネルギー・エントロピー計算から DC 成分を除外し, AC 成分のみで特徴量を計算するよう修正. (NA.)
+- FFT のエネルギー・エントロピー計算から DC 成分を除外し, AC 成分のみで特徴量を計算するよう修正. ([#138](https://github.com/kurorosu/pochivision/pull/138))
+- FFT 帯域エネルギーの最終帯域を上限なしに変更し, 非正方形画像でも合計が ~1.0 になるよう修正. (NA.)
 
 ### Removed
 - 無し

--- a/pochivision/feature_extractors/fft_frequency.py
+++ b/pochivision/feature_extractors/fft_frequency.py
@@ -138,7 +138,11 @@ class FFTFrequencyExtractor(BaseFeatureExtractor):
         energies = {}
 
         for i, (fmin, fmax) in enumerate(bands):
-            mask = (freq_norm >= fmin) & (freq_norm < fmax)
+            # 最終帯域は上限なし (非正方形画像の対角線で freq_norm > 0.5 になる分を含める)
+            if i == len(bands) - 1:
+                mask = freq_norm >= fmin
+            else:
+                mask = (freq_norm >= fmin) & (freq_norm < fmax)
             energy = (
                 np.sum(power_spectrum[mask]) / total_energy if total_energy > 0 else 0.0
             )
@@ -326,7 +330,11 @@ class FFTFrequencyExtractor(BaseFeatureExtractor):
         entropies = {}
 
         for i, (fmin, fmax) in enumerate(bands):
-            mask = (freq_norm >= fmin) & (freq_norm < fmax)
+            # 最終帯域は上限なし (非正方形画像の対角線で freq_norm > 0.5 になる分を含める)
+            if i == len(bands) - 1:
+                mask = freq_norm >= fmin
+            else:
+                mask = (freq_norm >= fmin) & (freq_norm < fmax)
             band_magnitude = magnitude[mask]
 
             if band_magnitude.size == 0:

--- a/tests/extractors/test_fft_features.py
+++ b/tests/extractors/test_fft_features.py
@@ -502,8 +502,8 @@ class TestFFTFrequencyExtractor:
         features = self.extractor.extract(self._make_h_stripe())
         assert features["band_1_0.00_0.10"] < 0.5
 
-    def test_band_energies_sum_to_near_one(self):
-        """帯域エネルギーの合計が ~1.0 になることを確認."""
+    def test_band_energies_sum_to_one_square(self):
+        """正方形画像の帯域エネルギー合計が ~1.0."""
         np.random.seed(42)
         image = np.random.randint(0, 256, (64, 64), dtype=np.uint8)
         features = self.extractor.extract(image)
@@ -512,7 +512,19 @@ class TestFFTFrequencyExtractor:
             + features["band_2_0.10_0.30"]
             + features["band_3_0.30_0.50"]
         )
-        assert 0.8 <= total <= 1.1, f"got {total}"
+        assert 0.95 <= total <= 1.05, f"got {total}"
+
+    def test_band_energies_sum_to_one_nonsquare(self):
+        """非正方形画像でも帯域エネルギー合計が ~1.0."""
+        np.random.seed(42)
+        image = np.random.randint(0, 256, (32, 96), dtype=np.uint8)
+        features = self.extractor.extract(image)
+        total = (
+            features["band_1_0.00_0.10"]
+            + features["band_2_0.10_0.30"]
+            + features["band_3_0.30_0.50"]
+        )
+        assert 0.95 <= total <= 1.05, f"got {total}"
 
     # --- high_low_ratio ---
 


### PR DESCRIPTION
## Summary

- `_compute_band_energy` と `_compute_band_entropy` の最終帯域のマスクを `freq_norm >= fmin` (上限なし) に変更し, 非正方形画像の対角線で `freq_norm > 0.5` になるエネルギーも高周波帯に含めるよう修正した.
- 非正方形画像の帯域合計テストを追加した.

## Related Issue

Closes #139

## Changes

- `pochivision/feature_extractors/fft_frequency.py`:
  - `_compute_band_energy`: 最終帯域は `freq_norm >= fmin` (上限なし)
  - `_compute_band_entropy`: 同様
- `tests/extractors/test_fft_features.py`:
  - `test_band_energies_sum_to_one_nonsquare`: 32x96 非正方形画像で合計 ~1.0 を検証

## Code Changes

```python
# 最終帯域は上限なし
if i == len(bands) - 1:
    mask = freq_norm >= fmin
else:
    mask = (freq_norm >= fmin) & (freq_norm < fmax)
```

## Test Plan

- [x] `uv run pytest tests/extractors/test_fft_features.py` で 44 テストがパス
- [x] `uv run pytest` で全 317 テストがパス

## Checklist

- [x] 非正方形画像でも帯域エネルギー合計が ~1.0
- [x] 正方形画像のテストも引き続きパス
- [x] `uv run pytest` が通る