### PR TITLE
docs: FFT 特徴量抽出器の docstring に設計制約と前処理フローを追記

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@
 - FFT 帯域エネルギーの最終帯域を上限なしに変更し, 非正方形画像でも合計が ~1.0 になるよう修正. ([#145](https://github.com/kurorosu/pochivision/pull/145))
 - FFT 抽出で最小画像サイズ (4x4) のバリデーションを追加. 極小画像で全特徴量がサイレントにゼロになる問題を解消. ([#146](https://github.com/kurorosu/pochivision/pull/146))
 - FFT `max_peak_amp` を検出ピーク内の最大振幅に修正 (グローバル最大値ではなく). ([#147](https://github.com/kurorosu/pochivision/pull/147))
-- FFT `except Exception` を削除しエラーを伝播するよう変更. `mm_per_pixel` のバリデーションを追加. (NA.)
+- FFT `except Exception` を削除しエラーを伝播するよう変更. `mm_per_pixel` のバリデーションを追加. ([#150](https://github.com/kurorosu/pochivision/pull/150))
+- FFT 特徴量抽出器のクラス docstring に前処理フロー・設計制約を追記. エントロピー単位を `normalized` に修正. (NA.)
 - FFT エントロピーを正規化エントロピー (`entropy / log2(N)`, [0, 1] 範囲) に変更し, 帯域間で比較可能に. ([#148](https://github.com/kurorosu/pochivision/pull/148))
 
 ### Removed

--- a/pochivision/feature_extractors/fft_frequency.py
+++ b/pochivision/feature_extractors/fft_frequency.py
@@ -17,8 +17,13 @@ class FFTFrequencyExtractor(BaseFeatureExtractor):
     """
     画像のFFT（高速フーリエ変換）周波数領域特徴量を抽出するクラス.
 
-    FFTは画像の周波数成分を解析し、テクスチャや周期性の特徴を抽出します。
-    空間領域の画像を周波数領域に変換することで、画像の周波数特性を定量化できます。
+    FFTは画像の周波数成分を解析し, テクスチャや周期性の特徴を抽出する.
+    空間領域の画像を周波数領域に変換することで, 画像の周波数特性を定量化できる.
+
+    前処理:
+    - グレースケール変換後, float64 のまま処理 (コントラスト情報を保持)
+    - Hanning 窓関数を適用 (画像境界のスペクトルリークを抑制)
+    - DC 成分 (平均輝度) を除外し, AC 成分のみで特徴量を計算
 
     抽出する特徴量:
     - high_low_ratio: 高周波/低周波エネルギー比 [ratio]
@@ -29,12 +34,20 @@ class FFTFrequencyExtractor(BaseFeatureExtractor):
     - max_peak_amp: 最大ピーク振幅 [amplitude]
     - band_energy: 周波数帯域別エネルギー [ratio]
     - spectral_centroid: スペクトル重心 [cycle/mm or cycle/pixel]
-    - spectral_entropy: スペクトラム全体のエントロピー [bits]
-    - horizontal_entropy: 水平方向スペクトラムエントロピー [bits]
-    - vertical_entropy: 垂直方向スペクトラムエントロピー [bits]
-    - band_entropy: 周波数帯域別エントロピー [bits]
+    - spectral_entropy: スペクトラム全体の正規化エントロピー [normalized, 0-1]
+    - horizontal_entropy: 水平方向の正規化エントロピー [normalized, 0-1]
+    - vertical_entropy: 垂直方向の正規化エントロピー [normalized, 0-1]
+    - band_entropy: 周波数帯域別の正規化エントロピー [normalized, 0-1]
 
-    設定により、周波数帯域、閾値、ピクセル解像度などを調整できます。
+    設計上の制約:
+    - 最小画像サイズ: 4x4. それ未満は ValueError を送出.
+    - Hanning 窓により画像端のピクセルがゼロに減衰するため,
+      max_peak_amp 等の絶対値はピクセル位置に依存する.
+    - 非正方形画像では freq_norm を max(cx, cy) で正規化するため,
+      短辺方向の Nyquist 周波数は 0.5 に達しない.
+      最終帯域は上限なしで対角線分を含め, 帯域合計 ~1.0 を保証する.
+
+    詳細は docs/fft_features.md を参照.
     """
 
     # 特徴量の単位定義


### PR DESCRIPTION
## Summary

- `FFTFrequencyExtractor` のクラス docstring に前処理フロー (Hanning 窓, DC 除外, float64 処理) と設計制約 (最小画像サイズ, 非正方形画像, 窓関数の影響) を追記した.
- エントロピー特徴量の単位を `bits` → `normalized, 0-1` に修正した.

## Related Issue

Closes #144

## Changes

- `pochivision/feature_extractors/fft_frequency.py`:
  - クラス docstring に「前処理」「設計上の制約」セクションを追加
  - エントロピー特徴量の単位表記を `[bits]` → `[normalized, 0-1]` に修正
  - `docs/fft_features.md` への参照を追加

## Test Plan

- [x] `uv run pytest` で全 319 テストがパス

## Checklist

- [x] Hanning 窓の影響が docstring に記載されている
- [x] 帯域境界の制約が docstring に記載されている
- [x] 最小画像サイズが docstring に記載されている
- [x] `uv run pytest` が通る