### PR TITLE
fix: HLAC _get_default_results のフォールバック特徴量数を 45 → 37 に修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@
 - GLCM docstring の `asm` を `ASM` に修正. ([#165](https://github.com/kurorosu/pochivision/pull/165))
 - GLCM docstring に特徴量名形式・特徴量数の計算式を追記. ([#166](https://github.com/kurorosu/pochivision/pull/166))
 - HLAC の `except Exception` を削除しエラーをログ出力後に再送出するよう変更. ([#174](https://github.com/kurorosu/pochivision/pull/174))
-- HLAC のゼロパディングを削除し, 境界の特徴量減衰を解消. 二値化方式に適応的二値化 (`adaptive`) を追加しデフォルトに設定. (NA.)
+- HLAC のゼロパディングを削除し, 境界の特徴量減衰を解消. 二値化方式に適応的二値化 (`adaptive`) を追加しデフォルトに設定. ([#175](https://github.com/kurorosu/pochivision/pull/175))
+- HLAC `_get_default_results` のフォールバック特徴量数を 45 → 37 に修正. (NA.)
 
 ### Changed
 - GLCM に `resize_shape` オプションを追加. ([#163](https://github.com/kurorosu/pochivision/pull/163))

--- a/pochivision/feature_extractors/hlac_texture.py
+++ b/pochivision/feature_extractors/hlac_texture.py
@@ -278,7 +278,7 @@ class HLACTextureExtractor(BaseFeatureExtractor):
         num_features = (
             len(self.kernels)
             if hasattr(self, "kernels")
-            else (11 if self.rotate_invariant else 45)
+            else (11 if self.rotate_invariant else 37)
         )
         return {f"hlac_feature_{i:02d}": 0.0 for i in range(num_features)}
 


### PR DESCRIPTION
## Summary

- `_get_default_results` のフォールバック分岐で非回転不変 2nd order の特徴量数が自己ペア除外前の `45` のまま残っていたのを `37` に修正した.

## Related Issue

Closes #170

## Changes

- `pochivision/feature_extractors/hlac_texture.py`: `45` → `37`

## Test Plan

- [x] `uv run pytest` で全 336 テストがパス

## Checklist

- [x] フォールバック値が `get_base_feature_names()` と一致している (37)
- [x] `uv run pytest` が通る