### PR TITLE
refactor: Pydantic V2 非推奨 API を移行しワーニングを解消

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 - 無し
 
 ### Changed
-- 振る舞いテスト用ダミー画像を `tests/extractors/conftest.py` の `DummyImages` クラスに共通化. FFT/GLCM/HLAC/SWT の重複ヘルパーを削除. (NA.)
+- 振る舞いテスト用ダミー画像を `tests/extractors/conftest.py` の `DummyImages` クラスに共通化. FFT/GLCM/HLAC/SWT の重複ヘルパーを削除. ([#215](https://github.com/kurorosu/pochivision/pull/215))
+- Pydantic V2 非推奨 API を移行 (`min_items` → `min_length`, `class Config` → `ConfigDict`, `each_item_gt` を削除). (NA.)
 
 ### Fixed
 - 無し
@@ -20,7 +21,7 @@
 ## [0.1.4] - 2026-03-29
 
 ### Added
-- `docs/swt_features.md` を追加. SWT 特徴量抽出器の全特徴量・パラメータ・設計制約の解説. (NA.)
+- `docs/swt_features.md` を追加. SWT 特徴量抽出器の全特徴量・パラメータ・設計制約の解説. ([#209](https://github.com/kurorosu/pochivision/pull/209))
 - SWT の振る舞いテスト 18 件を追加. ([#208](https://github.com/kurorosu/pochivision/pull/208))
 
 ### Changed


### PR DESCRIPTION
## Summary

- Pydantic V2 の非推奨 API を移行し, テスト実行時のワーニングを 9 → 0 に解消した.

## Related Issue

Closes #88

## Changes

- `pochivision/capturelib/config_schema.py`:
  - `min_items` → `min_length`, `max_items` → `max_length` (3 箇所)
  - `class Config` → `model_config = ConfigDict(populate_by_name=True)`
  - `each_item_gt=0` を削除 (CLAHEValidator で既に検証済み)
  - `ConfigDict` のインポートを追加

## Test Plan

- [x] `uv run pytest` で全 364 テストがパス
- [x] ワーニング 0 件

## Checklist

- [x] Pydantic V2 非推奨ワーニングが 0 件
- [x] `uv run pytest` が通る