### PR TITLE
test: HLAC 特徴量の振る舞いテストを追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@
 - HLAC のゼロパディングを削除し, 境界の特徴量減衰を解消. 二値化方式に適応的二値化 (`adaptive`) を追加しデフォルトに設定. ([#175](https://github.com/kurorosu/pochivision/pull/175))
 - HLAC `_get_default_results` のフォールバック特徴量数を 45 → 37 に修正. ([#178](https://github.com/kurorosu/pochivision/pull/178))
 - HLAC のスケールリサイザーを初回呼び出し時にキャッシュし, 毎回のインスタンス化を解消. ([#179](https://github.com/kurorosu/pochivision/pull/179))
-- FFT と SWT に `resize_shape` を追加. 全抽出器 (GLCM, LBP, HLAC, FFT, SWT) に `preserve_aspect_ratio` / `aspect_ratio_mode` を追加しデフォルト `true` / `"width"` に設定. (NA.)
+- FFT と SWT に `resize_shape` を追加. 全抽出器 (GLCM, LBP, HLAC, FFT, SWT) に `preserve_aspect_ratio` / `aspect_ratio_mode` を追加しデフォルト `true` / `"width"` に設定. ([#180](https://github.com/kurorosu/pochivision/pull/180))
+- HLAC の振る舞いテスト 11 件を追加. 全白, チェッカーボード, ストライプ, ランダム画像で特徴量値を検証. (NA.)
 
 ### Changed
 - GLCM に `resize_shape` オプションを追加. ([#163](https://github.com/kurorosu/pochivision/pull/163))

--- a/tests/extractors/test_hlac_features.py
+++ b/tests/extractors/test_hlac_features.py
@@ -475,3 +475,163 @@ if __name__ == "__main__":
     test_feature_names_and_units()
     test_unit_for_feature_method()
     print("\n=== HLACテクスチャ特徴量抽出テスト完了 ===")
+
+
+class TestHLACBehavior:
+    """HLAC 特徴量の振る舞いテスト."""
+
+    _CONFIG_RAW = {
+        "order": 2,
+        "rotate_invariant": False,
+        "normalize": False,
+        "scales": [1.0],
+        "resize_shape": None,
+        "binarization_method": "adaptive",
+        "adaptive_block_size": 11,
+        "adaptive_c": 2,
+        "preserve_aspect_ratio": True,
+        "aspect_ratio_mode": "width",
+    }
+    _CONFIG_NORM = {
+        "order": 2,
+        "rotate_invariant": False,
+        "normalize": True,
+        "scales": [1.0],
+        "resize_shape": None,
+        "binarization_method": "adaptive",
+        "adaptive_block_size": 11,
+        "adaptive_c": 2,
+        "preserve_aspect_ratio": True,
+        "aspect_ratio_mode": "width",
+    }
+
+    @staticmethod
+    def _make_white(size: int = 32) -> np.ndarray:
+        return np.full((size, size), 255, dtype=np.uint8)
+
+    @staticmethod
+    def _make_black(size: int = 32) -> np.ndarray:
+        return np.zeros((size, size), dtype=np.uint8)
+
+    @staticmethod
+    def _make_checker(size: int = 32) -> np.ndarray:
+        img = np.zeros((size, size), dtype=np.uint8)
+        img[0::2, 0::2] = 255
+        img[1::2, 1::2] = 255
+        return img
+
+    @staticmethod
+    def _make_h_stripe(size: int = 32, period: int = 4) -> np.ndarray:
+        img = np.zeros((size, size), dtype=np.uint8)
+        for k in range(period // 2):
+            img[k::period, :] = 255
+        return img
+
+    @staticmethod
+    def _make_random(size: int = 32) -> np.ndarray:
+        np.random.seed(42)
+        return np.random.randint(0, 256, (size, size), dtype=np.uint8)
+
+    # --- 全白画像 ---
+
+    def test_white_0th_order_equals_valid_pixels(self):
+        """全白画像の 0th order は valid 領域のピクセル数と一致."""
+        ext = HLACTextureExtractor(config=self._CONFIG_RAW)
+        f = ext.extract(self._make_white())
+        # 32x32 画像で mode="valid" + 3x3 カーネル → 30x30 = 900
+        assert f["hlac_feature_00"] == 900
+
+    def test_white_1st_order_all_equal(self):
+        """全白画像の 1st order は全方向同じ値."""
+        ext = HLACTextureExtractor(config=self._CONFIG_RAW)
+        f = ext.extract(self._make_white())
+        values = [f[f"hlac_feature_{i:02d}"] for i in range(1, 9)]
+        assert len(set(values)) == 1  # 全方向同値
+
+    def test_white_equals_black(self):
+        """全白と全黒は adaptive 二値化後に同じパターンになる."""
+        ext = HLACTextureExtractor(config=self._CONFIG_RAW)
+        fw = ext.extract(self._make_white())
+        fb = ext.extract(self._make_black())
+        for i in range(37):
+            assert fw[f"hlac_feature_{i:02d}"] == fb[f"hlac_feature_{i:02d}"]
+
+    # --- チェッカーボード ---
+
+    def test_checker_1st_order_axis_zero(self):
+        """チェッカーボードの 1st order は軸方向 (feature_01,03,05,07) がゼロ."""
+        ext = HLACTextureExtractor(config=self._CONFIG_RAW)
+        f = ext.extract(self._make_checker())
+        # offsets: 01=(0,-1), 03=(-1,0), 05=(0,1), 07=(1,0) が軸方向
+        for i in [1, 3, 5, 7]:
+            assert f[f"hlac_feature_{i:02d}"] == 0
+
+    def test_checker_1st_order_diagonal_nonzero(self):
+        """チェッカーボードの 1st order は対角方向 (feature_02,04,06,08) が非ゼロ."""
+        ext = HLACTextureExtractor(config=self._CONFIG_RAW)
+        f = ext.extract(self._make_checker())
+        for i in [2, 4, 6, 8]:
+            assert f[f"hlac_feature_{i:02d}"] > 0
+
+    # --- 水平ストライプ ---
+
+    def test_h_stripe_vertical_direction_highest(self):
+        """水平ストライプは垂直方向 (feature_03, 07) の 1st order が最大."""
+        ext = HLACTextureExtractor(config=self._CONFIG_RAW)
+        f = ext.extract(self._make_h_stripe())
+        # feature_03=(-1,0)上, feature_07=(1,0)下 が垂直方向
+        vertical = f["hlac_feature_03"]
+        horizontal = f["hlac_feature_01"]  # (0,-1)左
+        assert vertical > horizontal
+
+    # --- ランダム ---
+
+    def test_random_1st_order_nearly_uniform(self):
+        """ランダム画像の 1st order は全方向ほぼ均等."""
+        ext = HLACTextureExtractor(config=self._CONFIG_RAW)
+        f = ext.extract(self._make_random())
+        values = [f[f"hlac_feature_{i:02d}"] for i in range(1, 9)]
+        mean_val = sum(values) / len(values)
+        for v in values:
+            assert abs(v - mean_val) / mean_val < 0.1  # 10% 以内
+
+    # --- ランダム vs チェッカーボード ---
+
+    def test_checker_differs_from_random(self):
+        """チェッカーボードとランダムの特徴量が区別可能."""
+        ext = HLACTextureExtractor(config=self._CONFIG_NORM)
+        fc = ext.extract(self._make_checker())
+        fr = ext.extract(self._make_random())
+        # チェッカーボードの軸方向 1st order = 0, ランダムは > 0
+        assert fc["hlac_feature_01"] == 0
+        assert fr["hlac_feature_01"] > 0
+
+    # --- 正規化 ---
+
+    def test_normalized_sum_is_one(self):
+        """正規化時の全特徴量の合計は ~1.0."""
+        ext = HLACTextureExtractor(config=self._CONFIG_NORM)
+        f = ext.extract(self._make_random())
+        total = sum(f.values())
+        assert 0.99 <= total <= 1.01
+
+    def test_normalized_0th_less_than_one(self):
+        """正規化時の 0th order は 1.0 未満."""
+        ext = HLACTextureExtractor(config=self._CONFIG_NORM)
+        f = ext.extract(self._make_random())
+        assert f["hlac_feature_00"] < 1.0
+
+    # --- 水平 vs 垂直ストライプ ---
+
+    def test_h_stripe_differs_from_v_stripe(self):
+        """水平ストライプと垂直ストライプは方向性特徴量が異なる."""
+        ext = HLACTextureExtractor(config=self._CONFIG_RAW)
+        v_stripe = np.zeros((32, 32), dtype=np.uint8)
+        v_stripe[:, 0::4] = 255
+        v_stripe[:, 1::4] = 255
+
+        fh = ext.extract(self._make_h_stripe())
+        fv = ext.extract(v_stripe)
+        # 水平ストライプは feature_03 (上) が高い, 垂直ストライプは feature_01 (左) が高い
+        assert fh["hlac_feature_03"] > fh["hlac_feature_01"]
+        assert fv["hlac_feature_01"] > fv["hlac_feature_03"]


### PR DESCRIPTION
## Summary

- HLAC 特徴量の振る舞いテスト 11 件を追加し, 特徴量抽出の正確性を担保する古典派テストを導入した.

## Related Issue

Closes #168

## Changes

- `tests/extractors/test_hlac_features.py`:
  - `TestHLACBehavior` クラスを追加
  - 共通画像メソッド (white, black, checker, h_stripe, random)
  - 全白: 0th order = valid 領域ピクセル数 (900), 1st order 全方向同値
  - 全白 = 全黒 (adaptive 二値化の特性)
  - チェッカーボード: 軸方向 1st order = 0, 対角方向 > 0
  - 水平ストライプ: 垂直方向の 1st order が最大
  - ランダム: 全方向 10% 以内の均等分布
  - チェッカー vs ランダム: 区別可能
  - 正規化: 合計 ~1.0, 0th < 1.0
  - 水平 vs 垂直ストライプ: 方向性特徴量が逆転

## Test Plan

- [x] `uv run pytest tests/extractors/test_hlac_features.py` で 24 テストがパス
- [x] `uv run pytest` で全 347 テストがパス

## Checklist

- [x] 既知の入力に対する期待値が検証されている
- [x] テクスチャ間の差が検証されている
- [x] 方向性の差が検証されている
- [x] 正規化の正確性が検証されている
- [x] `uv run pytest` が通る
