### PR TITLE
fix: SWT のエラーハンドリングを LogManager + raise に統一

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@
 - SWT エントロピー計算を `np.histogram` から `np.bincount` ベースに変更し, 狭い値域でのクラッシュを解消. ([#193](https://github.com/kurorosu/pochivision/pull/193))
 - SWT マルチスケールのレベルラベリングを修正し, L1=高周波, LN=低周波に変更. ([#194](https://github.com/kurorosu/pochivision/pull/194))
 - SWT `multiscale=False` 時のレベル選択と docstring を明確化 (level 1, 高周波詳細). ([#195](https://github.com/kurorosu/pochivision/pull/195))
-- SWT の dtype 正規化を統一し, uint8 と float32 (0-255) で同じ特徴量が得られるよう修正. (NA.)
+- SWT の dtype 正規化を統一し, uint8 と float32 (0-255) で同じ特徴量が得られるよう修正. ([#196](https://github.com/kurorosu/pochivision/pull/196))
+- SWT の `except Exception` を `LogManager` ログ出力 + `raise` に変更し, FFT/GLCM/HLAC と統一. (NA.)
 
 ### Removed
 - 無し

--- a/pochivision/feature_extractors/swt_frequency.py
+++ b/pochivision/feature_extractors/swt_frequency.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Optional, Union
 import numpy as np
 import pywt
 
+from pochivision.capturelib.log_manager import LogManager
 from pochivision.processors.resize import ResizeProcessor
 from pochivision.utils.image import to_grayscale
 
@@ -348,17 +349,9 @@ class SWTFrequencyExtractor(BaseFeatureExtractor):
 
             return features
 
-        except Exception as e:
-            # より詳細なエラーメッセージを提供
-            max_level = self.config.get("max_level", 1)
-
-            error_msg = f"SWT特徴量抽出中にエラーが発生しました: {str(e)}"
-            error_msg += f" (画像サイズ: {image.shape})"
-            if "gray_image" in locals():
-                error_msg += f" (調整後サイズ: {gray_image.shape})"
-            error_msg += f" (設定レベル: {max_level})"
-
-            raise RuntimeError(error_msg) from e
+        except Exception:
+            LogManager().get_logger().exception("SWT feature extraction failed")
+            raise
 
     @staticmethod
     def get_default_config() -> Dict[str, Any]:


### PR DESCRIPTION
## Summary

- `except Exception` の `RuntimeError` ラップを削除し, `LogManager` でログ出力後に元の例外を `raise` するよう変更した.
- 以下の修正済み抽出器と同じパターンに統一:
  - FFT ([#150](https://github.com/kurorosu/pochivision/pull/150))
  - GLCM ([#161](https://github.com/kurorosu/pochivision/pull/161))
  - HLAC ([#174](https://github.com/kurorosu/pochivision/pull/174))

## Related Issue

Closes #190

## Changes

- `pochivision/feature_extractors/swt_frequency.py`:
  - `RuntimeError` ラップ + 詳細メッセージ構築 → `LogManager().get_logger().exception()` + `raise`
  - `LogManager` のインポートを追加

## Test Plan

- [x] `uv run pytest` で全 347 テストがパス

## Checklist

- [x] 元の例外型が保持される
- [x] エラーがログに出力される
- [x] `uv run pytest` が通る