### PR TITLE
refactor: 振る舞いテスト用ダミー画像を DummyImages クラスに共通化

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - 無し
 
 ### Changed
-- 無し
+- 振る舞いテスト用ダミー画像を `tests/extractors/conftest.py` の `DummyImages` クラスに共通化. FFT/GLCM/HLAC/SWT の重複ヘルパーを削除. (NA.)
 
 ### Fixed
 - 無し

--- a/pochivision/capturelib/config_schema.py
+++ b/pochivision/capturelib/config_schema.py
@@ -6,7 +6,7 @@
 
 from typing import Dict, List, Optional
 
-from pydantic import BaseModel, Field, StrictFloat, StrictInt, StrictStr
+from pydantic import BaseModel, ConfigDict, Field, StrictFloat, StrictInt, StrictStr
 
 
 class GaussianBlurParams(BaseModel):
@@ -67,11 +67,7 @@ class BilateralFilterParams(BaseModel):
     sigma_color: StrictFloat = Field(alias="sigmaColor")
     sigma_space: StrictFloat = Field(alias="sigmaSpace")
 
-    class Config:
-        """Pydanticの設定クラス."""
-
-        populate_by_name = True  # 名前またはエイリアスでフィールドにアクセス可能にする
-        allow_population_by_field_name = True  # 後方互換性のため
+    model_config = ConfigDict(populate_by_name=True)
 
 
 class MotionBlurParams(BaseModel):
@@ -104,7 +100,7 @@ class CLAHEParams(BaseModel):
     color_mode: Optional[StrictStr] = Field(default="gray", pattern="^(gray|lab|bgr)$")
     clip_limit: Optional[StrictFloat] = Field(default=2.0, gt=0)
     tile_grid_size: Optional[List[StrictInt]] = Field(
-        default=[8, 8], min_items=2, max_items=2, each_item_gt=0
+        default=[8, 8], min_length=2, max_length=2
     )
 
 
@@ -130,10 +126,10 @@ class ContourParams(BaseModel):
     select_mode: Optional[StrictStr] = Field(default="rank", pattern="^(rank|all)$")
     contour_rank: Optional[StrictInt] = Field(default=0, ge=0)
     outside_color: Optional[List[StrictInt]] = Field(
-        default=[0, 0, 0], min_items=3, max_items=3
+        default=[0, 0, 0], min_length=3, max_length=3
     )
     inside_color: Optional[List[StrictInt]] = Field(
-        default=[255, 255, 255], min_items=3, max_items=3
+        default=[255, 255, 255], min_length=3, max_length=3
     )
 
 

