### PR TITLE
fix: GLCM の例外握りつぶしを廃止しエラー伝播に変更

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@
 - 無し
 
 ### Fixed
-- GLCM の `cv2.normalize(NORM_MINMAX)` を削除し, uint8 変換と整数除算量子化に変更. コントラスト情報が保持される. (NA.)
+- GLCM の `cv2.normalize(NORM_MINMAX)` を削除し, uint8 変換と整数除算量子化に変更. コントラスト情報が保持される. ([#160](https://github.com/kurorosu/pochivision/pull/160))
+- GLCM の `except Exception` を削除しエラーをログ出力後に再送出するよう変更. (NA.)
 
 ### Removed
 - 無し

--- a/pochivision/feature_extractors/glcm_texture.py
+++ b/pochivision/feature_extractors/glcm_texture.py
@@ -6,6 +6,8 @@ import cv2
 import numpy as np
 from skimage.feature import graycomatrix, graycoprops
 
+from pochivision.capturelib.log_manager import LogManager
+
 from .base import BaseFeatureExtractor
 from .registry import register_feature_extractor
 
@@ -175,21 +177,14 @@ class GLCMTextureExtractor(BaseFeatureExtractor):
                             results[feature_name] = feature_value
 
                 except Exception:
-                    # プロパティ計算でエラーが発生した場合、0で埋める
-                    for d_idx, distance in enumerate(self.distances):
-                        for a_idx, angle in enumerate(self.angles):
-                            angle_deg = int(np.degrees(angle))
-                            feature_name = f"{prop}_{distance}_{angle_deg}"
-                            results[feature_name] = 0.0
+                    LogManager().get_logger().exception(
+                        f"GLCM property '{prop}' computation failed"
+                    )
+                    raise
 
         except Exception:
-            # GLCM計算全体でエラーが発生した場合、すべて0で埋める
-            for prop in self.properties:
-                for distance in self.distances:
-                    for angle in self.angles:
-                        angle_deg = int(np.degrees(angle))
-                        feature_name = f"{prop}_{distance}_{angle_deg}"
-                        results[feature_name] = 0.0
+            LogManager().get_logger().exception("GLCM feature extraction failed")
+            raise
 
         return results
 


### PR DESCRIPTION
## Summary

- `extract()` の `except Exception` 2 箇所を `LogManager` によるログ出力 + `raise` に変更した.
- バグがサイレントに all-zero で返されなくなり, デバッグが可能になった.

## Related Issue

Closes #154

## Changes

- `pochivision/feature_extractors/glcm_texture.py`:
  - 内側 `except Exception` (プロパティ計算): ログ出力 + `raise`
  - 外側 `except Exception` (GLCM 全体): ログ出力 + `raise`
  - `LogManager` のインポートを追加

## Test Plan

- [x] `uv run pytest tests/extractors/test_glcm_texture_extractor.py` で 21 テストがパス
- [x] `uv run pytest` で全 319 テストがパス

## Checklist

- [x] 例外がログ出力後に伝播する
- [x] all-zero での握りつぶしが廃止されている
- [x] `uv run pytest` が通る