### PR TITLE
refactor: HLAC の二値化正規化を堅牢化し correlate2d に変更

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@
 - HLAC `_get_default_results` のフォールバック特徴量数を 45 → 37 に修正. ([#178](https://github.com/kurorosu/pochivision/pull/178))
 - HLAC のスケールリサイザーを初回呼び出し時にキャッシュし, 毎回のインスタンス化を解消. ([#179](https://github.com/kurorosu/pochivision/pull/179))
 - FFT と SWT に `resize_shape` を追加. 全抽出器 (GLCM, LBP, HLAC, FFT, SWT) に `preserve_aspect_ratio` / `aspect_ratio_mode` を追加しデフォルト `true` / `"width"` に設定. ([#180](https://github.com/kurorosu/pochivision/pull/180))
-- HLAC の振る舞いテスト 11 件を追加. 全白, チェッカーボード, ストライプ, ランダム画像で特徴量値を検証. (NA.)
+- HLAC の振る舞いテスト 11 件を追加. 全白, チェッカーボード, ストライプ, ランダム画像で特徴量値を検証. ([#181](https://github.com/kurorosu/pochivision/pull/181))
+- HLAC の二値化を `binary / 255` から `binary > 0` に変更, `convolve2d` + 二重反転を `correlate2d` に変更. (NA.)
 
 ### Changed
 - GLCM に `resize_shape` オプションを追加. ([#163](https://github.com/kurorosu/pochivision/pull/163))

--- a/pochivision/feature_extractors/hlac_texture.py
+++ b/pochivision/feature_extractors/hlac_texture.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Optional, Union
 
 import cv2
 import numpy as np
-from scipy.signal import convolve2d
+from scipy.signal import correlate2d
 
 from pochivision.capturelib.log_manager import LogManager
 from pochivision.processors.base import BaseProcessor
@@ -258,11 +258,11 @@ class HLACTextureExtractor(BaseFeatureExtractor):
             # 二値化プロセッサを使用
             binary_image = self.binarizer.process(scaled_image)
             # HLACでは0と1の二値画像が必要なので255を1に正規化
-            binary_image = (binary_image / 255).astype(np.uint8)
+            binary_image = (binary_image > 0).astype(np.uint8)
 
             # 各カーネルに対して相関計算 (パディングなしで境界を除外)
             for i, kernel in enumerate(self.kernels):
-                conv_result = convolve2d(binary_image, kernel[::-1, ::-1], mode="valid")
+                conv_result = correlate2d(binary_image, kernel, mode="valid")
                 total_features[i] += np.sum(conv_result == kernel.sum())
 
         # 正規化処理


### PR DESCRIPTION
## Summary

- `binary_image / 255` を `binary_image > 0` に変更し, Otsu の `maxval=255` への暗黙依存を除去した.
- `convolve2d(image, kernel[::-1, ::-1])` (二重反転) を `correlate2d(image, kernel)` に変更し, 意図を明確化した.

## Related Issue

Closes #173

## Changes

- `pochivision/feature_extractors/hlac_texture.py`:
  - `(binary_image / 255).astype(np.uint8)` → `(binary_image > 0).astype(np.uint8)`
  - `from scipy.signal import convolve2d` → `from scipy.signal import correlate2d`
  - `convolve2d(binary_image, kernel[::-1, ::-1], mode="valid")` → `correlate2d(binary_image, kernel, mode="valid")`

## Test Plan

- [x] `uv run pytest tests/extractors/test_hlac_features.py` で 24 テストがパス (振る舞いテスト含む)
- [x] `uv run pytest` で全 347 テストがパス

## Checklist

- [x] 二値化が `maxval` に依存しない
- [x] `correlate2d` で意図が明確
- [x] 振る舞いテストが引き続きパス
- [x] `uv run pytest` が通る