### PR TITLE
fix: SWT の dtype 正規化を統一し入力型に関わらず同じ特徴量を返すよう修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@
 ### Fixed
 - SWT エントロピー計算を `np.histogram` から `np.bincount` ベースに変更し, 狭い値域でのクラッシュを解消. ([#193](https://github.com/kurorosu/pochivision/pull/193))
 - SWT マルチスケールのレベルラベリングを修正し, L1=高周波, LN=低周波に変更. ([#194](https://github.com/kurorosu/pochivision/pull/194))
-- SWT `multiscale=False` 時のレベル選択と docstring を明確化 (level 1, 高周波詳細). (NA.)
+- SWT `multiscale=False` 時のレベル選択と docstring を明確化 (level 1, 高周波詳細). ([#195](https://github.com/kurorosu/pochivision/pull/195))
+- SWT の dtype 正規化を統一し, uint8 と float32 (0-255) で同じ特徴量が得られるよう修正. (NA.)
 
 ### Removed
 - 無し

--- a/pochivision/feature_extractors/swt_frequency.py
+++ b/pochivision/feature_extractors/swt_frequency.py
@@ -316,10 +316,10 @@ class SWTFrequencyExtractor(BaseFeatureExtractor):
             # SWT変換のために画像サイズを調整（奇数サイズを偶数サイズに）
             gray_image = self._adjust_image_size_for_swt(gray_image)
 
-            if np.issubdtype(gray_image.dtype, np.integer):
-                gray_image = gray_image.astype(np.float32) / 255.0
-            else:
-                gray_image = gray_image.astype(np.float32)
+            # dtype に関わらず同じ画像から同じ特徴量が得られるよう [0, 1] に統一
+            gray_image = gray_image.astype(np.float32)
+            if gray_image.max() > 1.0:
+                gray_image = gray_image / 255.0
 
             # 設定値を使用してSWT変換を実行
             max_level = self.config.get("max_level", 1)


### PR DESCRIPTION
## Summary

- dtype 判定ベースの分岐 (`np.issubdtype`) を値ベースの判定 (`max() > 1.0`) に変更し, uint8 と float32 (0-255) で同じ特徴量が得られるよう修正した.

## Related Issue

Closes #189

## Changes

- `pochivision/feature_extractors/swt_frequency.py`:
  - `np.issubdtype(dtype, np.integer)` による分岐を削除
  - `gray_image.max() > 1.0` の場合に `/255.0` で [0, 1] に正規化

## Code Changes

```python
# 修正前: dtype で分岐 → 同じ画像でも型が違うと結果が変わる
if np.issubdtype(gray_image.dtype, np.integer):
    gray_image = gray_image.astype(np.float32) / 255.0
else:
    gray_image = gray_image.astype(np.float32)

# 修正後: 値ベースで判定 → 常に同じ結果
gray_image = gray_image.astype(np.float32)
if gray_image.max() > 1.0:
    gray_image = gray_image / 255.0
```

## Test Plan

- [x] uint8 と float32 (0-255) で同じ特徴量が得られることを確認
- [x] `uv run pytest` で全 347 テストがパス

## Checklist

- [x] dtype に関わらず同じ画像から同じ特徴量が返る
- [x] `uv run pytest` が通る