### PR TITLE
fix: SWT レベルラベリングを修正し L1=高周波, LN=低周波に変更

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@
 - 無し
 
 ### Fixed
-- SWT エントロピー計算を `np.histogram` から `np.bincount` ベースに変更し, 狭い値域でのクラッシュを解消. (NA.)
+- SWT エントロピー計算を `np.histogram` から `np.bincount` ベースに変更し, 狭い値域でのクラッシュを解消. ([#193](https://github.com/kurorosu/pochivision/pull/193))
+- SWT マルチスケールのレベルラベリングを反転し, L1=最細 (高周波), LN=最粗 (低周波) にウェーブレット慣習と統一. (NA.)
 
 ### Removed
 - 無し

--- a/pochivision/feature_extractors/swt_frequency.py
+++ b/pochivision/feature_extractors/swt_frequency.py
@@ -332,8 +332,11 @@ class SWTFrequencyExtractor(BaseFeatureExtractor):
             features = {}
 
             if self.config.get("multiscale", True):
-                # マルチスケール解析：各レベルの特徴量を抽出
-                for level_idx, level_coeffs in enumerate(coeffs, start=1):
+                # マルチスケール解析: 各レベルの特徴量を抽出
+                # pywt.swt2 は coarsest-first で返すので逆順にし,
+                # L1=最細 (level 1), LN=最粗 (level N) とする
+                max_level = len(coeffs)
+                for level_idx, level_coeffs in enumerate(reversed(coeffs), start=1):
                     level_features = self._extract_single_level_features(
                         level_coeffs, level=level_idx
                     )


### PR DESCRIPTION
## Summary

- `enumerate(coeffs, start=1)` を `enumerate(reversed(coeffs), start=1)` に変更し, L1=最細 (高周波詳細), LN=最粗 (低周波近似) とした.
- 標準ウェーブレット慣習と一致.

## Related Issue

Closes #187

## Changes

- `pochivision/feature_extractors/swt_frequency.py`:
  - マルチスケールループで `coeffs` を逆順に走査

## Code Changes

```python
# 修正前: L1=最粗 (慣習と逆)
for level_idx, level_coeffs in enumerate(coeffs, start=1):

# 修正後: L1=最細 (慣習通り)
for level_idx, level_coeffs in enumerate(reversed(coeffs), start=1):
```

## Test Plan

- [x] `uv run pytest` で全 347 テストがパス

## Checklist

- [x] L1 が最細レベル (高周波) に対応する
- [x] `get_base_feature_names` と `extract()` のキー順が一致する
- [x] `uv run pytest` が通る