### PR TITLE
fix: FFT 抽出に最小画像サイズバリデーションを追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@
 - FFT 計算前に Hanning 窓関数を適用し, 画像境界のスペクトルリークを抑制. ([#136](https://github.com/kurorosu/pochivision/pull/136))
 - FFT 前の uint8 正規化を削除し, float64 のまま処理するよう変更. コントラスト情報が保持される. ([#137](https://github.com/kurorosu/pochivision/pull/137))
 - FFT のエネルギー・エントロピー計算から DC 成分を除外し, AC 成分のみで特徴量を計算するよう修正. ([#138](https://github.com/kurorosu/pochivision/pull/138))
-- FFT 帯域エネルギーの最終帯域を上限なしに変更し, 非正方形画像でも合計が ~1.0 になるよう修正. (NA.)
+- FFT 帯域エネルギーの最終帯域を上限なしに変更し, 非正方形画像でも合計が ~1.0 になるよう修正. ([#145](https://github.com/kurorosu/pochivision/pull/145))
+- FFT 抽出で最小画像サイズ (4x4) のバリデーションを追加. 極小画像で全特徴量がサイレントにゼロになる問題を解消. (NA.)
 
 ### Removed
 - 無し

--- a/pochivision/feature_extractors/fft_frequency.py
+++ b/pochivision/feature_extractors/fft_frequency.py
@@ -370,6 +370,13 @@ class FFTFrequencyExtractor(BaseFeatureExtractor):
         else:
             raise ValueError(f"Input image must be 2D or 3D, got shape: {image.shape}")
 
+        _MIN_FFT_SIZE = 4
+        if gray_image.shape[0] < _MIN_FFT_SIZE or gray_image.shape[1] < _MIN_FFT_SIZE:
+            raise ValueError(
+                f"Image too small for FFT: {gray_image.shape}. "
+                f"Minimum size is {_MIN_FFT_SIZE}x{_MIN_FFT_SIZE}."
+            )
+
         # コントラスト情報を保持するため float64 のまま FFT に渡す
         gray_image = gray_image.astype(np.float64)
 

--- a/tests/extractors/test_fft_features.py
+++ b/tests/extractors/test_fft_features.py
@@ -132,6 +132,19 @@ class TestFFTFrequencyExtractor:
         with pytest.raises(ValueError, match="Input image must be 2D or 3D"):
             self.extractor.extract(invalid_image)
 
+    def test_extract_too_small_image(self):
+        """極小画像で ValueError が発生することを確認."""
+        for size in [(1, 1), (2, 2), (3, 3), (3, 64), (64, 3)]:
+            small_image = np.ones(size, dtype=np.uint8) * 128
+            with pytest.raises(ValueError, match="Image too small for FFT"):
+                self.extractor.extract(small_image)
+
+    def test_extract_minimum_size_works(self):
+        """最小サイズ (4x4) の画像が正常に処理されることを確認."""
+        min_image = np.random.randint(0, 256, (4, 4), dtype=np.uint8)
+        features = self.extractor.extract(min_image)
+        assert "high_low_ratio" in features
+
     def test_extract_different_dtypes(self):
         """異なるデータ型の画像での特徴量抽出をテスト."""
         base_image = np.random.randint(0, 256, (32, 32), dtype=np.uint8)


### PR DESCRIPTION
## Summary

- `extract()` で最小画像サイズ (4x4) のバリデーションを追加し, 極小画像で全特徴量がサイレントにゼロになる問題を解消した.

## Related Issue

Closes #140

## Changes

- `pochivision/feature_extractors/fft_frequency.py`:
  - グレースケール変換後に `_MIN_FFT_SIZE = 4` で画像サイズをチェックし, 小さすぎる場合は `ValueError` を送出
- `tests/extractors/test_fft_features.py`:
  - `test_extract_too_small_image`: 1x1, 2x2, 3x3, 3x64, 64x3 で `ValueError` を検証
  - `test_extract_minimum_size_works`: 4x4 が正常に処理されることを検証

## Test Plan

- [x] `uv run pytest tests/extractors/test_fft_features.py` で 46 テストがパス
- [x] `uv run pytest` で全 319 テストがパス

## Checklist

- [x] 極小画像で明確なエラーが発生する
- [x] 4x4 以上の画像は正常に処理される
- [x] `uv run pytest` が通る