### PR TITLE
fix: SWT multiscale=False のレベル選択と docstring を明確化

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@
 
 ### Fixed
 - SWT エントロピー計算を `np.histogram` から `np.bincount` ベースに変更し, 狭い値域でのクラッシュを解消. ([#193](https://github.com/kurorosu/pochivision/pull/193))
-- SWT マルチスケールのレベルラベリングを反転し, L1=最細 (高周波), LN=最粗 (低周波) にウェーブレット慣習と統一. (NA.)
+- SWT マルチスケールのレベルラベリングを修正し, L1=高周波, LN=低周波に変更. ([#194](https://github.com/kurorosu/pochivision/pull/194))
+- SWT `multiscale=False` 時のレベル選択と docstring を明確化 (level 1, 高周波詳細). (NA.)
 
 ### Removed
 - 無し

--- a/pochivision/feature_extractors/swt_frequency.py
+++ b/pochivision/feature_extractors/swt_frequency.py
@@ -43,8 +43,8 @@ class SWTFrequencyExtractor(BaseFeatureExtractor):
     - std_hl: 垂直高周波成分の標準偏差 [coefficient]
     - std_hh: 対角高周波成分の標準偏差 [coefficient]
 
-    マルチスケール解析を行う場合、各レベルの特徴量が追加されます。
-    マルチスケールでない場合は、最高レベル（最も詳細な分解レベル）の特徴量のみが抽出されます。
+    マルチスケール解析を行う場合, L1 (高周波) から LN (低周波) の各レベルの特徴量が追加される.
+    マルチスケールでない場合は, level 1 (最細, 高周波詳細) の特徴量のみが抽出される.
     """
 
     def __init__(
@@ -342,9 +342,9 @@ class SWTFrequencyExtractor(BaseFeatureExtractor):
                     )
                     features.update(level_features)
             else:
-                # 単一スケール解析：最高レベル（最も詳細な分解レベル）のみ
-                highest_level_coeffs = coeffs[-1]
-                features = self._extract_single_level_features(highest_level_coeffs)
+                # 単一スケール解析: level 1 (最細, 高周波詳細) のみ
+                finest_level_coeffs = coeffs[-1]
+                features = self._extract_single_level_features(finest_level_coeffs)
 
             return features
 


### PR DESCRIPTION
## Summary

- `multiscale=False` 時のコメントを「最高レベル (最も詳細な分解レベル)」から「level 1 (最細, 高周波詳細)」に明確化した.
- クラス docstring のマルチスケール説明を「L1 (高周波) から LN (低周波)」に修正した.

## Related Issue

Closes #188

## Changes

- `pochivision/feature_extractors/swt_frequency.py`:
  - line 345: コメントを「level 1 (最細, 高周波詳細) のみ」に修正
  - line 346: 変数名を `highest_level_coeffs` → `finest_level_coeffs` に変更
  - クラス docstring のマルチスケール説明を修正

## Test Plan

- [x] `uv run pytest` で全 347 テストがパス

## Checklist

- [x] `multiscale=False` の意図が明確に記載されている
- [x] docstring がレベル順と一致している
- [x] `uv run pytest` が通る