### PR TITLE
feat: 特徴量抽出器のリサイズを統一しアスペクト比保持オプションを追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@
 - HLAC の `except Exception` を削除しエラーをログ出力後に再送出するよう変更. ([#174](https://github.com/kurorosu/pochivision/pull/174))
 - HLAC のゼロパディングを削除し, 境界の特徴量減衰を解消. 二値化方式に適応的二値化 (`adaptive`) を追加しデフォルトに設定. ([#175](https://github.com/kurorosu/pochivision/pull/175))
 - HLAC `_get_default_results` のフォールバック特徴量数を 45 → 37 に修正. ([#178](https://github.com/kurorosu/pochivision/pull/178))
-- HLAC のスケールリサイザーを初回呼び出し時にキャッシュし, 毎回のインスタンス化を解消. (NA.)
+- HLAC のスケールリサイザーを初回呼び出し時にキャッシュし, 毎回のインスタンス化を解消. ([#179](https://github.com/kurorosu/pochivision/pull/179))
+- FFT と SWT に `resize_shape` を追加. 全抽出器 (GLCM, LBP, HLAC, FFT, SWT) に `preserve_aspect_ratio` / `aspect_ratio_mode` を追加しデフォルト `true` / `"width"` に設定. (NA.)
 
 ### Changed
 - GLCM に `resize_shape` オプションを追加. ([#163](https://github.com/kurorosu/pochivision/pull/163))

--- a/extractor_config.json
+++ b/extractor_config.json
@@ -26,7 +26,9 @@
         "energy",
         "correlation",
         "ASM"],
-      "resize_shape": [512, 512]
+      "resize_shape": [512, 512],
+      "preserve_aspect_ratio": true,
+      "aspect_ratio_mode": "width"
     },
     "fft": {
       "frequency_bands": [
@@ -37,19 +39,27 @@
       "high_low_threshold": 0.2,
       "directional_tolerance": 10.0,
       "peak_threshold_ratio": 0.1,
-      "mm_per_pixel": 0.05
+      "mm_per_pixel": 0.05,
+      "resize_shape": [512, 512],
+      "preserve_aspect_ratio": true,
+      "aspect_ratio_mode": "width"
     },
     "swt": {
       "wavelet": "db4",
       "max_level": 1,
-      "multiscale": true
+      "multiscale": true,
+      "resize_shape": [512, 512],
+      "preserve_aspect_ratio": true,
+      "aspect_ratio_mode": "width"
     },
     "lbp": {
       "P": 8,
       "R": 1,
       "method": "uniform",
       "resize_shape": [512, 512],
-      "include_histogram": true
+      "include_histogram": true,
+      "preserve_aspect_ratio": true,
+      "aspect_ratio_mode": "width"
     },
     "hlac": {
       "order": 2,
@@ -57,6 +67,8 @@
       "normalize": true,
       "scales": [1.0, 0.75, 0.5],
       "resize_shape": [512, 512],
+      "preserve_aspect_ratio": true,
+      "aspect_ratio_mode": "width",
       "binarization_method": "adaptive",
       "adaptive_block_size": 11,
       "adaptive_c": 2

--- a/pochivision/feature_extractors/fft_frequency.py
+++ b/pochivision/feature_extractors/fft_frequency.py
@@ -7,6 +7,7 @@ import numpy as np
 from scipy.ndimage import maximum_filter
 
 from pochivision.capturelib.log_manager import LogManager
+from pochivision.processors.resize import ResizeProcessor
 
 from .base import BaseFeatureExtractor
 from .registry import register_feature_extractor
@@ -90,6 +91,25 @@ class FFTFrequencyExtractor(BaseFeatureExtractor):
         self.directional_tolerance = self.config["directional_tolerance"]
         self.peak_threshold_ratio = self.config["peak_threshold_ratio"]
         self.mm_per_pixel = self.config.get("mm_per_pixel")
+
+        # リサイズ
+        resize_shape_config = self.config["resize_shape"]
+        self.resize_shape = (
+            tuple(resize_shape_config) if resize_shape_config is not None else None
+        )
+        self.resize_processor = None
+        if self.resize_shape is not None:
+            resize_config = ResizeProcessor.get_default_config()
+            resize_config["width"] = self.resize_shape[1]
+            resize_config["height"] = self.resize_shape[0]
+            resize_config["preserve_aspect_ratio"] = self.config[
+                "preserve_aspect_ratio"
+            ]
+            resize_config["aspect_ratio_mode"] = self.config["aspect_ratio_mode"]
+            self.resize_processor = ResizeProcessor(
+                name="resize_for_fft", config=resize_config
+            )
+
         if self.mm_per_pixel is not None and self.mm_per_pixel <= 0:
             raise ValueError(
                 f"mm_per_pixel must be a positive number, got {self.mm_per_pixel}"
@@ -395,6 +415,9 @@ class FFTFrequencyExtractor(BaseFeatureExtractor):
         else:
             raise ValueError(f"Input image must be 2D or 3D, got shape: {image.shape}")
 
+        if self.resize_processor is not None:
+            gray_image = self.resize_processor.process(gray_image)
+
         _MIN_FFT_SIZE = 4
         if gray_image.shape[0] < _MIN_FFT_SIZE or gray_image.shape[1] < _MIN_FFT_SIZE:
             raise ValueError(
@@ -505,6 +528,9 @@ class FFTFrequencyExtractor(BaseFeatureExtractor):
             "directional_tolerance": 10.0,  # 方向性エネルギーの許容角度（度）
             "peak_threshold_ratio": 0.1,  # ピーク検出の閾値比
             "mm_per_pixel": None,  # ピクセル解像度（Noneの場合はピクセル単位）
+            "resize_shape": None,  # リサイズ形状 (None=リサイズしない)
+            "preserve_aspect_ratio": True,  # アスペクト比を保持
+            "aspect_ratio_mode": "width",  # 基準軸 ("width" or "height")
         }
 
     @staticmethod

--- a/pochivision/feature_extractors/glcm_texture.py
+++ b/pochivision/feature_extractors/glcm_texture.py
@@ -82,7 +82,10 @@ class GLCMTextureExtractor(BaseFeatureExtractor):
             resize_config = ResizeProcessor.get_default_config()
             resize_config["width"] = self.resize_shape[1]
             resize_config["height"] = self.resize_shape[0]
-            resize_config["preserve_aspect_ratio"] = False
+            resize_config["preserve_aspect_ratio"] = self.config[
+                "preserve_aspect_ratio"
+            ]
+            resize_config["aspect_ratio_mode"] = self.config["aspect_ratio_mode"]
             self.resize_processor = ResizeProcessor(
                 name="resize_for_glcm", config=resize_config
             )
@@ -248,6 +251,8 @@ class GLCMTextureExtractor(BaseFeatureExtractor):
                 "ASM",  # Angular Second Moment
             ],
             "resize_shape": None,  # リサイズ形状 (None=リサイズしない)
+            "preserve_aspect_ratio": True,
+            "aspect_ratio_mode": "width",
         }
 
     @staticmethod

--- a/pochivision/feature_extractors/hlac_texture.py
+++ b/pochivision/feature_extractors/hlac_texture.py
@@ -75,9 +75,10 @@ class HLACTextureExtractor(BaseFeatureExtractor):
             resize_config = ResizeProcessor.get_default_config()
             resize_config["width"] = self.resize_shape[1]
             resize_config["height"] = self.resize_shape[0]
-            # 特徴量抽出では正確なサイズ合わせが必要なため、アスペクト比保持を無効化
-            resize_config["preserve_aspect_ratio"] = False
-
+            resize_config["preserve_aspect_ratio"] = self.config[
+                "preserve_aspect_ratio"
+            ]
+            resize_config["aspect_ratio_mode"] = self.config["aspect_ratio_mode"]
             self.resize_processor = ResizeProcessor(
                 name="resize_for_hlac", config=resize_config
             )
@@ -305,6 +306,8 @@ class HLACTextureExtractor(BaseFeatureExtractor):
             "normalize": True,
             "scales": [1.0, 0.75, 0.5],
             "resize_shape": None,
+            "preserve_aspect_ratio": True,
+            "aspect_ratio_mode": "width",
             "binarization_method": "adaptive",  # "otsu" or "adaptive"
             "adaptive_block_size": 11,  # adaptive 時のブロックサイズ
             "adaptive_c": 2,  # adaptive 時の定数 C

--- a/pochivision/feature_extractors/lbp_texture.py
+++ b/pochivision/feature_extractors/lbp_texture.py
@@ -76,9 +76,10 @@ class LBPTextureExtractor(BaseFeatureExtractor):
             resize_config = ResizeProcessor.get_default_config()
             resize_config["width"] = self.resize_shape[1]
             resize_config["height"] = self.resize_shape[0]
-            # 特徴量抽出では正確なサイズ合わせが必要なため、アスペクト比保持を無効化
-            resize_config["preserve_aspect_ratio"] = False
-
+            resize_config["preserve_aspect_ratio"] = self.config[
+                "preserve_aspect_ratio"
+            ]
+            resize_config["aspect_ratio_mode"] = self.config["aspect_ratio_mode"]
             self.resize_processor = ResizeProcessor(
                 name="resize_for_lbp", config=resize_config
             )
@@ -278,6 +279,8 @@ class LBPTextureExtractor(BaseFeatureExtractor):
             "method": "uniform",  # 回転不変uniform LBP
             "resize_shape": [128, 128],  # 128x128にリサイズ
             "include_histogram": False,  # ヒストグラムは含めない（統計量のみ）
+            "preserve_aspect_ratio": True,
+            "aspect_ratio_mode": "width",
         }
 
     @staticmethod

--- a/pochivision/feature_extractors/swt_frequency.py
+++ b/pochivision/feature_extractors/swt_frequency.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Optional, Union
 import numpy as np
 import pywt
 
+from pochivision.processors.resize import ResizeProcessor
 from pochivision.utils.image import to_grayscale
 
 from .base import BaseFeatureExtractor
@@ -45,6 +46,38 @@ class SWTFrequencyExtractor(BaseFeatureExtractor):
     マルチスケール解析を行う場合、各レベルの特徴量が追加されます。
     マルチスケールでない場合は、最高レベル（最も詳細な分解レベル）の特徴量のみが抽出されます。
     """
+
+    def __init__(
+        self,
+        name: str = "swt_frequency",
+        config: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """
+        SWTFrequencyExtractorのコンストラクタ.
+
+        Args:
+            name (str): 特徴量抽出器名.
+            config (dict, optional): 設定パラメータ.
+        """
+        super().__init__(name, config or {})
+
+        # リサイズ
+        resize_shape_config = self.config["resize_shape"]
+        self.resize_shape = (
+            tuple(resize_shape_config) if resize_shape_config is not None else None
+        )
+        self.resize_processor = None
+        if self.resize_shape is not None:
+            resize_config = ResizeProcessor.get_default_config()
+            resize_config["width"] = self.resize_shape[1]
+            resize_config["height"] = self.resize_shape[0]
+            resize_config["preserve_aspect_ratio"] = self.config[
+                "preserve_aspect_ratio"
+            ]
+            resize_config["aspect_ratio_mode"] = self.config["aspect_ratio_mode"]
+            self.resize_processor = ResizeProcessor(
+                name="resize_for_swt", config=resize_config
+            )
 
     # 特徴量の単位定義
     _FEATURE_UNITS = {
@@ -278,6 +311,9 @@ class SWTFrequencyExtractor(BaseFeatureExtractor):
         try:
             gray_image = to_grayscale(image)
 
+            if self.resize_processor is not None:
+                gray_image = self.resize_processor.process(gray_image)
+
             # SWT変換のために画像サイズを調整（奇数サイズを偶数サイズに）
             gray_image = self._adjust_image_size_for_swt(gray_image)
 
@@ -334,6 +370,9 @@ class SWTFrequencyExtractor(BaseFeatureExtractor):
             "wavelet": "db1",
             "max_level": 1,
             "multiscale": True,
+            "resize_shape": None,
+            "preserve_aspect_ratio": True,
+            "aspect_ratio_mode": "width",
         }
 
     @staticmethod


### PR DESCRIPTION
## Summary

- FFT と SWT に `resize_shape` オプションを追加した.
- 全 5 抽出器 (GLCM, LBP, HLAC, FFT, SWT) に `preserve_aspect_ratio` / `aspect_ratio_mode` パラメータを追加し, デフォルトで `true` / `"width"` に設定した.
- 既存の `preserve_aspect_ratio = False` ハードコードを設定ベースに変更した.

## Related Issue

Closes #177

## Changes

- `pochivision/feature_extractors/fft_frequency.py`: `resize_shape`, `preserve_aspect_ratio`, `aspect_ratio_mode` を追加. `ResizeProcessor` をインポート.
- `pochivision/feature_extractors/swt_frequency.py`: `__init__` を新設し同パラメータを追加. `ResizeProcessor` をインポート.
- `pochivision/feature_extractors/glcm_texture.py`: `preserve_aspect_ratio = False` → 設定ベースに変更. デフォルトに `preserve_aspect_ratio`, `aspect_ratio_mode` を追加.
- `pochivision/feature_extractors/lbp_texture.py`: 同上.
- `pochivision/feature_extractors/hlac_texture.py`: 同上.
- `extractor_config.json`: 全 5 抽出器に `resize_shape`, `preserve_aspect_ratio`, `aspect_ratio_mode` を追加.

## Test Plan

- [x] `uv run pytest` で全 336 テストがパス

## Checklist

- [x] FFT と SWT で `resize_shape` が設定可能
- [x] 全 5 抽出器で `preserve_aspect_ratio` / `aspect_ratio_mode` が設定可能
- [x] デフォルトが `true` / `"width"`
- [x] `resize_shape: null` でリサイズなし (後方互換)
- [x] `uv run pytest` が通る