### PR TITLE
fix: SWT エントロピー計算を bincount ベースに変更し狭い値域でのクラッシュを解消

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - 無し
 
 ### Fixed
-- 無し
+- SWT エントロピー計算を `np.histogram` から `np.bincount` ベースに変更し, 狭い値域でのクラッシュを解消. (NA.)
 
 ### Removed
 - 無し

--- a/pochivision/feature_extractors/swt_frequency.py
+++ b/pochivision/feature_extractors/swt_frequency.py
@@ -129,22 +129,21 @@ class SWTFrequencyExtractor(BaseFeatureExtractor):
         # 値の範囲を取得
         min_val, max_val = flattened.min(), flattened.max()
 
-        # 範囲が0の場合（すべて同じ値）はエントロピー0
+        # 値域が極めて狭い場合はエントロピー 0 (均一に近い)
         if max_val == min_val:
             return 0.0
 
-        # ヒストグラムを計算（256ビンで正規化された範囲）
-        hist, _ = np.histogram(
-            flattened, bins=256, range=(min_val, max_val), density=False
-        )
+        # 256 段階に量子化してヒストグラムを作成
+        # 浮動小数点の精度問題を回避するため, 整数インデックスに変換
+        normalized = (flattened - min_val) / (max_val - min_val)  # [0, 1]
+        indices = np.clip((normalized * 255).astype(np.int32), 0, 255)
+        hist = np.bincount(indices, minlength=256).astype(np.float64)
 
-        # 確率に変換
+        # 確率に変換, ゼロを除外
         prob = hist / np.sum(hist)
-
-        # ゼロ確率を除去（log(0)を回避）
         prob = prob[prob > 0]
 
-        # シャノンエントロピーを計算: -Σ p * log2(p)
+        # シャノンエントロピーを計算: -sum(p * log2(p))
         return float(-np.sum(prob * np.log2(prob)))
 
     def _compute_std(self, coeffs: np.ndarray) -> float:


### PR DESCRIPTION
## Summary

- `_compute_entropy` の `np.histogram(bins=256)` を `np.bincount` ベースの量子化に変更し, 浮動小数点精度の問題によるクラッシュを解消した.
- 小画像 + 高 level で再現していた `ValueError: Too many bins for data range` が発生しなくなった.

## Related Issue

Closes #186

## Changes

- `pochivision/feature_extractors/swt_frequency.py`:
  - `np.histogram(bins=256, range=(min_val, max_val))` → [0, 1] に正規化後 `np.bincount(indices, minlength=256)` に変更
  - 値域チェックの tolerance を `max_val == min_val` (完全一致) のまま維持 (量子化で精度問題を回避)

## Code Changes

```python
# 修正前: np.histogram が狭い値域でクラッシュ
hist, _ = np.histogram(flattened, bins=256, range=(min_val, max_val))

# 修正後: 整数インデックスに量子化してから bincount
normalized = (flattened - min_val) / (max_val - min_val)
indices = np.clip((normalized * 255).astype(np.int32), 0, 255)
hist = np.bincount(indices, minlength=256).astype(np.float64)
```

## Test Plan

- [x] `uv run pytest tests/extractors/test_swt_frequency.py` で 20 テストがパス
- [x] 8x8 画像 + max_level=3 でクラッシュしないことを確認
- [x] 均一画像でエントロピー = 0 を確認
- [x] `uv run pytest` で全 347 テストがパス

## Checklist

- [x] 狭い値域でクラッシュしない
- [x] 均一画像でエントロピー = 0
- [x] `uv run pytest` が通る