### PR TITLE
fix: FFT エントロピーを正規化エントロピーに変更し帯域間で比較可能に

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@
 - FFT のエネルギー・エントロピー計算から DC 成分を除外し, AC 成分のみで特徴量を計算するよう修正. ([#138](https://github.com/kurorosu/pochivision/pull/138))
 - FFT 帯域エネルギーの最終帯域を上限なしに変更し, 非正方形画像でも合計が ~1.0 になるよう修正. ([#145](https://github.com/kurorosu/pochivision/pull/145))
 - FFT 抽出で最小画像サイズ (4x4) のバリデーションを追加. 極小画像で全特徴量がサイレントにゼロになる問題を解消. ([#146](https://github.com/kurorosu/pochivision/pull/146))
-- FFT `max_peak_amp` を検出ピーク内の最大振幅に修正 (グローバル最大値ではなく). (NA.)
+- FFT `max_peak_amp` を検出ピーク内の最大振幅に修正 (グローバル最大値ではなく). ([#147](https://github.com/kurorosu/pochivision/pull/147))
+- FFT エントロピーを正規化エントロピー (`entropy / log2(N)`, [0, 1] 範囲) に変更し, 帯域間で比較可能に. (NA.)
 
 ### Removed
 - 無し

--- a/pochivision/feature_extractors/fft_frequency.py
+++ b/pochivision/feature_extractors/fft_frequency.py
@@ -44,15 +44,15 @@ class FFTFrequencyExtractor(BaseFeatureExtractor):
         "num_peaks": "count",
         "max_peak_amp": "amplitude",
         "spectral_centroid": "cycle/mm_or_cycle/pixel",
-        "spectral_entropy": "bits",
-        "horizontal_entropy": "bits",
-        "vertical_entropy": "bits",
+        "spectral_entropy": "normalized",
+        "horizontal_entropy": "normalized",
+        "vertical_entropy": "normalized",
         "band_1_0.00_0.10": "ratio",
         "band_2_0.10_0.30": "ratio",
         "band_3_0.30_0.50": "ratio",
-        "band_1_0.00_0.10_entropy": "bits",
-        "band_2_0.10_0.30_entropy": "bits",
-        "band_3_0.30_0.50_entropy": "bits",
+        "band_1_0.00_0.10_entropy": "normalized",
+        "band_2_0.10_0.30_entropy": "normalized",
+        "band_3_0.30_0.50_entropy": "normalized",
     }
 
     def __init__(
@@ -263,23 +263,27 @@ class FFTFrequencyExtractor(BaseFeatureExtractor):
 
     def _compute_spectral_entropy(self, magnitude: np.ndarray) -> float:
         """
-        スペクトラムのエントロピーを計算する.
+        正規化スペクトラムエントロピーを計算する.
+
+        Shannon エントロピーを log2(N) で正規化し, [0, 1] の範囲に変換する.
+        これにより異なるピクセル数の領域間でエントロピーを直接比較できる.
 
         Args:
             magnitude (np.ndarray): スペクトラムの振幅
 
         Returns:
-            float: スペクトラルエントロピー
+            float: 正規化スペクトラルエントロピー (0.0〜1.0)
         """
         total = np.sum(magnitude)
-        if total == 0:
+        n = magnitude.size
+        if total == 0 or n <= 1:
             return 0.0
 
         prob = magnitude / total
-        # エントロピー計算（0 log 0 = 0 として処理: ゼロ要素を除外）
         nonzero = prob > 0
         entropy = -np.sum(prob[nonzero] * np.log2(prob[nonzero]))
-        return float(entropy)
+        max_entropy = np.log2(n)
+        return float(entropy / max_entropy)
 
     def _compute_directional_entropy(
         self,

--- a/tests/extractors/test_fft_features.py
+++ b/tests/extractors/test_fft_features.py
@@ -331,15 +331,15 @@ class TestFFTFrequencyExtractor:
             "num_peaks[count]",
             "max_peak_amp[amplitude]",
             "spectral_centroid[cycle/mm_or_cycle/pixel]",
-            "spectral_entropy[bits]",
-            "horizontal_entropy[bits]",
-            "vertical_entropy[bits]",
+            "spectral_entropy[normalized]",
+            "horizontal_entropy[normalized]",
+            "vertical_entropy[normalized]",
             "band_1_0.00_0.10[ratio]",
             "band_2_0.10_0.30[ratio]",
             "band_3_0.30_0.50[ratio]",
-            "band_1_0.00_0.10_entropy[bits]",
-            "band_2_0.10_0.30_entropy[bits]",
-            "band_3_0.30_0.50_entropy[bits]",
+            "band_1_0.00_0.10_entropy[normalized]",
+            "band_2_0.10_0.30_entropy[normalized]",
+            "band_3_0.30_0.50_entropy[normalized]",
         ]
 
         assert len(feature_names) == len(expected_features)
@@ -385,15 +385,15 @@ class TestFFTFrequencyExtractor:
             "num_peaks[count]",
             "max_peak_amp[amplitude]",
             "spectral_centroid[cycle/mm_or_cycle/pixel]",
-            "spectral_entropy[bits]",
-            "horizontal_entropy[bits]",
-            "vertical_entropy[bits]",
+            "spectral_entropy[normalized]",
+            "horizontal_entropy[normalized]",
+            "vertical_entropy[normalized]",
             "band_1_0.00_0.10[ratio]",
             "band_2_0.10_0.30[ratio]",
             "band_3_0.30_0.50[ratio]",
-            "band_1_0.00_0.10_entropy[bits]",
-            "band_2_0.10_0.30_entropy[bits]",
-            "band_3_0.30_0.50_entropy[bits]",
+            "band_1_0.00_0.10_entropy[normalized]",
+            "band_2_0.10_0.30_entropy[normalized]",
+            "band_3_0.30_0.50_entropy[normalized]",
         ]
         print(f"単位付き特徴量名: {unit_names}")
         assert (
@@ -410,15 +410,15 @@ class TestFFTFrequencyExtractor:
             "num_peaks": "count",
             "max_peak_amp": "amplitude",
             "spectral_centroid": "cycle/mm_or_cycle/pixel",
-            "spectral_entropy": "bits",
-            "horizontal_entropy": "bits",
-            "vertical_entropy": "bits",
+            "spectral_entropy": "normalized",
+            "horizontal_entropy": "normalized",
+            "vertical_entropy": "normalized",
             "band_1_0.00_0.10": "ratio",
             "band_2_0.10_0.30": "ratio",
             "band_3_0.30_0.50": "ratio",
-            "band_1_0.00_0.10_entropy": "bits",
-            "band_2_0.10_0.30_entropy": "bits",
-            "band_3_0.30_0.50_entropy": "bits",
+            "band_1_0.00_0.10_entropy": "normalized",
+            "band_2_0.10_0.30_entropy": "normalized",
+            "band_3_0.30_0.50_entropy": "normalized",
         }
         print(f"特徴量単位辞書: {units}")
         assert units == expected_units, f"Expected {expected_units}, got {units}"
@@ -614,13 +614,13 @@ class TestFFTFrequencyExtractor:
 
     # --- spectral_entropy ---
 
-    def test_spectral_entropy_random_above_10(self):
-        """ランダム画像のスペクトルエントロピーは > 10 bits (高エントロピー)."""
+    def test_spectral_entropy_random_above_08(self):
+        """ランダム画像の正規化エントロピーは > 0.8 (高エントロピー)."""
         np.random.seed(42)
         features = self.extractor.extract(
             np.random.randint(0, 256, (64, 64), dtype=np.uint8)
         )
-        assert features["spectral_entropy"] > 10.0
+        assert features["spectral_entropy"] > 0.8
 
     def test_spectral_entropy_stripe_below_random(self):
         """ストライプ画像のエントロピーはランダムより低い."""


### PR DESCRIPTION
## Summary

- `_compute_spectral_entropy` の Shannon エントロピーを `log2(N)` で正規化し, [0, 1] 範囲に変換した.
- これにより異なるピクセル数の帯域・方向間でエントロピーを直接比較可能に.
- 単位を `bits` → `normalized` に変更.

## Related Issue

Closes #142

## Changes

- `pochivision/feature_extractors/fft_frequency.py`:
  - `_compute_spectral_entropy`: `entropy / log2(N)` で正規化, `n <= 1` ガード追加
  - `_FEATURE_UNITS`: 全エントロピー単位を `bits` → `normalized` に変更
- `tests/extractors/test_fft_features.py`:
  - 単位アサーションを `normalized` に更新
  - エントロピー閾値テストを `> 10.0` → `> 0.8` に更新

## Code Changes

```python
# pochivision/feature_extractors/fft_frequency.py
entropy = -np.sum(prob[nonzero] * np.log2(prob[nonzero]))
max_entropy = np.log2(n)
return float(entropy / max_entropy)  # [0, 1] 範囲
```

## Test Plan

- [x] `uv run pytest tests/extractors/test_fft_features.py` で 46 テストがパス
- [x] `uv run pytest` で全 319 テストがパス

## Checklist

- [x] エントロピーが [0, 1] の正規化範囲に変換されている
- [x] 異なる帯域間でエントロピーが比較可能
- [x] `uv run pytest` が通る
