### PR TITLE
fix: HLAC の例外握りつぶしを廃止しエラー伝播に変更

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
 ### Added
 - GLCM の振る舞いテスト 17 件を追加. 均一画像, チェッカーボード, グラデーション, ランダム画像で特徴量値を検証. ([#164](https://github.com/kurorosu/pochivision/pull/164))
 - GLCM docstring の `asm` を `ASM` に修正. ([#165](https://github.com/kurorosu/pochivision/pull/165))
-- GLCM docstring に特徴量名形式・特徴量数の計算式を追記. (NA.)
+- GLCM docstring に特徴量名形式・特徴量数の計算式を追記. ([#166](https://github.com/kurorosu/pochivision/pull/166))
+- HLAC の `except Exception` を削除しエラーをログ出力後に再送出するよう変更. (NA.)
 
 ### Changed
 - GLCM に `resize_shape` オプションを追加. ([#163](https://github.com/kurorosu/pochivision/pull/163))

--- a/pochivision/feature_extractors/hlac_texture.py
+++ b/pochivision/feature_extractors/hlac_texture.py
@@ -6,6 +6,7 @@ import cv2
 import numpy as np
 from scipy.signal import convolve2d
 
+from pochivision.capturelib.log_manager import LogManager
 from pochivision.processors.binarization import OtsuBinarizationProcessor
 from pochivision.processors.resize import ResizeProcessor
 
@@ -139,8 +140,8 @@ class HLACTextureExtractor(BaseFeatureExtractor):
             return results
 
         except Exception:
-            # エラーが発生した場合、デフォルト値で埋める
-            return self._get_default_results()
+            LogManager().get_logger().exception("HLAC feature extraction failed")
+            raise
 
     def _generate_hlac_kernels(self) -> List[np.ndarray]:
         """


### PR DESCRIPTION
## Summary

- `extract()` の `except Exception` を `LogManager` によるログ出力 + `raise` に変更した.
- FFT ([#150](https://github.com/kurorosu/pochivision/pull/150)) / GLCM ([#161](https://github.com/kurorosu/pochivision/pull/161)) と同じパターンに統一.

## Related Issue

Closes #167

## Changes

- `pochivision/feature_extractors/hlac_texture.py`:
  - `except Exception` → `LogManager().get_logger().exception()` + `raise`
  - `LogManager` のインポートを追加

## Test Plan

- [x] `uv run pytest tests/extractors/test_hlac_features.py` で 13 テストがパス
- [x] `uv run pytest` で全 336 テストがパス

## Checklist

- [x] 例外がログ出力後に伝播する
- [x] all-zero での握りつぶしが廃止されている
- [x] `uv run pytest` が通る