### PR TITLE
docs: GLCM docstring に特徴量名形式と特徴量数の計算式を追記

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 
 ### Added
 - GLCM の振る舞いテスト 17 件を追加. 均一画像, チェッカーボード, グラデーション, ランダム画像で特徴量値を検証. ([#164](https://github.com/kurorosu/pochivision/pull/164))
-- GLCM docstring の `asm` を `ASM` に修正. (NA.)
+- GLCM docstring の `asm` を `ASM` に修正. ([#165](https://github.com/kurorosu/pochivision/pull/165))
+- GLCM docstring に特徴量名形式・特徴量数の計算式を追記. (NA.)
 
 ### Changed
 - GLCM に `resize_shape` オプションを追加. ([#163](https://github.com/kurorosu/pochivision/pull/163))

--- a/pochivision/feature_extractors/glcm_texture.py
+++ b/pochivision/feature_extractors/glcm_texture.py
@@ -16,21 +16,27 @@ from .registry import register_feature_extractor
 @register_feature_extractor("glcm")
 class GLCMTextureExtractor(BaseFeatureExtractor):
     """
-    画像のGLCM（Gray-Level Co-occurrence Matrix）テクスチャ特徴量を抽出するクラス.
+    画像のGLCM (Gray-Level Co-occurrence Matrix) テクスチャ特徴量を抽出するクラス.
 
-    GLCMは画像のテクスチャ解析に使用される重要な特徴量で、
-    指定された距離と角度でのグレーレベルの共起関係を表現します。
-    テクスチャの粗さ、方向性、規則性などを定量化できます。
+    GLCM は画像のテクスチャ解析に使用される特徴量で,
+    指定された距離と角度でのグレーレベルの共起関係を表現する.
+    テクスチャの粗さ, 方向性, 規則性などを定量化できる.
 
-    抽出する特徴量:
-    - contrast: コントラスト（局所的な強度変化） [intensity_squared]
-    - dissimilarity: 非類似度（隣接ピクセル間の差異） [intensity]
-    - homogeneity: 均質性（局所的な均一性） [ratio]
-    - energy: エネルギー（テクスチャの均一性） [ratio]
-    - correlation: 相関（ピクセル間の線形依存関係） [correlation coefficient]
+    抽出するプロパティ (各距離・角度の組み合わせごとに出力):
+    - contrast: コントラスト (局所的な強度変化) [intensity_squared]
+    - dissimilarity: 非類似度 (隣接ピクセル間の差異) [intensity]
+    - homogeneity: 均質性 (局所的な均一性) [ratio]
+    - energy: エネルギー (テクスチャの均一性) [ratio]
+    - correlation: 相関 (ピクセル間の線形依存関係) [correlation_coefficient]
     - ASM: Angular Second Moment (エネルギーの二乗) [ratio]
 
-    設定により、距離、角度、グレーレベル数、対称性、正規化などを調整できます。
+    特徴量名の形式: ``{property}_{distance}_{angle_deg}``
+    (例: ``contrast_1_0``, ``energy_2_45``)
+
+    特徴量数 = len(properties) x len(distances) x len(angles).
+    デフォルト設定 (6 プロパティ x 3 距離 x 4 角度) では 72 特徴量.
+
+    設定により, 距離, 角度, グレーレベル数, 対称性, 正規化, リサイズ形状などを調整できる.
     """
 
     # 特徴量の単位定義


### PR DESCRIPTION
## Summary

- クラス docstring に特徴量名の形式 (`{property}_{distance}_{angle_deg}`) と特徴量数の計算式 (`len(properties) x len(distances) x len(angles)`) を追記した.
- デフォルト設定での特徴量数 (72) を明記した.

## Related Issue

Closes #159

## Changes

- `pochivision/feature_extractors/glcm_texture.py`: クラス docstring を更新

## Test Plan

- [x] `uv run pytest` で全 336 テストがパス

## Checklist

- [x] 特徴量名形式が記載されている
- [x] 特徴量数の計算式が記載されている
- [x] `uv run pytest` が通る