### PR TITLE
docs: GLCM docstring の asm を ASM に修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 ## [Unreleased]
 
 ### Added
-- GLCM の振る舞いテスト 17 件を追加. 均一画像, チェッカーボード, グラデーション, ランダム画像で特徴量値を検証. (NA.)
+- GLCM の振る舞いテスト 17 件を追加. 均一画像, チェッカーボード, グラデーション, ランダム画像で特徴量値を検証. ([#164](https://github.com/kurorosu/pochivision/pull/164))
+- GLCM docstring の `asm` を `ASM` に修正. (NA.)
 
 ### Changed
 - GLCM に `resize_shape` オプションを追加. ([#163](https://github.com/kurorosu/pochivision/pull/163))

--- a/pochivision/feature_extractors/glcm_texture.py
+++ b/pochivision/feature_extractors/glcm_texture.py
@@ -28,7 +28,7 @@ class GLCMTextureExtractor(BaseFeatureExtractor):
     - homogeneity: 均質性（局所的な均一性） [ratio]
     - energy: エネルギー（テクスチャの均一性） [ratio]
     - correlation: 相関（ピクセル間の線形依存関係） [correlation coefficient]
-    - asm: Angular Second Moment（エネルギーの二乗） [ratio]
+    - ASM: Angular Second Moment (エネルギーの二乗) [ratio]
 
     設定により、距離、角度、グレーレベル数、対称性、正規化などを調整できます。
     """


### PR DESCRIPTION
## Summary

- クラス docstring の `asm` (小文字) を `ASM` (大文字) に修正し, コードの `_FEATURE_UNITS` および `get_default_config` と一致させた.

## Related Issue

Closes #158

## Changes

- `pochivision/feature_extractors/glcm_texture.py`: docstring の `asm` → `ASM`

## Test Plan

- [x] `uv run pytest` で全 336 テストがパス

## Checklist

- [x] docstring とコードで ASM の表記が一致している
- [x] `uv run pytest` が通る