### PR TITLE
fix: GLCM の NaN/Inf を NaN として保持し警告ログを出力

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@
 
 ### Fixed
 - GLCM の `cv2.normalize(NORM_MINMAX)` を削除し, uint8 変換と整数除算量子化に変更. コントラスト情報が保持される. ([#160](https://github.com/kurorosu/pochivision/pull/160))
-- GLCM の `except Exception` を削除しエラーをログ出力後に再送出するよう変更. (NA.)
+- GLCM の `except Exception` を削除しエラーをログ出力後に再送出するよう変更. ([#161](https://github.com/kurorosu/pochivision/pull/161))
+- GLCM の NaN/Inf を 0.0 ではなく NaN として保持し, 警告ログを出力するよう変更. (NA.)
 
 ### Removed
 - 無し

--- a/pochivision/feature_extractors/glcm_texture.py
+++ b/pochivision/feature_extractors/glcm_texture.py
@@ -170,9 +170,13 @@ class GLCMTextureExtractor(BaseFeatureExtractor):
                             # 特徴量値を取得
                             feature_value = float(prop_values[d_idx, a_idx])
 
-                            # NaNや無限大の値をチェック
+                            # NaN/Inf は未定義を示す (例: 均一画像の correlation)
                             if np.isnan(feature_value) or np.isinf(feature_value):
-                                feature_value = 0.0
+                                LogManager().get_logger().warning(
+                                    f"GLCM {feature_name} is {feature_value}, "
+                                    "replacing with NaN"
+                                )
+                                feature_value = float("nan")
 
                             results[feature_name] = feature_value
 


### PR DESCRIPTION
## Summary

- NaN/Inf をサイレントに `0.0` に置換していたのを, 警告ログ出力 + `NaN` 保持に変更した.
- `correlation=0.0` (無相関) と `correlation=NaN` (未定義) が区別可能になった.

## Related Issue

Closes #155

## Changes

- `pochivision/feature_extractors/glcm_texture.py`:
  - NaN/Inf 検出時に `LogManager` で警告ログを出力
  - `feature_value = 0.0` → `feature_value = float("nan")` に変更

## Test Plan

- [x] `uv run pytest tests/extractors/test_glcm_texture_extractor.py` で 21 テストがパス
- [x] `uv run pytest` で全 319 テストがパス

## Checklist

- [x] NaN が 0.0 にサイレント置換されない
- [x] 警告ログが出力される
- [x] `uv run pytest` が通る