### PR TITLE
fix: HLAC の境界特徴量減衰を解消し適応的二値化を追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - GLCM docstring の `asm` を `ASM` に修正. ([#165](https://github.com/kurorosu/pochivision/pull/165))
 - GLCM docstring に特徴量名形式・特徴量数の計算式を追記. ([#166](https://github.com/kurorosu/pochivision/pull/166))
 - HLAC の `except Exception` を削除しエラーをログ出力後に再送出するよう変更. ([#174](https://github.com/kurorosu/pochivision/pull/174))
-- HLAC のゼロパディングを削除し, `convolve2d(mode="valid")` で境界を除外した正確なパターンマッチに変更. (NA.)
+- HLAC のゼロパディングを削除し, 境界の特徴量減衰を解消. 二値化方式に適応的二値化 (`adaptive`) を追加しデフォルトに設定. (NA.)
 
 ### Changed
 - GLCM に `resize_shape` オプションを追加. ([#163](https://github.com/kurorosu/pochivision/pull/163))

--- a/extractor_config.json
+++ b/extractor_config.json
@@ -56,7 +56,10 @@
       "rotate_invariant": true,
       "normalize": true,
       "scales": [1.0, 0.75, 0.5],
-      "resize_shape": [512, 512]
+      "resize_shape": [512, 512],
+      "binarization_method": "adaptive",
+      "adaptive_block_size": 11,
+      "adaptive_c": 2
     },
     "circle_counter": {
       "min_radius": 5,

--- a/pochivision/feature_extractors/hlac_texture.py
+++ b/pochivision/feature_extractors/hlac_texture.py
@@ -7,7 +7,11 @@ import numpy as np
 from scipy.signal import convolve2d
 
 from pochivision.capturelib.log_manager import LogManager
-from pochivision.processors.binarization import OtsuBinarizationProcessor
+from pochivision.processors.base import BaseProcessor
+from pochivision.processors.binarization import (
+    GaussianAdaptiveBinarizationProcessor,
+    OtsuBinarizationProcessor,
+)
 from pochivision.processors.resize import ResizeProcessor
 
 from .base import BaseFeatureExtractor
@@ -78,8 +82,19 @@ class HLACTextureExtractor(BaseFeatureExtractor):
                 name="resize_for_hlac", config=resize_config
             )
 
-        # 大津法二値化プロセッサの準備
-        self.otsu_processor = OtsuBinarizationProcessor(name="otsu_for_hlac", config={})
+        # 二値化プロセッサの準備
+        self.binarization_method = self.config["binarization_method"]
+        self.binarizer: BaseProcessor
+        if self.binarization_method == "adaptive":
+            adaptive_config = {
+                "block_size": self.config.get("adaptive_block_size", 11),
+                "c": self.config.get("adaptive_c", 2),
+            }
+            self.binarizer = GaussianAdaptiveBinarizationProcessor(
+                name="adaptive_for_hlac", config=adaptive_config
+            )
+        else:
+            self.binarizer = OtsuBinarizationProcessor(name="otsu_for_hlac", config={})
 
         # HLACカーネルの事前生成
         self.kernels = self._generate_hlac_kernels()
@@ -236,7 +251,7 @@ class HLACTextureExtractor(BaseFeatureExtractor):
                 scaled_image = image
 
             # 大津法二値化プロセッサを使用
-            binary_image = self.otsu_processor.process(scaled_image)
+            binary_image = self.binarizer.process(scaled_image)
             # HLACでは0と1の二値画像が必要なので255を1に正規化
             binary_image = (binary_image / 255).astype(np.uint8)
 
@@ -286,6 +301,9 @@ class HLACTextureExtractor(BaseFeatureExtractor):
             "normalize": True,
             "scales": [1.0, 0.75, 0.5],
             "resize_shape": None,
+            "binarization_method": "adaptive",  # "otsu" or "adaptive"
+            "adaptive_block_size": 11,  # adaptive 時のブロックサイズ
+            "adaptive_c": 2,  # adaptive 時の定数 C
         }
 
     @staticmethod


### PR DESCRIPTION
## Summary

- ゼロパディングを削除し, `convolve2d(mode="valid")` で境界を除外した正確なパターンマッチに変更した.
- 二値化方式を設定可能にし, 適応的二値化 (`adaptive`) をデフォルトに設定. Otsu より局所テクスチャパターンが保持される.

## Related Issue

Closes #169

## Changes

- `pochivision/feature_extractors/hlac_texture.py`:
  - `np.pad` を削除, `convolve2d(binary_image, ..., mode="valid")` で直接処理
  - `binarization_method` パラメータを追加 (`"adaptive"` / `"otsu"`)
  - `adaptive_block_size`, `adaptive_c` パラメータを追加
  - `self.otsu_processor` → `self.binarizer` に統一
  - `GaussianAdaptiveBinarizationProcessor` のインポートを追加
- `extractor_config.json`: `hlac` セクションに二値化設定を追加

## Code Changes

```python
# 二値化方式の選択
if self.binarization_method == "adaptive":
    self.binarizer = GaussianAdaptiveBinarizationProcessor(...)
else:
    self.binarizer = OtsuBinarizationProcessor(...)

# パディングなしで直接処理
conv_result = convolve2d(binary_image, kernel[::-1, ::-1], mode="valid")
```

## Test Plan

- [x] `uv run pytest tests/extractors/test_hlac_features.py` で 13 テストがパス
- [x] `uv run pytest` で全 336 テストがパス

## Checklist

- [x] ゼロパディングが削除されている
- [x] 二値化方式が設定可能 (`adaptive` / `otsu`)
- [x] デフォルトが `adaptive` に設定されている
- [x] `extractor_config.json` が更新されている
- [x] `uv run pytest` が通る