--- a/tests/extractors/conftest.py
+++ b/tests/extractors/conftest.py
@@ -1,0 +1,60 @@
+"""特徴量抽出器テスト用の共通ダミー画像ヘルパー."""
+
+import numpy as np
+
+
+class DummyImages:
+    """振る舞いテスト用のダミー画像を生成するヘルパークラス."""
+
+    @staticmethod
+    def uniform(size: int = 64, value: int = 128) -> np.ndarray:
+        """単色画像."""
+        return np.full((size, size), value, dtype=np.uint8)
+
+    @staticmethod
+    def white(size: int = 64) -> np.ndarray:
+        """全白画像."""
+        return np.full((size, size), 255, dtype=np.uint8)
+
+    @staticmethod
+    def black(size: int = 64) -> np.ndarray:
+        """全黒画像."""
+        return np.zeros((size, size), dtype=np.uint8)
+
+    @staticmethod
+    def gradient(size: int = 64) -> np.ndarray:
+        """滑らかな垂直グラデーション."""
+        img = np.zeros((size, size), dtype=np.uint8)
+        for i in range(size):
+            img[i, :] = int(i * 255 / (size - 1))
+        return img
+
+    @staticmethod
+    def h_stripe(size: int = 64, period: int = 4) -> np.ndarray:
+        """水平ストライプ."""
+        img = np.zeros((size, size), dtype=np.uint8)
+        for k in range(period // 2):
+            img[k::period, :] = 255
+        return img
+
+    @staticmethod
+    def v_stripe(size: int = 64, period: int = 4) -> np.ndarray:
+        """垂直ストライプ."""
+        img = np.zeros((size, size), dtype=np.uint8)
+        for k in range(period // 2):
+            img[:, k::period] = 255
+        return img
+
+    @staticmethod
+    def checker(size: int = 64) -> np.ndarray:
+        """チェッカーボード."""
+        img = np.zeros((size, size), dtype=np.uint8)
+        img[0::2, 0::2] = 255
+        img[1::2, 1::2] = 255
+        return img
+
+    @staticmethod
+    def random(size: int = 64, seed: int = 42) -> np.ndarray:
+        """ランダム画像 (シード固定)."""
+        np.random.seed(seed)
+        return np.random.randint(0, 256, (size, size), dtype=np.uint8)

--- a/tests/extractors/test_fft_features.py
+++ b/tests/extractors/test_fft_features.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 
 from pochivision.feature_extractors.fft_frequency import FFTFrequencyExtractor
+from tests.extractors.conftest import DummyImages
 
 
 class TestFFTFrequencyExtractor:
@@ -459,60 +460,21 @@ class TestFFTFrequencyExtractor:
             assert not np.isnan(value)
             assert not np.isinf(value)
 
-    # --- 振る舞いテスト用の共通画像 ---
-
-    @staticmethod
-    def _make_gradient(size: int = 64) -> np.ndarray:
-        """低周波: 滑らかな垂直グラデーション."""
-        img = np.zeros((size, size), dtype=np.uint8)
-        for i in range(size):
-            img[i, :] = int(i * 255 / (size - 1))
-        return img
-
-    @staticmethod
-    def _make_h_stripe(size: int = 64, period: int = 4) -> np.ndarray:
-        """中周波: 水平ストライプ (period px 周期)."""
-        img = np.zeros((size, size), dtype=np.uint8)
-        for k in range(period // 2):
-            img[k::period, :] = 255
-        return img
-
-    @staticmethod
-    def _make_v_stripe(size: int = 64, period: int = 4) -> np.ndarray:
-        """中周波: 垂直ストライプ (period px 周期)."""
-        img = np.zeros((size, size), dtype=np.uint8)
-        for k in range(period // 2):
-            img[:, k::period] = 255
-        return img
-
-    @staticmethod
-    def _make_checker(size: int = 64) -> np.ndarray:
-        """高周波: チェッカーボード."""
-        img = np.zeros((size, size), dtype=np.uint8)
-        img[0::2, 0::2] = 255
-        img[1::2, 1::2] = 255
-        return img
-
-    @staticmethod
-    def _make_uniform(size: int = 64, value: int = 128) -> np.ndarray:
-        """単色画像."""
-        return np.full((size, size), value, dtype=np.uint8)
-
     # --- band_energy ---
 
     def test_gradient_energy_concentrated_in_low_band(self):
         """グラデーション画像はエネルギーの 95% 以上が低帯域に集中."""
-        features = self.extractor.extract(self._make_gradient())
+        features = self.extractor.extract(DummyImages.gradient())
         assert features["band_1_0.00_0.10"] > 0.95
 
     def test_stripe_energy_majority_in_mid_band(self):
         """4px ストライプは中帯域にエネルギーの 50% 以上が集中."""
-        features = self.extractor.extract(self._make_h_stripe())
+        features = self.extractor.extract(DummyImages.h_stripe())
         assert features["band_2_0.10_0.30"] > 0.5
 
     def test_stripe_low_band_not_dominant(self):
         """ストライプの低帯域エネルギーは 50% 未満 (DC 除外の効果)."""
-        features = self.extractor.extract(self._make_h_stripe())
+        features = self.extractor.extract(DummyImages.h_stripe())
         assert features["band_1_0.00_0.10"] < 0.5
 
     def test_band_energies_sum_to_one_square(self):
@@ -543,19 +505,19 @@ class TestFFTFrequencyExtractor:
 
     def test_gradient_high_low_ratio_near_zero(self):
         """グラデーション画像の high_low_ratio は ~0 (低周波のみ)."""
-        features = self.extractor.extract(self._make_gradient())
+        features = self.extractor.extract(DummyImages.gradient())
         assert features["high_low_ratio"] < 0.01
 
     def test_stripe_high_low_ratio_above_one(self):
         """ストライプ画像の high_low_ratio は > 1 (高周波 > 低周波)."""
-        features = self.extractor.extract(self._make_h_stripe())
+        features = self.extractor.extract(DummyImages.h_stripe())
         assert features["high_low_ratio"] > 1.0
 
     # --- spectral_std ---
 
     def test_spectral_std_uniform_is_near_zero(self):
         """単色画像のスペクトル標準偏差はランダム画像より十分小さい."""
-        features_uniform = self.extractor.extract(self._make_uniform())
+        features_uniform = self.extractor.extract(DummyImages.uniform())
         np.random.seed(42)
         features_random = self.extractor.extract(
             np.random.randint(0, 256, (64, 64), dtype=np.uint8)
@@ -575,41 +537,41 @@ class TestFFTFrequencyExtractor:
 
     def test_h_stripe_vertical_energy_above_70pct(self):
         """水平ストライプの vertical_energy は 70% 以上."""
-        features = self.extractor.extract(self._make_h_stripe())
+        features = self.extractor.extract(DummyImages.h_stripe())
         assert features["vertical_energy"] > 0.7
 
     def test_h_stripe_vertical_greater_than_horizontal(self):
         """水平ストライプは vertical_energy > horizontal_energy."""
-        features = self.extractor.extract(self._make_h_stripe())
+        features = self.extractor.extract(DummyImages.h_stripe())
         assert features["vertical_energy"] > features["horizontal_energy"]
 
     def test_v_stripe_horizontal_greater_than_vertical(self):
         """垂直ストライプは horizontal_energy > vertical_energy."""
-        features = self.extractor.extract(self._make_v_stripe())
+        features = self.extractor.extract(DummyImages.v_stripe())
         assert features["horizontal_energy"] > features["vertical_energy"]
 
     # --- spectral_centroid ---
 
     def test_gradient_centroid_below_005(self):
         """グラデーション画像のスペクトル重心は < 0.05 (低周波に集中)."""
-        features = self.extractor.extract(self._make_gradient())
+        features = self.extractor.extract(DummyImages.gradient())
         assert features["spectral_centroid"] < 0.05
 
     def test_stripe_centroid_near_025(self):
         """ストライプ画像のスペクトル重心は 0.1-0.3 付近."""
-        features = self.extractor.extract(self._make_h_stripe())
+        features = self.extractor.extract(DummyImages.h_stripe())
         assert 0.1 < features["spectral_centroid"] < 0.3
 
     # --- num_peaks / max_peak_amp ---
 
     def test_num_peaks_positive_for_stripe(self):
         """ストライプ画像のピーク数は 1 以上."""
-        features = self.extractor.extract(self._make_h_stripe())
+        features = self.extractor.extract(DummyImages.h_stripe())
         assert features["num_peaks"] >= 1
 
     def test_max_peak_amp_positive(self):
         """max_peak_amp は非ゼロ画像で正の値."""
-        features = self.extractor.extract(self._make_h_stripe())
+        features = self.extractor.extract(DummyImages.h_stripe())
         assert features["max_peak_amp"] > 0
 
     # --- spectral_entropy ---
@@ -628,15 +590,15 @@ class TestFFTFrequencyExtractor:
         features_random = self.extractor.extract(
             np.random.randint(0, 256, (64, 64), dtype=np.uint8)
         )
-        features_stripe = self.extractor.extract(self._make_h_stripe())
+        features_stripe = self.extractor.extract(DummyImages.h_stripe())
         assert features_stripe["spectral_entropy"] < features_random["spectral_entropy"]
 
     # --- directional_entropy ---
 
     def test_directional_entropy_h_stripe_more_vertical(self):
         """水平ストライプは垂直方向のエントロピーが垂直ストライプより大きい."""
-        features_h = self.extractor.extract(self._make_h_stripe())
-        features_v = self.extractor.extract(self._make_v_stripe())
+        features_h = self.extractor.extract(DummyImages.h_stripe())
+        features_v = self.extractor.extract(DummyImages.v_stripe())
         assert features_h["vertical_entropy"] > features_v["vertical_entropy"]
 
     # --- band_entropy ---

--- a/tests/extractors/test_glcm_texture_extractor.py
+++ b/tests/extractors/test_glcm_texture_extractor.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 
 from pochivision.feature_extractors.glcm_texture import GLCMTextureExtractor
+from tests.extractors.conftest import DummyImages
 
 
 class TestGLCMTextureExtractor:
@@ -541,29 +542,6 @@ class TestGLCMBehavior:
         "resize_shape": None,
     }
 
-    @staticmethod
-    def _make_uniform(size: int = 64, value: int = 128) -> np.ndarray:
-        return np.full((size, size), value, dtype=np.uint8)
-
-    @staticmethod
-    def _make_checker(size: int = 64) -> np.ndarray:
-        img = np.zeros((size, size), dtype=np.uint8)
-        img[0::2, 0::2] = 255
-        img[1::2, 1::2] = 255
-        return img
-
-    @staticmethod
-    def _make_gradient(size: int = 64) -> np.ndarray:
-        img = np.zeros((size, size), dtype=np.uint8)
-        for i in range(size):
-            img[i, :] = int(i * 255 / (size - 1))
-        return img
-
-    @staticmethod
-    def _make_random(size: int = 64) -> np.ndarray:
-        np.random.seed(42)
-        return np.random.randint(0, 256, (size, size), dtype=np.uint8)
-
     def setup_method(self):
         """テストメソッドごとに extractor を初期化."""
         self.ext = GLCMTextureExtractor(config=self._CONFIG)
@@ -572,31 +550,31 @@ class TestGLCMBehavior:
 
     def test_uniform_contrast_is_zero(self):
         """均一画像の contrast は全方向で 0."""
-        f = self.ext.extract(self._make_uniform())
+        f = self.ext.extract(DummyImages.uniform())
         for angle in [0, 45, 90, 135]:
             assert f[f"contrast_1_{angle}"] == 0.0
 
     def test_uniform_homogeneity_is_one(self):
         """均一画像の homogeneity は全方向で 1.0."""
-        f = self.ext.extract(self._make_uniform())
+        f = self.ext.extract(DummyImages.uniform())
         for angle in [0, 45, 90, 135]:
             assert f[f"homogeneity_1_{angle}"] == 1.0
 
     def test_uniform_energy_is_one(self):
         """均一画像の energy は全方向で 1.0."""
-        f = self.ext.extract(self._make_uniform())
+        f = self.ext.extract(DummyImages.uniform())
         for angle in [0, 45, 90, 135]:
             assert f[f"energy_1_{angle}"] == 1.0
 
     def test_uniform_asm_is_one(self):
         """均一画像の ASM は全方向で 1.0."""
-        f = self.ext.extract(self._make_uniform())
+        f = self.ext.extract(DummyImages.uniform())
         for angle in [0, 45, 90, 135]:
             assert f[f"ASM_1_{angle}"] == 1.0
 
     def test_uniform_dissimilarity_is_zero(self):
         """均一画像の dissimilarity は全方向で 0."""
-        f = self.ext.extract(self._make_uniform())
+        f = self.ext.extract(DummyImages.uniform())
         for angle in [0, 45, 90, 135]:
             assert f[f"dissimilarity_1_{angle}"] == 0.0
 
@@ -604,19 +582,19 @@ class TestGLCMBehavior:
 
     def test_checker_contrast_high_in_axis_directions(self):
         """チェッカーボードは 0 度と 90 度で contrast が非常に高い (65025)."""
-        f = self.ext.extract(self._make_checker())
+        f = self.ext.extract(DummyImages.checker())
         assert f["contrast_1_0"] > 60000
         assert f["contrast_1_90"] > 60000
 
     def test_checker_contrast_zero_in_diagonal(self):
         """チェッカーボードは 45 度と 135 度で contrast が 0."""
-        f = self.ext.extract(self._make_checker())
+        f = self.ext.extract(DummyImages.checker())
         assert f["contrast_1_45"] < 1.0
         assert f["contrast_1_135"] < 1.0
 
     def test_checker_correlation_negative_in_axis(self):
         """チェッカーボードは 0 度と 90 度で correlation が -1 (反相関)."""
-        f = self.ext.extract(self._make_checker())
+        f = self.ext.extract(DummyImages.checker())
         assert f["correlation_1_0"] < -0.9
         assert f["correlation_1_90"] < -0.9
 
@@ -624,52 +602,52 @@ class TestGLCMBehavior:
 
     def test_gradient_horizontal_contrast_zero(self):
         """垂直グラデーションは水平方向 (0 度) の contrast が 0."""
-        f = self.ext.extract(self._make_gradient())
+        f = self.ext.extract(DummyImages.gradient())
         assert f["contrast_1_0"] == 0.0
 
     def test_gradient_horizontal_homogeneity_one(self):
         """垂直グラデーションは水平方向 (0 度) の homogeneity が 1.0."""
-        f = self.ext.extract(self._make_gradient())
+        f = self.ext.extract(DummyImages.gradient())
         assert f["homogeneity_1_0"] == 1.0
 
     def test_gradient_horizontal_correlation_one(self):
         """垂直グラデーションは水平方向 (0 度) の correlation が ~1.0."""
-        f = self.ext.extract(self._make_gradient())
+        f = self.ext.extract(DummyImages.gradient())
         assert f["correlation_1_0"] > 0.99
 
     def test_gradient_vertical_contrast_positive(self):
         """垂直グラデーションは垂直方向 (90 度) の contrast が > 0."""
-        f = self.ext.extract(self._make_gradient())
+        f = self.ext.extract(DummyImages.gradient())
         assert f["contrast_1_90"] > 1.0
 
     # --- ランダム vs 均一 ---
 
     def test_random_contrast_higher_than_uniform(self):
         """ランダム画像の contrast は均一画像より大きい."""
-        f_rand = self.ext.extract(self._make_random())
-        f_uni = self.ext.extract(self._make_uniform())
+        f_rand = self.ext.extract(DummyImages.random())
+        f_uni = self.ext.extract(DummyImages.uniform())
         assert f_rand["contrast_1_0"] > f_uni["contrast_1_0"]
 
     def test_random_energy_lower_than_uniform(self):
         """ランダム画像の energy は均一画像より小さい."""
-        f_rand = self.ext.extract(self._make_random())
-        f_uni = self.ext.extract(self._make_uniform())
+        f_rand = self.ext.extract(DummyImages.random())
+        f_uni = self.ext.extract(DummyImages.uniform())
         assert f_rand["energy_1_0"] < f_uni["energy_1_0"]
 
     def test_random_homogeneity_lower_than_uniform(self):
         """ランダム画像の homogeneity は均一画像より小さい."""
-        f_rand = self.ext.extract(self._make_random())
-        f_uni = self.ext.extract(self._make_uniform())
+        f_rand = self.ext.extract(DummyImages.random())
+        f_uni = self.ext.extract(DummyImages.uniform())
         assert f_rand["homogeneity_1_0"] < f_uni["homogeneity_1_0"]
 
     # --- ランダム: 閾値テスト ---
 
     def test_random_energy_near_zero(self):
         """ランダム画像の energy は非常に小さい (< 0.05)."""
-        f = self.ext.extract(self._make_random())
+        f = self.ext.extract(DummyImages.random())
         assert f["energy_1_0"] < 0.05
 
     def test_random_contrast_above_1000(self):
         """ランダム画像の contrast は > 1000."""
-        f = self.ext.extract(self._make_random())
+        f = self.ext.extract(DummyImages.random())
         assert f["contrast_1_0"] > 1000

--- a/tests/extractors/test_hlac_features.py
+++ b/tests/extractors/test_hlac_features.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest  # noqa: F401
 
 from pochivision.feature_extractors import HLACTextureExtractor, get_feature_extractor
+from tests.extractors.conftest import DummyImages
 
 
 def test_hlac_texture_basic():
@@ -505,54 +506,27 @@ class TestHLACBehavior:
         "aspect_ratio_mode": "width",
     }
 
-    @staticmethod
-    def _make_white(size: int = 32) -> np.ndarray:
-        return np.full((size, size), 255, dtype=np.uint8)
-
-    @staticmethod
-    def _make_black(size: int = 32) -> np.ndarray:
-        return np.zeros((size, size), dtype=np.uint8)
-
-    @staticmethod
-    def _make_checker(size: int = 32) -> np.ndarray:
-        img = np.zeros((size, size), dtype=np.uint8)
-        img[0::2, 0::2] = 255
-        img[1::2, 1::2] = 255
-        return img
-
-    @staticmethod
-    def _make_h_stripe(size: int = 32, period: int = 4) -> np.ndarray:
-        img = np.zeros((size, size), dtype=np.uint8)
-        for k in range(period // 2):
-            img[k::period, :] = 255
-        return img
-
-    @staticmethod
-    def _make_random(size: int = 32) -> np.ndarray:
-        np.random.seed(42)
-        return np.random.randint(0, 256, (size, size), dtype=np.uint8)
-
     # --- 全白画像 ---
 
     def test_white_0th_order_equals_valid_pixels(self):
         """全白画像の 0th order は valid 領域のピクセル数と一致."""
         ext = HLACTextureExtractor(config=self._CONFIG_RAW)
-        f = ext.extract(self._make_white())
+        f = ext.extract(DummyImages.white(32))
         # 32x32 画像で mode="valid" + 3x3 カーネル → 30x30 = 900
         assert f["hlac_feature_00"] == 900
 
     def test_white_1st_order_all_equal(self):
         """全白画像の 1st order は全方向同じ値."""
         ext = HLACTextureExtractor(config=self._CONFIG_RAW)
-        f = ext.extract(self._make_white())
+        f = ext.extract(DummyImages.white(32))
         values = [f[f"hlac_feature_{i:02d}"] for i in range(1, 9)]
         assert len(set(values)) == 1  # 全方向同値
 
     def test_white_equals_black(self):
         """全白と全黒は adaptive 二値化後に同じパターンになる."""
         ext = HLACTextureExtractor(config=self._CONFIG_RAW)
-        fw = ext.extract(self._make_white())
-        fb = ext.extract(self._make_black())
+        fw = ext.extract(DummyImages.white(32))
+        fb = ext.extract(DummyImages.black(32))
         for i in range(37):
             assert fw[f"hlac_feature_{i:02d}"] == fb[f"hlac_feature_{i:02d}"]
 
@@ -561,7 +535,7 @@ class TestHLACBehavior:
     def test_checker_1st_order_axis_zero(self):
         """チェッカーボードの 1st order は軸方向 (feature_01,03,05,07) がゼロ."""
         ext = HLACTextureExtractor(config=self._CONFIG_RAW)
-        f = ext.extract(self._make_checker())
+        f = ext.extract(DummyImages.checker(32))
         # offsets: 01=(0,-1), 03=(-1,0), 05=(0,1), 07=(1,0) が軸方向
         for i in [1, 3, 5, 7]:
             assert f[f"hlac_feature_{i:02d}"] == 0
@@ -569,7 +543,7 @@ class TestHLACBehavior:
     def test_checker_1st_order_diagonal_nonzero(self):
         """チェッカーボードの 1st order は対角方向 (feature_02,04,06,08) が非ゼロ."""
         ext = HLACTextureExtractor(config=self._CONFIG_RAW)
-        f = ext.extract(self._make_checker())
+        f = ext.extract(DummyImages.checker(32))
         for i in [2, 4, 6, 8]:
             assert f[f"hlac_feature_{i:02d}"] > 0
 
@@ -578,7 +552,7 @@ class TestHLACBehavior:
     def test_h_stripe_vertical_direction_highest(self):
         """水平ストライプは垂直方向 (feature_03, 07) の 1st order が最大."""
         ext = HLACTextureExtractor(config=self._CONFIG_RAW)
-        f = ext.extract(self._make_h_stripe())
+        f = ext.extract(DummyImages.h_stripe(32))
         # feature_03=(-1,0)上, feature_07=(1,0)下 が垂直方向
         vertical = f["hlac_feature_03"]
         horizontal = f["hlac_feature_01"]  # (0,-1)左
@@ -589,7 +563,7 @@ class TestHLACBehavior:
     def test_random_1st_order_nearly_uniform(self):
         """ランダム画像の 1st order は全方向ほぼ均等."""
         ext = HLACTextureExtractor(config=self._CONFIG_RAW)
-        f = ext.extract(self._make_random())
+        f = ext.extract(DummyImages.random(32))
         values = [f[f"hlac_feature_{i:02d}"] for i in range(1, 9)]
         mean_val = sum(values) / len(values)
         for v in values:
@@ -600,8 +574,8 @@ class TestHLACBehavior:
     def test_checker_differs_from_random(self):
         """チェッカーボードとランダムの特徴量が区別可能."""
         ext = HLACTextureExtractor(config=self._CONFIG_NORM)
-        fc = ext.extract(self._make_checker())
-        fr = ext.extract(self._make_random())
+        fc = ext.extract(DummyImages.checker(32))
+        fr = ext.extract(DummyImages.random(32))
         # チェッカーボードの軸方向 1st order = 0, ランダムは > 0
         assert fc["hlac_feature_01"] == 0
         assert fr["hlac_feature_01"] > 0
@@ -611,14 +585,14 @@ class TestHLACBehavior:
     def test_normalized_sum_is_one(self):
         """正規化時の全特徴量の合計は ~1.0."""
         ext = HLACTextureExtractor(config=self._CONFIG_NORM)
-        f = ext.extract(self._make_random())
+        f = ext.extract(DummyImages.random(32))
         total = sum(f.values())
         assert 0.99 <= total <= 1.01
 
     def test_normalized_0th_less_than_one(self):
         """正規化時の 0th order は 1.0 未満."""
         ext = HLACTextureExtractor(config=self._CONFIG_NORM)
-        f = ext.extract(self._make_random())
+        f = ext.extract(DummyImages.random(32))
         assert f["hlac_feature_00"] < 1.0
 
     # --- 水平 vs 垂直ストライプ ---
@@ -630,7 +604,7 @@ class TestHLACBehavior:
         v_stripe[:, 0::4] = 255
         v_stripe[:, 1::4] = 255
 
-        fh = ext.extract(self._make_h_stripe())
+        fh = ext.extract(DummyImages.h_stripe(32))
         fv = ext.extract(v_stripe)
         # 水平ストライプは feature_03 (上) が高い, 垂直ストライプは feature_01 (左) が高い
         assert fh["hlac_feature_03"] > fh["hlac_feature_01"]

--- a/tests/extractors/test_swt_frequency.py
+++ b/tests/extractors/test_swt_frequency.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest  # noqa: F401
 
 from pochivision.feature_extractors.swt_frequency import SWTFrequencyExtractor
+from tests.extractors.conftest import DummyImages
 
 
 class TestSWTFrequencyExtractor:
@@ -416,29 +417,6 @@ class TestSWTBehavior:
         "aspect_ratio_mode": "width",
     }
 
-    @staticmethod
-    def _make_uniform(size: int = 64, value: int = 128) -> np.ndarray:
-        return np.full((size, size), value, dtype=np.uint8)
-
-    @staticmethod
-    def _make_h_stripe(size: int = 64) -> np.ndarray:
-        img = np.zeros((size, size), dtype=np.uint8)
-        img[0::4, :] = 255
-        img[1::4, :] = 255
-        return img
-
-    @staticmethod
-    def _make_v_stripe(size: int = 64) -> np.ndarray:
-        img = np.zeros((size, size), dtype=np.uint8)
-        img[:, 0::4] = 255
-        img[:, 1::4] = 255
-        return img
-
-    @staticmethod
-    def _make_random(size: int = 64) -> np.ndarray:
-        np.random.seed(42)
-        return np.random.randint(0, 256, (size, size), dtype=np.uint8)
-
     def setup_method(self):
         """テストメソッドごとに extractor を初期化."""
         self.ext = SWTFrequencyExtractor(config=self._CONFIG)
@@ -447,14 +425,14 @@ class TestSWTBehavior:
 
     def test_uniform_detail_energy_zero(self):
         """均一画像の detail energy (LH, HL, HH) は全てゼロ."""
-        f = self.ext.extract(self._make_uniform())
+        f = self.ext.extract(DummyImages.uniform())
         assert f["L1_energy_lh"] == 0.0
         assert f["L1_energy_hl"] == 0.0
         assert f["L1_energy_hh"] == 0.0
 
     def test_uniform_entropy_zero(self):
         """均一画像のエントロピーは全てゼロ."""
-        f = self.ext.extract(self._make_uniform())
+        f = self.ext.extract(DummyImages.uniform())
         assert f["L1_entropy_ll"] == 0.0
         assert f["L1_entropy_lh"] == 0.0
         assert f["L1_entropy_hl"] == 0.0
@@ -462,7 +440,7 @@ class TestSWTBehavior:
 
     def test_uniform_std_zero(self):
         """均一画像の detail std は全てゼロ."""
-        f = self.ext.extract(self._make_uniform())
+        f = self.ext.extract(DummyImages.uniform())
         assert f["L1_std_lh"] == 0.0
         assert f["L1_std_hl"] == 0.0
         assert f["L1_std_hh"] == 0.0
@@ -471,59 +449,59 @@ class TestSWTBehavior:
 
     def test_h_stripe_lh_energy_positive(self):
         """水平ストライプは LH (垂直エッジ検出) のエネルギーが正."""
-        f = self.ext.extract(self._make_h_stripe())
+        f = self.ext.extract(DummyImages.h_stripe())
         assert f["L1_energy_lh"] > 100
 
     def test_h_stripe_hl_energy_zero(self):
         """水平ストライプは HL (水平エッジ検出) のエネルギーがゼロ."""
-        f = self.ext.extract(self._make_h_stripe())
+        f = self.ext.extract(DummyImages.h_stripe())
         assert f["L1_energy_hl"] < 0.01
 
     def test_h_stripe_energy_ratio_h_is_one(self):
         """水平ストライプは energy_ratio_h (LH 方向) が ~1.0."""
-        f = self.ext.extract(self._make_h_stripe())
+        f = self.ext.extract(DummyImages.h_stripe())
         assert f["L1_energy_ratio_h"] > 0.95
 
     def test_h_stripe_energy_ratio_v_is_zero(self):
         """水平ストライプは energy_ratio_v (HL 方向) が ~0."""
-        f = self.ext.extract(self._make_h_stripe())
+        f = self.ext.extract(DummyImages.h_stripe())
         assert f["L1_energy_ratio_v"] < 0.05
 
     # --- 垂直ストライプ → LH=0, HL>0 (水平と逆) ---
 
     def test_v_stripe_hl_energy_positive(self):
         """垂直ストライプは HL (水平エッジ検出) のエネルギーが正."""
-        f = self.ext.extract(self._make_v_stripe())
+        f = self.ext.extract(DummyImages.v_stripe())
         assert f["L1_energy_hl"] > 100
 
     def test_v_stripe_lh_energy_zero(self):
         """垂直ストライプは LH (垂直エッジ検出) のエネルギーがゼロ."""
-        f = self.ext.extract(self._make_v_stripe())
+        f = self.ext.extract(DummyImages.v_stripe())
         assert f["L1_energy_lh"] < 0.01
 
     def test_v_stripe_energy_ratio_v_is_one(self):
         """垂直ストライプは energy_ratio_v (HL 方向) が ~1.0."""
-        f = self.ext.extract(self._make_v_stripe())
+        f = self.ext.extract(DummyImages.v_stripe())
         assert f["L1_energy_ratio_v"] > 0.95
 
     # --- ランダム ---
 
     def test_random_all_ratios_nonzero(self):
         """ランダム画像は全方向の energy_ratio が正."""
-        f = self.ext.extract(self._make_random())
+        f = self.ext.extract(DummyImages.random())
         assert f["L1_energy_ratio_h"] > 0.1
         assert f["L1_energy_ratio_v"] > 0.1
         assert f["L1_energy_ratio_d"] > 0.1
 
     def test_random_ratios_sum_near_one(self):
         """ランダム画像の energy_ratio の合計が ~1.0."""
-        f = self.ext.extract(self._make_random())
+        f = self.ext.extract(DummyImages.random())
         total = f["L1_energy_ratio_h"] + f["L1_energy_ratio_v"] + f["L1_energy_ratio_d"]
         assert 0.95 <= total <= 1.05
 
     def test_random_entropy_positive(self):
         """ランダム画像のエントロピーは全て正."""
-        f = self.ext.extract(self._make_random())
+        f = self.ext.extract(DummyImages.random())
         assert f["L1_entropy_ll"] > 1.0
         assert f["L1_entropy_lh"] > 1.0
         assert f["L1_entropy_hl"] > 1.0
@@ -562,8 +540,8 @@ class TestSWTBehavior:
 
     def test_h_stripe_v_stripe_symmetry(self):
         """水平と垂直ストライプの LH/HL エネルギーが入れ替わる."""
-        fh = self.ext.extract(self._make_h_stripe())
-        fv = self.ext.extract(self._make_v_stripe())
+        fh = self.ext.extract(DummyImages.h_stripe())
+        fv = self.ext.extract(DummyImages.v_stripe())
         # 水平ストライプの LH ≈ 垂直ストライプの HL
         assert abs(fh["L1_energy_lh"] - fv["L1_energy_hl"]) < 1.0
         # 水平ストライプの HL ≈ 垂直ストライプの LH


### PR DESCRIPTION
## Summary

- `tests/extractors/conftest.py` に `DummyImages` クラスを新設し, FFT/GLCM/HLAC/SWT の各テストクラスに重複していたダミー画像生成メソッドを統一した.

## Related Issue

Closes #207

## Changes

- `tests/extractors/conftest.py`: 新規作成. `DummyImages` クラスに `uniform`, `white`, `black`, `gradient`, `h_stripe`, `v_stripe`, `checker`, `random` を集約
- `tests/extractors/test_fft_features.py`: 5 つの `_make_*` メソッドを削除, `DummyImages.*()` に置換
- `tests/extractors/test_glcm_texture_extractor.py`: 4 つの `_make_*` メソッドを削除, `DummyImages.*()` に置換
- `tests/extractors/test_hlac_features.py`: 5 つの `_make_*` メソッドを削除, `DummyImages.*()` に置換
- `tests/extractors/test_swt_frequency.py`: 4 つの `_make_*` メソッドを削除, `DummyImages.*()` に置換

## Test Plan

- [x] `uv run pytest` で全 364 テストがパス

## Checklist

- [x] ダミー画像生成が 1 箇所に集約されている
- [x] 各テストクラスが `DummyImages` を使用している
- [x] 既存テストが全て通る