### PR TITLE
fix: LBP lbp_uniformity を lbp_energy にリネームし GLCM と名称を統一

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@
 
 ### Fixed
 - LBP ヒストグラム計算を `density=True` から手動正規化に変更. var メソッドの値域と nri_uniform のビン数を修正. ([#217](https://github.com/kurorosu/pochivision/pull/217))
-- LBP エントロピーを `log2(n_bins)` で正規化し [0, 1] 範囲に変更. 単位を `normalized` に統一. (NA.)
+- LBP エントロピーを `log2(n_bins)` で正規化し [0, 1] 範囲に変更. 単位を `normalized` に統一. ([#218](https://github.com/kurorosu/pochivision/pull/218))
+- LBP `lbp_uniformity` を `lbp_energy` にリネームし GLCM の energy (ASM) と名称を統一. (NA.)
 
 ### Removed
 - 無し

--- a/pochivision/feature_extractors/lbp_texture.py
+++ b/pochivision/feature_extractors/lbp_texture.py
@@ -27,7 +27,7 @@ class LBPTextureExtractor(BaseFeatureExtractor):
        - 平均 [pattern index] 標準偏差 [pattern index]
        - 歪度 [dimensionless] 尖度 [dimensionless]
     - エントロピー: パターンの複雑さを表す [bits]
-    - 均一性: パターンの均一性を表す [ratio]
+    - energy: ヒストグラムのエネルギー (sum(p^2), GLCM の ASM と同一計算) [ratio]
     - 各LBPビンの正規化頻度（オプション） [ratio]
 
     設定により、近傍点数、半径、手法、画像リサイズなどを調整できます.
@@ -40,7 +40,7 @@ class LBPTextureExtractor(BaseFeatureExtractor):
         "lbp_skewness": "dimensionless",
         "lbp_kurtosis": "dimensionless",
         "lbp_entropy": "normalized",
-        "lbp_uniformity": "ratio",
+        "lbp_energy": "ratio",
     }
 
     def __init__(
@@ -98,7 +98,7 @@ class LBPTextureExtractor(BaseFeatureExtractor):
                 - lbp_skewness: LBPヒストグラムの歪度
                 - lbp_kurtosis: LBPヒストグラムの尖度
                 - lbp_entropy: LBPヒストグラムのエントロピー
-                - lbp_uniformity: LBPヒストグラムの均一性
+                - lbp_energy: LBPヒストグラムのエネルギー (sum(p^2))
                 - lbp_bin_{i}: 各LBPビンの正規化頻度（include_histogramがTrueの場合）
 
         Raises:
@@ -228,9 +228,9 @@ class LBPTextureExtractor(BaseFeatureExtractor):
                 entropy = 0.0
             results["lbp_entropy"] = float(entropy)
 
-            # 均一性（Uniformity）- エネルギーとも呼ばれる
-            uniformity = np.sum(hist**2)
-            results["lbp_uniformity"] = float(uniformity)
+            # エネルギー (Angular Second Moment): sum(p^2)
+            energy = np.sum(hist**2)
+            results["lbp_energy"] = float(energy)
 
         except Exception:
             # 統計量計算でエラーが発生した場合、0で埋める
@@ -241,7 +241,7 @@ class LBPTextureExtractor(BaseFeatureExtractor):
                     "lbp_skewness": 0.0,
                     "lbp_kurtosis": 0.0,
                     "lbp_entropy": 0.0,
-                    "lbp_uniformity": 0.0,
+                    "lbp_energy": 0.0,
                 }
             )
 
@@ -260,7 +260,7 @@ class LBPTextureExtractor(BaseFeatureExtractor):
             "lbp_skewness": 0.0,
             "lbp_kurtosis": 0.0,
             "lbp_entropy": 0.0,
-            "lbp_uniformity": 0.0,
+            "lbp_energy": 0.0,
         }
 
         # ヒストグラムを含む場合のデフォルト値
@@ -328,7 +328,7 @@ class LBPTextureExtractor(BaseFeatureExtractor):
             "lbp_skewness",
             "lbp_kurtosis",
             "lbp_entropy",
-            "lbp_uniformity",
+            "lbp_energy",
         ]
 
         # デフォルト設定でヒストグラムを含む場合
@@ -403,7 +403,7 @@ class LBPTextureExtractor(BaseFeatureExtractor):
             "lbp_skewness",
             "lbp_kurtosis",
             "lbp_entropy",
-            "lbp_uniformity",
+            "lbp_energy",
         ]
 
         for feature in base_features:
@@ -444,7 +444,7 @@ class LBPTextureExtractor(BaseFeatureExtractor):
             "lbp_skewness",
             "lbp_kurtosis",
             "lbp_entropy",
-            "lbp_uniformity",
+            "lbp_energy",
         ]
 
         # インスタンスの設定でヒストグラムを含む場合

--- a/tests/extractors/test_lbp_features.py
+++ b/tests/extractors/test_lbp_features.py
@@ -34,7 +34,7 @@ def test_lbp_texture_basic():
         "lbp_skewness",
         "lbp_kurtosis",
         "lbp_entropy",
-        "lbp_uniformity",
+        "lbp_energy",
     ]
     for feature in expected_features:
         assert feature in features, f"特徴量 {feature} が見つかりません"
@@ -281,7 +281,7 @@ def test_lbp_feature_names_and_config():
     print(f"特徴量の単位辞書: {feature_units}")
 
     # 個別の特徴量の単位取得テスト
-    test_features = ["lbp_mean", "lbp_entropy", "lbp_uniformity", "nonexistent_feature"]
+    test_features = ["lbp_mean", "lbp_entropy", "lbp_energy", "nonexistent_feature"]
     for feature in test_features:
         unit = LBPTextureExtractor._get_unit_for_feature(feature)
         print(f"特徴量 '{feature}' の単位: {unit}")
@@ -328,7 +328,7 @@ def test_lbp_feature_names_and_config():
         "lbp_skewness": "dimensionless",
         "lbp_kurtosis": "dimensionless",
         "lbp_entropy": "normalized",
-        "lbp_uniformity": "ratio",
+        "lbp_energy": "ratio",
     }
 
     for feature, expected_unit in expected_units.items():


### PR DESCRIPTION
## Summary

- `lbp_uniformity` を `lbp_energy` にリネームした. `sum(p^2)` は GLCM では `energy` (ASM) と呼ばれる指標であり, 名称を統一.
- docstring とコメントを更新.

## Related Issue

Closes #201

## Changes

- `pochivision/feature_extractors/lbp_texture.py`:
  - `lbp_uniformity` → `lbp_energy` (全 8 箇所)
  - `_FEATURE_UNITS`, `_calculate_statistics`, `_get_default_results`, `get_base_feature_names`, `get_feature_names_instance`, `get_base_feature_names_instance`, `get_feature_units_instance`
  - docstring とコメントを「均一性 (Uniformity)」から「エネルギー (ASM)」に修正
- `tests/extractors/test_lbp_features.py`:
  - `lbp_uniformity` → `lbp_energy` (全 3 箇所)

## Test Plan

- [x] `uv run pytest` で全 364 テストがパス

## Checklist

- [x] `lbp_uniformity` が `lbp_energy` にリネームされている
- [x] GLCM の energy と名称が統一されている
- [x] `uv run pytest` が通る