### PR TITLE
fix: LBP エントロピーを正規化し FFT/SWT と [0, 1] 範囲に統一

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,11 @@
 
 ### Changed
 - 振る舞いテスト用ダミー画像を `tests/extractors/conftest.py` の `DummyImages` クラスに共通化. FFT/GLCM/HLAC/SWT の重複ヘルパーを削除. ([#215](https://github.com/kurorosu/pochivision/pull/215))
-- Pydantic V2 非推奨 API を移行 (`min_items` → `min_length`, `class Config` → `ConfigDict`, `each_item_gt` を削除). (NA.)
+- Pydantic V2 非推奨 API を移行 (`min_items` → `min_length`, `class Config` → `ConfigDict`, `each_item_gt` を削除). ([#216](https://github.com/kurorosu/pochivision/pull/216))
 
 ### Fixed
-- LBP ヒストグラム計算を `density=True` から手動正規化に変更. var メソッドの値域と nri_uniform のビン数を修正. (NA.)
+- LBP ヒストグラム計算を `density=True` から手動正規化に変更. var メソッドの値域と nri_uniform のビン数を修正. ([#217](https://github.com/kurorosu/pochivision/pull/217))
+- LBP エントロピーを `log2(n_bins)` で正規化し [0, 1] 範囲に変更. 単位を `normalized` に統一. (NA.)
 
 ### Removed
 - 無し

--- a/pochivision/feature_extractors/lbp_texture.py
+++ b/pochivision/feature_extractors/lbp_texture.py
@@ -39,7 +39,7 @@ class LBPTextureExtractor(BaseFeatureExtractor):
         "lbp_std": "pattern_index",
         "lbp_skewness": "dimensionless",
         "lbp_kurtosis": "dimensionless",
-        "lbp_entropy": "bits",
+        "lbp_entropy": "normalized",
         "lbp_uniformity": "ratio",
     }
 
@@ -218,11 +218,12 @@ class LBPTextureExtractor(BaseFeatureExtractor):
                 kurtosis = 0.0
             results["lbp_kurtosis"] = float(kurtosis)
 
-            # エントロピー
-            # 0の値を除外してエントロピーを計算
+            # 正規化エントロピー [0, 1] (FFT/SWT と統一)
             hist_nonzero = hist[hist > 0]
-            if len(hist_nonzero) > 0:
-                entropy = -np.sum(hist_nonzero * np.log2(hist_nonzero))
+            if len(hist_nonzero) > 1:
+                raw_entropy = -np.sum(hist_nonzero * np.log2(hist_nonzero))
+                max_entropy = np.log2(len(hist))
+                entropy = raw_entropy / max_entropy if max_entropy > 0 else 0.0
             else:
                 entropy = 0.0
             results["lbp_entropy"] = float(entropy)

--- a/tests/extractors/test_lbp_features.py
+++ b/tests/extractors/test_lbp_features.py
@@ -327,7 +327,7 @@ def test_lbp_feature_names_and_config():
         "lbp_std": "pattern_index",
         "lbp_skewness": "dimensionless",
         "lbp_kurtosis": "dimensionless",
-        "lbp_entropy": "bits",
+        "lbp_entropy": "normalized",
         "lbp_uniformity": "ratio",
     }
 


### PR DESCRIPTION
## Summary

- LBP エントロピーを `log2(n_bins)` で正規化し, [0, 1] 範囲に変更した.
- FFT ([#148](https://github.com/kurorosu/pochivision/pull/148)) / SWT と同じ正規化方式に統一.
- 単位を `bits` → `normalized` に変更.

## Related Issue

Closes #200

## Changes

- `pochivision/feature_extractors/lbp_texture.py`:
  - `raw_entropy / log2(n_bins)` で正規化
  - `_FEATURE_UNITS` の `lbp_entropy` を `bits` → `normalized` に変更
- `tests/extractors/test_lbp_features.py`:
  - 単位アサーションを `normalized` に更新

## Code Changes

```python
# 修正前
entropy = -np.sum(hist_nonzero * np.log2(hist_nonzero))  # [0, log2(n_bins)]

# 修正後
raw_entropy = -np.sum(hist_nonzero * np.log2(hist_nonzero))
max_entropy = np.log2(len(hist))
entropy = raw_entropy / max_entropy  # [0, 1]
```

## Test Plan

- [x] `uv run pytest` で全 364 テストがパス

## Checklist

- [x] LBP エントロピーが [0, 1] 範囲
- [x] 単位が `normalized` に統一
- [x] `uv run pytest` が通る