### PR TITLE
fix: リサイズ対応 5 抽出器のスキーマに resize/aspect_ratio フィールドを追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@
 ### Fixed
 - LBP ヒストグラム計算を `density=True` から手動正規化に変更. var メソッドの値域と nri_uniform のビン数を修正. ([#217](https://github.com/kurorosu/pochivision/pull/217))
 - LBP エントロピーを `log2(n_bins)` で正規化し [0, 1] 範囲に変更. 単位を `normalized` に統一. ([#218](https://github.com/kurorosu/pochivision/pull/218))
-- LBP `lbp_uniformity` を `lbp_energy` にリネームし GLCM の energy (ASM) と名称を統一. (NA.)
+- LBP `lbp_uniformity` を `lbp_energy` にリネームし GLCM の energy (ASM) と名称を統一. ([#219](https://github.com/kurorosu/pochivision/pull/219))
+- リサイズ対応 5 抽出器 (GLCM, FFT, SWT, LBP, HLAC) のスキーマに `preserve_aspect_ratio` / `aspect_ratio_mode` を追加. FFT/SWT スキーマに `resize_shape` を追加. (NA.)
 
 ### Removed
 - 無し

--- a/pochivision/feature_extractors/schema.py
+++ b/pochivision/feature_extractors/schema.py
@@ -64,6 +64,15 @@ class GLCMTextureParams(BaseModel):
         ],
         description="計算するプロパティのリスト",
     )
+    resize_shape: Optional[List[StrictInt]] = Field(
+        default=None, description="リサイズ形状 [高さ, 幅]"
+    )
+    preserve_aspect_ratio: Optional[StrictBool] = Field(
+        default=True, description="アスペクト比を保持するか"
+    )
+    aspect_ratio_mode: Optional[StrictStr] = Field(
+        default="width", pattern="^(width|height)$", description="基準軸"
+    )
 
 
 class FFTFrequencyParams(BaseModel):
@@ -90,6 +99,15 @@ class FFTFrequencyParams(BaseModel):
         gt=0.0,
         description="ピクセルあたりのmm（Noneの場合はピクセル単位）",
     )
+    resize_shape: Optional[List[StrictInt]] = Field(
+        default=None, description="リサイズ形状 [高さ, 幅]"
+    )
+    preserve_aspect_ratio: Optional[StrictBool] = Field(
+        default=True, description="アスペクト比を保持するか"
+    )
+    aspect_ratio_mode: Optional[StrictStr] = Field(
+        default="width", pattern="^(width|height)$", description="基準軸"
+    )
 
 
 class SWTFrequencyParams(BaseModel):
@@ -105,10 +123,19 @@ class SWTFrequencyParams(BaseModel):
     multiscale: Optional[StrictBool] = Field(
         default=True,
         description=(
-            "マルチスケール解析を行うかどうか。"
-            "Trueの場合は各レベルの特徴量を抽出、"
-            "Falseの場合は最高レベル（最も詳細な分解レベル）のみ抽出"
+            "マルチスケール解析を行うかどうか. "
+            "True: 各レベルの特徴量を抽出, "
+            "False: level 1 (高周波) のみ抽出"
         ),
+    )
+    resize_shape: Optional[List[StrictInt]] = Field(
+        default=None, description="リサイズ形状 [高さ, 幅]"
+    )
+    preserve_aspect_ratio: Optional[StrictBool] = Field(
+        default=True, description="アスペクト比を保持するか"
+    )
+    aspect_ratio_mode: Optional[StrictStr] = Field(
+        default="width", pattern="^(width|height)$", description="基準軸"
     )
 
 
@@ -134,6 +161,12 @@ class LBPTextureParams(BaseModel):
         default=False,
         description="ヒストグラムの各ビンを特徴量として含むかどうか",
     )
+    preserve_aspect_ratio: Optional[StrictBool] = Field(
+        default=True, description="アスペクト比を保持するか"
+    )
+    aspect_ratio_mode: Optional[StrictStr] = Field(
+        default="width", pattern="^(width|height)$", description="基準軸"
+    )
 
 
 class HLACTextureParams(BaseModel):
@@ -155,6 +188,12 @@ class HLACTextureParams(BaseModel):
     resize_shape: Optional[List[StrictInt]] = Field(
         default=None,
         description="リサイズ形状 [高さ, 幅]（Noneの場合はリサイズしない）",
+    )
+    preserve_aspect_ratio: Optional[StrictBool] = Field(
+        default=True, description="アスペクト比を保持するか"
+    )
+    aspect_ratio_mode: Optional[StrictStr] = Field(
+        default="width", pattern="^(width|height)$", description="基準軸"
     )
 
 


### PR DESCRIPTION
## Summary

- GLCM, FFT, SWT, LBP, HLAC の全スキーマに `preserve_aspect_ratio` と `aspect_ratio_mode` を追加した.
- FFT と SWT のスキーマに `resize_shape` を追加した.
- コードの `self.config["preserve_aspect_ratio"]` がスキーマ経由のバリデーション後に `KeyError` になる問題を解消.

## Related Issue

Closes #202

## Changes

- `pochivision/feature_extractors/schema.py`:
  - `GLCMTextureParams`: `resize_shape`, `preserve_aspect_ratio`, `aspect_ratio_mode` を追加
  - `FFTFrequencyParams`: `resize_shape`, `preserve_aspect_ratio`, `aspect_ratio_mode` を追加
  - `SWTFrequencyParams`: `resize_shape`, `preserve_aspect_ratio`, `aspect_ratio_mode` を追加
  - `LBPTextureParams`: `preserve_aspect_ratio`, `aspect_ratio_mode` を追加
  - `HLACTextureParams`: `preserve_aspect_ratio`, `aspect_ratio_mode` を追加

## Test Plan

- [x] `uv run pytest` で全 364 テストがパス

## Checklist

- [x] 全 5 抽出器スキーマに `preserve_aspect_ratio` / `aspect_ratio_mode` がある
- [x] FFT/SWT スキーマに `resize_shape` がある
- [x] `uv run pytest` が通る