### PR TITLE
chore: v0.1.3 リリース準備

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,50 +6,42 @@
 ## [Unreleased]
 
 ### Added
-- `docs/glcm_features.md` を追加. GLCM 特徴量抽出器の全プロパティ・パラメータ・設計制約の解説. ([#176](https://github.com/kurorosu/pochivision/pull/176))
-- GLCM の振る舞いテスト 17 件を追加. 均一画像, チェッカーボード, グラデーション, ランダム画像で特徴量値を検証. ([#164](https://github.com/kurorosu/pochivision/pull/164))
-- GLCM docstring の `asm` を `ASM` に修正. ([#165](https://github.com/kurorosu/pochivision/pull/165))
-- GLCM docstring に特徴量名形式・特徴量数の計算式を追記. ([#166](https://github.com/kurorosu/pochivision/pull/166))
-- HLAC の `except Exception` を削除しエラーをログ出力後に再送出するよう変更. ([#174](https://github.com/kurorosu/pochivision/pull/174))
-- HLAC のゼロパディングを削除し, 境界の特徴量減衰を解消. 二値化方式に適応的二値化 (`adaptive`) を追加しデフォルトに設定. ([#175](https://github.com/kurorosu/pochivision/pull/175))
-- HLAC `_get_default_results` のフォールバック特徴量数を 45 → 37 に修正. ([#178](https://github.com/kurorosu/pochivision/pull/178))
-- HLAC のスケールリサイザーを初回呼び出し時にキャッシュし, 毎回のインスタンス化を解消. ([#179](https://github.com/kurorosu/pochivision/pull/179))
-- FFT と SWT に `resize_shape` を追加. 全抽出器 (GLCM, LBP, HLAC, FFT, SWT) に `preserve_aspect_ratio` / `aspect_ratio_mode` を追加しデフォルト `true` / `"width"` に設定. ([#180](https://github.com/kurorosu/pochivision/pull/180))
-- HLAC の振る舞いテスト 11 件を追加. 全白, チェッカーボード, ストライプ, ランダム画像で特徴量値を検証. ([#181](https://github.com/kurorosu/pochivision/pull/181))
-- HLAC の二値化を `binary / 255` から `binary > 0` に変更, `convolve2d` + 二重反転を `correlate2d` に変更. ([#182](https://github.com/kurorosu/pochivision/pull/182))
-- HLAC docstring に回転不変性の制約 (90度回転のみ, 反転未対応) を追記. ([#183](https://github.com/kurorosu/pochivision/pull/183))
-- `docs/hlac_features.md` を追加. FFT/GLCM docs にリサイズパラメータを追記. (NA.)
+- 無し
 
 ### Changed
-- GLCM に `resize_shape` オプションを追加. ([#163](https://github.com/kurorosu/pochivision/pull/163))
+- 無し
 
 ### Fixed
-- GLCM の `cv2.normalize(NORM_MINMAX)` を削除し, uint8 変換と整数除算量子化に変更. コントラスト情報が保持される. ([#160](https://github.com/kurorosu/pochivision/pull/160))
-- GLCM の `except Exception` を削除しエラーをログ出力後に再送出するよう変更. ([#161](https://github.com/kurorosu/pochivision/pull/161))
-- GLCM の NaN/Inf を 0.0 ではなく NaN として保持し, 警告ログを出力するよう変更. ([#162](https://github.com/kurorosu/pochivision/pull/162))
+- 無し
 
 ### Removed
 - 無し
 
-## [0.1.2] - 2026-03-28
+## [0.1.3] - 2026-03-29
 
 ### Added
-- `docs/fft_features.md` を追加. FFT 特徴量抽出器の全特徴量・パラメータ・設計制約の解説. ([#149](https://github.com/kurorosu/pochivision/pull/149))
+- `docs/glcm_features.md` を追加. GLCM 特徴量抽出器の全プロパティ・パラメータ・設計制約の解説. ([#176](https://github.com/kurorosu/pochivision/pull/176))
+- `docs/hlac_features.md` を追加. FFT/GLCM docs にリサイズパラメータを追記. ([#184](https://github.com/kurorosu/pochivision/pull/184))
+- GLCM の振る舞いテスト 17 件を追加. ([#164](https://github.com/kurorosu/pochivision/pull/164))
+- HLAC の振る舞いテスト 11 件を追加. ([#181](https://github.com/kurorosu/pochivision/pull/181))
+- GLCM に `resize_shape` オプションを追加. ([#163](https://github.com/kurorosu/pochivision/pull/163))
+- FFT と SWT に `resize_shape` を追加. 全抽出器に `preserve_aspect_ratio` / `aspect_ratio_mode` を追加. ([#180](https://github.com/kurorosu/pochivision/pull/180))
+- HLAC に適応的二値化 (`adaptive`) を追加しデフォルトに設定. ([#175](https://github.com/kurorosu/pochivision/pull/175))
 
 ### Changed
-- 無し
+- GLCM docstring の `asm` を `ASM` に修正. ([#165](https://github.com/kurorosu/pochivision/pull/165))
+- GLCM docstring に特徴量名形式と特徴量数の計算式を追記. ([#166](https://github.com/kurorosu/pochivision/pull/166))
+- HLAC の二値化を `binary / 255` から `binary > 0` に変更, `convolve2d` を `correlate2d` に変更. ([#182](https://github.com/kurorosu/pochivision/pull/182))
+- HLAC のスケールリサイザーを初回呼び出し時にキャッシュ. ([#179](https://github.com/kurorosu/pochivision/pull/179))
+- HLAC docstring に回転不変性の制約を追記. ([#183](https://github.com/kurorosu/pochivision/pull/183))
 
 ### Fixed
-- FFT 周波数正規化を対角線距離基準から軸方向最大距離基準に修正し, 帯域カバレッジを改善. ([#135](https://github.com/kurorosu/pochivision/pull/135))
-- FFT 計算前に Hanning 窓関数を適用し, 画像境界のスペクトルリークを抑制. ([#136](https://github.com/kurorosu/pochivision/pull/136))
-- FFT 前の uint8 正規化を削除し, float64 のまま処理するよう変更. コントラスト情報が保持される. ([#137](https://github.com/kurorosu/pochivision/pull/137))
-- FFT のエネルギー・エントロピー計算から DC 成分を除外し, AC 成分のみで特徴量を計算するよう修正. ([#138](https://github.com/kurorosu/pochivision/pull/138))
-- FFT 帯域エネルギーの最終帯域を上限なしに変更し, 非正方形画像でも合計が ~1.0 になるよう修正. ([#145](https://github.com/kurorosu/pochivision/pull/145))
-- FFT 抽出で最小画像サイズ (4x4) のバリデーションを追加. 極小画像で全特徴量がサイレントにゼロになる問題を解消. ([#146](https://github.com/kurorosu/pochivision/pull/146))
-- FFT `max_peak_amp` を検出ピーク内の最大振幅に修正 (グローバル最大値ではなく). ([#147](https://github.com/kurorosu/pochivision/pull/147))
-- FFT エントロピーを正規化エントロピー (`entropy / log2(N)`, [0, 1] 範囲) に変更し, 帯域間で比較可能に. ([#148](https://github.com/kurorosu/pochivision/pull/148))
-- FFT `except Exception` を削除しエラーを伝播するよう変更. `mm_per_pixel` のバリデーションを追加. ([#150](https://github.com/kurorosu/pochivision/pull/150))
-- FFT 特徴量抽出器のクラス docstring に前処理フロー・設計制約を追記. エントロピー単位を `normalized` に修正. ([#151](https://github.com/kurorosu/pochivision/pull/151))
+- GLCM の `cv2.normalize(NORM_MINMAX)` を削除しコントラスト情報を保持. ([#160](https://github.com/kurorosu/pochivision/pull/160))
+- GLCM の `except Exception` を削除しエラーをログ出力後に再送出. ([#161](https://github.com/kurorosu/pochivision/pull/161))
+- GLCM の NaN/Inf を NaN として保持し警告ログを出力. ([#162](https://github.com/kurorosu/pochivision/pull/162))
+- HLAC の `except Exception` を削除しエラーをログ出力後に再送出. ([#174](https://github.com/kurorosu/pochivision/pull/174))
+- HLAC のゼロパディングを削除し境界の特徴量減衰を解消. ([#175](https://github.com/kurorosu/pochivision/pull/175))
+- HLAC `_get_default_results` のフォールバック特徴量数を 45 → 37 に修正. ([#178](https://github.com/kurorosu/pochivision/pull/178))
 
 ### Removed
 - 無し

--- a/changelogs/0.1.x.md
+++ b/changelogs/0.1.x.md
@@ -1,3 +1,26 @@
+## [0.1.2] - 2026-03-28
+
+### Added
+- `docs/fft_features.md` を追加. FFT 特徴量抽出器の全特徴量・パラメータ・設計制約の解説. ([#149](https://github.com/kurorosu/pochivision/pull/149))
+
+### Changed
+- 無し
+
+### Fixed
+- FFT 周波数正規化を対角線距離基準から軸方向最大距離基準に修正し, 帯域カバレッジを改善. ([#135](https://github.com/kurorosu/pochivision/pull/135))
+- FFT 計算前に Hanning 窓関数を適用し, 画像境界のスペクトルリークを抑制. ([#136](https://github.com/kurorosu/pochivision/pull/136))
+- FFT 前の uint8 正規化を削除し, float64 のまま処理するよう変更. コントラスト情報が保持される. ([#137](https://github.com/kurorosu/pochivision/pull/137))
+- FFT のエネルギー・エントロピー計算から DC 成分を除外し, AC 成分のみで特徴量を計算するよう修正. ([#138](https://github.com/kurorosu/pochivision/pull/138))
+- FFT 帯域エネルギーの最終帯域を上限なしに変更し, 非正方形画像でも合計が ~1.0 になるよう修正. ([#145](https://github.com/kurorosu/pochivision/pull/145))
+- FFT 抽出で最小画像サイズ (4x4) のバリデーションを追加. ([#146](https://github.com/kurorosu/pochivision/pull/146))
+- FFT `max_peak_amp` を検出ピーク内の最大振幅に修正. ([#147](https://github.com/kurorosu/pochivision/pull/147))
+- FFT エントロピーを正規化エントロピーに変更し帯域間で比較可能に. ([#148](https://github.com/kurorosu/pochivision/pull/148))
+- FFT `except Exception` を削除しエラーを伝播するよう変更. `mm_per_pixel` のバリデーションを追加. ([#150](https://github.com/kurorosu/pochivision/pull/150))
+- FFT docstring に前処理フロー・設計制約を追記. エントロピー単位を `normalized` に修正. ([#151](https://github.com/kurorosu/pochivision/pull/151))
+
+### Removed
+- 無し
+
 ## [0.1.1] - 2026-03-28
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pochivision"
-version = "0.1.2"
+version = "0.1.3"
 description = "Real-time image capture and preprocessing engine for AI vision"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -809,7 +809,7 @@ wheels = [
 
 [[package]]
 name = "pochivision"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- `pyproject.toml` のバージョンを 0.1.3 に更新.
- `uv.lock` を更新.
- `CHANGELOG.md` の `[Unreleased]` を `[0.1.3]` に切り出し.
- v0.1.2 エントリを `changelogs/0.1.x.md` にアーカイブ.

## Related Issue

無し

## Changes

- `pyproject.toml`: version 0.1.2 → 0.1.3
- `uv.lock`: バージョン更新に追従
- `CHANGELOG.md`: [Unreleased] → [0.1.3], v0.1.2 をアーカイブに移動
- `changelogs/0.1.x.md`: v0.1.2 エントリを追加

## Test Plan

- [x] `uv run pytest` で全 347 テストがパス
- [x] `uv lock` を実行済み

## Checklist

- [x] バージョン番号が 0.1.3 に更新されている
- [x] CHANGELOG に NA. が残っていない
- [x] v0.1.2 がアーカイブされている
- [x] `uv run pytest` が通る