### PR TITLE
docs: HLAC docstring に回転不変性の制約を追記

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@
 - HLAC のスケールリサイザーを初回呼び出し時にキャッシュし, 毎回のインスタンス化を解消. ([#179](https://github.com/kurorosu/pochivision/pull/179))
 - FFT と SWT に `resize_shape` を追加. 全抽出器 (GLCM, LBP, HLAC, FFT, SWT) に `preserve_aspect_ratio` / `aspect_ratio_mode` を追加しデフォルト `true` / `"width"` に設定. ([#180](https://github.com/kurorosu/pochivision/pull/180))
 - HLAC の振る舞いテスト 11 件を追加. 全白, チェッカーボード, ストライプ, ランダム画像で特徴量値を検証. ([#181](https://github.com/kurorosu/pochivision/pull/181))
-- HLAC の二値化を `binary / 255` から `binary > 0` に変更, `convolve2d` + 二重反転を `correlate2d` に変更. (NA.)
+- HLAC の二値化を `binary / 255` から `binary > 0` に変更, `convolve2d` + 二重反転を `correlate2d` に変更. ([#182](https://github.com/kurorosu/pochivision/pull/182))
+- HLAC docstring に回転不変性の制約 (90度回転のみ, 反転未対応) を追記. (NA.)
 
 ### Changed
 - GLCM に `resize_shape` オプションを追加. ([#163](https://github.com/kurorosu/pochivision/pull/163))

--- a/pochivision/feature_extractors/hlac_texture.py
+++ b/pochivision/feature_extractors/hlac_texture.py
@@ -29,12 +29,18 @@ class HLACTextureExtractor(BaseFeatureExtractor):
     高次の空間的相関パターンを定量化できます。
 
     抽出する特徴量:
-    - 標準HLAC: 37次元の特徴量（0次1 + 1次8 + 2次28） [correlation_coefficient]
-    - 回転不変HLAC: 11次元の特徴量（回転に対して不変） [correlation_coefficient]
+    - 標準HLAC: 37次元 (0次1 + 1次8 + 2次28) [correlation_coefficient]
+    - 回転不変HLAC: 11次元 (90度回転で等価なパターンを統合) [correlation_coefficient]
     - スケール不変性: 複数スケールでの特徴抽出 [correlation_coefficient]
-    - 正規化: 特徴量の正規化による明度変化への頑健性 [normalized_correlation]
+    - 正規化: L1 正規化による明度変化への頑健性 [normalized_correlation]
 
-    設定により、次数、回転不変性、正規化、スケール係数などを調整できます。
+    回転不変性の制約:
+    - 90度単位の回転 (0, 90, 180, 270度) のみ対応.
+    - 左右反転 / 上下反転は未対応.
+    - 8方向すべての変換 (4回転 x 2反転) に対応する場合は
+      更に特徴量次元が減少するが, 現実装では反転を含めない.
+
+    設定により, 次数, 回転不変性, 正規化, スケール係数, 二値化方式などを調整できる.
     """
 
     # 特徴量の単位定義


### PR DESCRIPTION
## Summary

- クラス docstring に回転不変性の制約 (90度回転のみ対応, 反転未対応) を明記した.

## Related Issue

Closes #172

## Changes

- `pochivision/feature_extractors/hlac_texture.py`: クラス docstring に「回転不変性の制約」セクションを追加

## Test Plan

- [x] `uv run pytest` で全 347 テストがパス

## Checklist

- [x] 90度回転のみ対応であることが記載されている
- [x] 反転未対応であることが記載されている
- [x] `uv run pytest` が通る