### PR TITLE
fix: LBP ヒストグラム計算の var メソッド対応と正規化方法を修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Pydantic V2 非推奨 API を移行 (`min_items` → `min_length`, `class Config` → `ConfigDict`, `each_item_gt` を削除). (NA.)
 
 ### Fixed
-- 無し
+- LBP ヒストグラム計算を `density=True` から手動正規化に変更. var メソッドの値域と nri_uniform のビン数を修正. (NA.)
 
 ### Removed
 - 無し

--- a/pochivision/feature_extractors/lbp_texture.py
+++ b/pochivision/feature_extractors/lbp_texture.py
@@ -138,14 +138,29 @@ class LBPTextureExtractor(BaseFeatureExtractor):
 
             lbp = local_binary_pattern(gray_image, self.P, self.R, method=self.method)
 
-            # 理論的ビン数を使用 (画像内容に依存しない固定次元)
+            # メソッド別のビン数と範囲を設定
             if self.method == "uniform":
                 n_bins = self.P + 2
-            else:
+                hist_range = (0.0, float(n_bins))
+            elif self.method == "nri_uniform":
+                n_bins = self.P * (self.P - 1) + 3
+                hist_range = (0.0, float(n_bins))
+            elif self.method == "var":
+                # var メソッドは連続値を返すため, 実際の値域を使用
+                n_bins = 256
+                hist_range = (float(lbp.min()), float(lbp.max()) + 1e-10)
+            else:  # default, ror
                 n_bins = 2**self.P
+                hist_range = (0.0, float(n_bins))
+
+            # density=False + 手動正規化で確率分布 (和=1) を計算
             hist, _ = np.histogram(
-                lbp.ravel(), bins=n_bins, range=(0, n_bins), density=True
+                lbp.ravel(), bins=n_bins, range=hist_range, density=False
             )
+            hist = hist.astype(np.float64)
+            total = hist.sum()
+            if total > 0:
+                hist = hist / total
 
             results = self._calculate_statistics(hist, lbp)
 
@@ -318,14 +333,17 @@ class LBPTextureExtractor(BaseFeatureExtractor):
         # デフォルト設定でヒストグラムを含む場合
         default_config = LBPTextureExtractor.get_default_config()
         if default_config["include_histogram"]:
-            # uniform LBPの場合のビン数を計算
             P = default_config["P"]
             method = default_config["method"]
 
             if method == "uniform":
-                max_bins = P + 2  # uniform LBPの場合
+                max_bins = P + 2
+            elif method == "nri_uniform":
+                max_bins = P * (P - 1) + 3
+            elif method == "var":
+                max_bins = 256
             else:
-                max_bins = 2**P  # 通常のLBPの場合
+                max_bins = 2**P
 
             for i in range(max_bins):
                 feature_names.append(f"lbp_bin_{i}")
@@ -398,9 +416,13 @@ class LBPTextureExtractor(BaseFeatureExtractor):
             method = self.method
 
             if method == "uniform":
-                max_bins = P + 2  # uniform LBPの場合
+                max_bins = P + 2
+            elif method == "nri_uniform":
+                max_bins = P * (P - 1) + 3
+            elif method == "var":
+                max_bins = 256
             else:
-                max_bins = 2**P  # 通常のLBPの場合
+                max_bins = 2**P
 
             for i in range(max_bins):
                 feature_names.append(f"lbp_bin_{i}[ratio]")
@@ -426,14 +448,17 @@ class LBPTextureExtractor(BaseFeatureExtractor):
 
         # インスタンスの設定でヒストグラムを含む場合
         if self.include_histogram:
-            # uniform LBPの場合のビン数を計算
             P = self.P
             method = self.method
 
             if method == "uniform":
-                max_bins = P + 2  # uniform LBPの場合
+                max_bins = P + 2
+            elif method == "nri_uniform":
+                max_bins = P * (P - 1) + 3
+            elif method == "var":
+                max_bins = 256
             else:
-                max_bins = 2**P  # 通常のLBPの場合
+                max_bins = 2**P
 
             for i in range(max_bins):
                 feature_names.append(f"lbp_bin_{i}")
@@ -451,14 +476,17 @@ class LBPTextureExtractor(BaseFeatureExtractor):
 
         # インスタンスの設定でヒストグラムを含む場合
         if self.include_histogram:
-            # uniform LBPの場合のビン数を計算
             P = self.P
             method = self.method
 
             if method == "uniform":
-                max_bins = P + 2  # uniform LBPの場合
+                max_bins = P + 2
+            elif method == "nri_uniform":
+                max_bins = P * (P - 1) + 3
+            elif method == "var":
+                max_bins = 256
             else:
-                max_bins = 2**P  # 通常のLBPの場合
+                max_bins = 2**P
 
             for i in range(max_bins):
                 units[f"lbp_bin_{i}"] = "ratio"


### PR DESCRIPTION
## Summary

- `density=True` を `density=False` + 手動正規化に変更し, 確率密度ではなく確率分布 (和=1) を計算するよう修正した.
- `var` メソッドの値域を実際の LBP 値範囲に合わせ, `range=(0, n_bins)` 固定で特徴量が壊れる問題を修正した.
- `nri_uniform` メソッドのビン数を `P * (P - 1) + 3` に修正した.
- 全 5 箇所のビン数計算ロジックを統一した.

## Related Issue

Closes #199

## Changes

- `pochivision/feature_extractors/lbp_texture.py`:
  - `extract()`: `density=True` → `density=False` + `hist / hist.sum()` に変更
  - `extract()`: メソッド別のビン数と range を設定 (uniform, nri_uniform, var, default)
  - `get_base_feature_names()`, `get_feature_names_instance()`, `get_base_feature_names_instance()`, `get_feature_units_instance()`: ビン数計算を 4 メソッド対応に統一

## Code Changes

```python
# 修正前
n_bins = self.P + 2 if self.method == "uniform" else 2**self.P
hist, _ = np.histogram(lbp.ravel(), bins=n_bins, range=(0, n_bins), density=True)

# 修正後
if self.method == "uniform":
    n_bins = self.P + 2
    hist_range = (0, n_bins)
elif self.method == "nri_uniform":
    n_bins = self.P * (self.P - 1) + 3
    hist_range = (0, n_bins)
elif self.method == "var":
    n_bins = 256
    hist_range = (float(lbp.min()), float(lbp.max()) + 1e-10)
else:
    n_bins = 2**self.P
    hist_range = (0, n_bins)

hist, _ = np.histogram(lbp.ravel(), bins=n_bins, range=hist_range, density=False)
hist = hist.astype(np.float64)
total = hist.sum()
if total > 0:
    hist = hist / total
```

## Test Plan

- [x] `uv run pytest tests/extractors/test_lbp_features.py` で 10 テストがパス
- [x] `uv run pytest` で全 364 テストがパス

## Checklist

- [x] `var` メソッドで正しいヒストグラムが計算される
- [x] `nri_uniform` のビン数が `P * (P - 1) + 3`
- [x] `density=False` + 手動正規化で確率分布を計算
- [x] 全 5 箇所のビン数計算が統一されている
- [x] `uv run pytest` が通る