### PR TITLE
refactor: HLAC のスケールリサイザーを初回呼び出し時にキャッシュ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@
 - GLCM docstring に特徴量名形式・特徴量数の計算式を追記. ([#166](https://github.com/kurorosu/pochivision/pull/166))
 - HLAC の `except Exception` を削除しエラーをログ出力後に再送出するよう変更. ([#174](https://github.com/kurorosu/pochivision/pull/174))
 - HLAC のゼロパディングを削除し, 境界の特徴量減衰を解消. 二値化方式に適応的二値化 (`adaptive`) を追加しデフォルトに設定. ([#175](https://github.com/kurorosu/pochivision/pull/175))
-- HLAC `_get_default_results` のフォールバック特徴量数を 45 → 37 に修正. (NA.)
+- HLAC `_get_default_results` のフォールバック特徴量数を 45 → 37 に修正. ([#178](https://github.com/kurorosu/pochivision/pull/178))
+- HLAC のスケールリサイザーを初回呼び出し時にキャッシュし, 毎回のインスタンス化を解消. (NA.)
 
 ### Changed
 - GLCM に `resize_shape` オプションを追加. ([#163](https://github.com/kurorosu/pochivision/pull/163))

--- a/pochivision/feature_extractors/hlac_texture.py
+++ b/pochivision/feature_extractors/hlac_texture.py
@@ -96,6 +96,9 @@ class HLACTextureExtractor(BaseFeatureExtractor):
         else:
             self.binarizer = OtsuBinarizationProcessor(name="otsu_for_hlac", config={})
 
+        # スケールリサイザーのキャッシュ (初回呼び出し時に生成)
+        self._scale_resizers: Dict[tuple, ResizeProcessor] = {}
+
         # HLACカーネルの事前生成
         self.kernels = self._generate_hlac_kernels()
 
@@ -235,22 +238,23 @@ class HLACTextureExtractor(BaseFeatureExtractor):
                 new_height = int(image.shape[0] * scale)
                 new_width = int(image.shape[1] * scale)
                 if new_height > 0 and new_width > 0:
-                    # ResizeProcessorを使用してリサイズ
-                    resize_config = ResizeProcessor.get_default_config()
-                    resize_config["width"] = new_width
-                    resize_config["height"] = new_height
-                    resize_config["preserve_aspect_ratio"] = False
-
-                    scale_resize_processor = ResizeProcessor(
-                        name=f"resize_scale_{scale}", config=resize_config
-                    )
-                    scaled_image = scale_resize_processor.process(image)
+                    # スケール用リサイザーをキャッシュ (同一サイズなら再利用)
+                    cache_key = (new_width, new_height)
+                    if cache_key not in self._scale_resizers:
+                        resize_config = ResizeProcessor.get_default_config()
+                        resize_config["width"] = new_width
+                        resize_config["height"] = new_height
+                        resize_config["preserve_aspect_ratio"] = False
+                        self._scale_resizers[cache_key] = ResizeProcessor(
+                            name=f"resize_scale_{scale}", config=resize_config
+                        )
+                    scaled_image = self._scale_resizers[cache_key].process(image)
                 else:
-                    continue  # スケールが小さすぎる場合はスキップ
+                    continue
             else:
                 scaled_image = image
 
-            # 大津法二値化プロセッサを使用
+            # 二値化プロセッサを使用
             binary_image = self.binarizer.process(scaled_image)
             # HLACでは0と1の二値画像が必要なので255を1に正規化
             binary_image = (binary_image / 255).astype(np.uint8)


### PR DESCRIPTION
## Summary

- `_extract_hlac_features` でスケールごとに `ResizeProcessor` を毎回インスタンス化していたのを, 初回呼び出し時にキャッシュして再利用するよう変更した.
- `ResizeProcessor` を使い続けるため, #177 のリサイズ統一 Issue との一貫性を維持.

## Related Issue

Closes #171

## Changes

- `pochivision/feature_extractors/hlac_texture.py`:
  - `__init__` に `self._scale_resizers: Dict[tuple, ResizeProcessor] = {}` を追加
  - `_extract_hlac_features` で `(new_width, new_height)` をキーにキャッシュから取得, 未生成なら生成してキャッシュ

## Code Changes

```python
# __init__
self._scale_resizers: Dict[tuple, ResizeProcessor] = {}

# _extract_hlac_features
cache_key = (new_width, new_height)
if cache_key not in self._scale_resizers:
    resize_config = ResizeProcessor.get_default_config()
    resize_config["width"] = new_width
    resize_config["height"] = new_height
    resize_config["preserve_aspect_ratio"] = False
    self._scale_resizers[cache_key] = ResizeProcessor(
        name=f"resize_scale_{scale}", config=resize_config
    )
scaled_image = self._scale_resizers[cache_key].process(image)
```

## Test Plan

- [x] `uv run pytest tests/extractors/test_hlac_features.py` で 13 テストがパス
- [x] `uv run pytest` で全 336 テストがパス

## Checklist

- [x] 2回目以降の `extract()` でスケールリサイザーが再利用される
- [x] `ResizeProcessor` ベースの実装が維持されている
- [x] `uv run pytest` が通る