### PR TITLE
fix: GLCM の NORM_MINMAX 正規化を削除しコントラスト情報を保持

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - 無し
 
 ### Fixed
-- 無し
+- GLCM の `cv2.normalize(NORM_MINMAX)` を削除し, uint8 変換と整数除算量子化に変更. コントラスト情報が保持される. (NA.)
 
 ### Removed
 - 無し

--- a/pochivision/feature_extractors/glcm_texture.py
+++ b/pochivision/feature_extractors/glcm_texture.py
@@ -128,17 +128,15 @@ class GLCMTextureExtractor(BaseFeatureExtractor):
         else:
             raise ValueError(f"Input image must be 2D or 3D, got shape: {image.shape}")
 
-        # 画像の値域を0-255に正規化（levelsが256の場合）
-        if self.levels == 256:
-            # 画像を0-255の範囲に正規化
-            gray_image = cv2.normalize(
-                gray_image, None, 0, 255, cv2.NORM_MINMAX, dtype=cv2.CV_8U
-            )
+        # uint8 に変換 (NORM_MINMAX はコントラスト情報を破壊するため使用しない)
+        if not np.issubdtype(gray_image.dtype, np.integer):
+            gray_image = np.clip(gray_image * 255, 0, 255).astype(np.uint8)
         else:
-            # 指定されたlevels数に量子化
-            gray_image = cv2.normalize(
-                gray_image, None, 0, self.levels - 1, cv2.NORM_MINMAX, dtype=cv2.CV_8U
-            )
+            gray_image = np.clip(gray_image, 0, 255).astype(np.uint8)
+
+        # levels < 256 の場合は整数除算で量子化
+        if self.levels < 256:
+            gray_image = (gray_image // (256 // self.levels)).astype(np.uint8)
 
         results = {}
 


### PR DESCRIPTION
## Summary

- `cv2.normalize(NORM_MINMAX)` を削除し, `uint8` 変換 + 整数除算量子化に変更した.
- 均一画像が全ゼロにならなくなり, 異なるコントラストの画像で特徴量が区別可能になった.

## Related Issue

Closes #153

## Changes

- `pochivision/feature_extractors/glcm_texture.py`:
  - `cv2.normalize(NORM_MINMAX)` を削除
  - float 画像は `* 255` で uint8 に変換, 整数画像は `clip(0, 255)` で uint8 に変換
  - `levels < 256` の場合は `gray // (256 // levels)` で量子化

## Code Changes

```python
# 修正前
gray_image = cv2.normalize(gray_image, None, 0, 255, cv2.NORM_MINMAX, dtype=cv2.CV_8U)

# 修正後
if not np.issubdtype(gray_image.dtype, np.integer):
    gray_image = np.clip(gray_image * 255, 0, 255).astype(np.uint8)
else:
    gray_image = np.clip(gray_image, 0, 255).astype(np.uint8)
if self.levels < 256:
    gray_image = (gray_image // (256 // self.levels)).astype(np.uint8)
```

## Test Plan

- [x] `uv run pytest tests/extractors/test_glcm_texture_extractor.py` で 21 テストがパス
- [x] `uv run pytest` で全 319 テストがパス

## Checklist

- [x] `cv2.normalize(NORM_MINMAX)` が削除されている
- [x] コントラスト情報が保持される
- [x] `uv run pytest` が通る