### PR TITLE
fix: FFT max_peak_amp を検出ピーク内の最大振幅に修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@
 - FFT 前の uint8 正規化を削除し, float64 のまま処理するよう変更. コントラスト情報が保持される. ([#137](https://github.com/kurorosu/pochivision/pull/137))
 - FFT のエネルギー・エントロピー計算から DC 成分を除外し, AC 成分のみで特徴量を計算するよう修正. ([#138](https://github.com/kurorosu/pochivision/pull/138))
 - FFT 帯域エネルギーの最終帯域を上限なしに変更し, 非正方形画像でも合計が ~1.0 になるよう修正. ([#145](https://github.com/kurorosu/pochivision/pull/145))
-- FFT 抽出で最小画像サイズ (4x4) のバリデーションを追加. 極小画像で全特徴量がサイレントにゼロになる問題を解消. (NA.)
+- FFT 抽出で最小画像サイズ (4x4) のバリデーションを追加. 極小画像で全特徴量がサイレントにゼロになる問題を解消. ([#146](https://github.com/kurorosu/pochivision/pull/146))
+- FFT `max_peak_amp` を検出ピーク内の最大振幅に修正 (グローバル最大値ではなく). (NA.)
 
 ### Removed
 - 無し

--- a/pochivision/feature_extractors/fft_frequency.py
+++ b/pochivision/feature_extractors/fft_frequency.py
@@ -257,7 +257,9 @@ class FFTFrequencyExtractor(BaseFeatureExtractor):
         peaks = (magnitude == max_local) & (
             magnitude > magnitude.max() * threshold_ratio
         )
-        return int(np.sum(peaks)), float(magnitude.max())
+        num_peaks = int(np.sum(peaks))
+        max_peak_amp = float(magnitude[peaks].max()) if num_peaks > 0 else 0.0
+        return num_peaks, max_peak_amp
 
     def _compute_spectral_entropy(self, magnitude: np.ndarray) -> float:
         """


### PR DESCRIPTION
## Summary

- `_compute_spectral_peaks` の `max_peak_amp` を `magnitude.max()` (グローバル最大値) から `magnitude[peaks].max()` (検出ピーク内の最大値) に修正した.

## Related Issue

Closes #141

## Changes

- `pochivision/feature_extractors/fft_frequency.py`:
  - `magnitude.max()` → `magnitude[peaks].max() if num_peaks > 0 else 0.0`

## Code Changes

```python
# 修正前
return int(np.sum(peaks)), float(magnitude.max())

# 修正後
num_peaks = int(np.sum(peaks))
max_peak_amp = float(magnitude[peaks].max()) if num_peaks > 0 else 0.0
return num_peaks, max_peak_amp
```

## Test Plan

- [x] `uv run pytest tests/extractors/test_fft_features.py` で 46 テストがパス
- [x] `uv run pytest` で全 319 テストがパス

## Checklist

- [x] `max_peak_amp` が検出ピークの振幅を返す
- [x] ピークなしの場合は 0.0 を返す
- [x] `uv run pytest` が通る