### PR TITLE
fix: LBP 統計量をヒストグラムのビン番号統計から LBP 画像の直接統計に変更

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@
 - LBP ヒストグラム計算を `density=True` から手動正規化に変更. var メソッドの値域と nri_uniform のビン数を修正. ([#217](https://github.com/kurorosu/pochivision/pull/217))
 - LBP エントロピーを `log2(n_bins)` で正規化し [0, 1] 範囲に変更. 単位を `normalized` に統一. ([#218](https://github.com/kurorosu/pochivision/pull/218))
 - LBP `lbp_uniformity` を `lbp_energy` にリネームし GLCM の energy (ASM) と名称を統一. ([#219](https://github.com/kurorosu/pochivision/pull/219))
-- リサイズ対応 5 抽出器 (GLCM, FFT, SWT, LBP, HLAC) のスキーマに `preserve_aspect_ratio` / `aspect_ratio_mode` を追加. FFT/SWT スキーマに `resize_shape` を追加. (NA.)
+- リサイズ対応 5 抽出器 (GLCM, FFT, SWT, LBP, HLAC) のスキーマに `preserve_aspect_ratio` / `aspect_ratio_mode` を追加. FFT/SWT スキーマに `resize_shape` を追加. ([#220](https://github.com/kurorosu/pochivision/pull/220))
+- LBP の mean/std/skewness/kurtosis をヒストグラムのビン番号統計から LBP 画像の直接統計に変更. (NA.)
 
 ### Removed
 - 無し

--- a/pochivision/feature_extractors/lbp_texture.py
+++ b/pochivision/feature_extractors/lbp_texture.py
@@ -179,7 +179,10 @@ class LBPTextureExtractor(BaseFeatureExtractor):
         self, hist: np.ndarray, lbp: np.ndarray
     ) -> Dict[str, float]:
         """
-        LBPヒストグラムから統計量を計算する.
+        LBP 画像とヒストグラムから統計量を計算する.
+
+        mean/std/skewness/kurtosis は LBP 画像の値から直接計算する.
+        entropy/energy はヒストグラムの分布から計算する.
 
         Args:
             hist (np.ndarray): 正規化されたLBPヒストグラム
@@ -191,32 +194,26 @@ class LBPTextureExtractor(BaseFeatureExtractor):
         results = {}
 
         try:
-            # 基本統計量
-            # ヒストグラムの重心（平均）
-            bin_centers = np.arange(len(hist))
-            mean = np.sum(bin_centers * hist) if np.sum(hist) > 0 else 0.0
-            results["lbp_mean"] = float(mean)
+            # LBP 画像から直接計算 (パターン番号ではなくテクスチャ特性を反映)
+            lbp_flat = lbp.ravel().astype(np.float64)
+            mean = float(np.mean(lbp_flat))
+            std = float(np.std(lbp_flat))
+            results["lbp_mean"] = mean
+            results["lbp_std"] = std
 
-            # 標準偏差
-            variance = (
-                np.sum(((bin_centers - mean) ** 2) * hist) if np.sum(hist) > 0 else 0.0
-            )
-            std = np.sqrt(variance)
-            results["lbp_std"] = float(std)
-
-            # 歪度（skewness）
+            # 歪度
             if std > 0:
-                skewness = np.sum(((bin_centers - mean) ** 3) * hist) / (std**3)
+                skewness = float(np.mean(((lbp_flat - mean) / std) ** 3))
             else:
                 skewness = 0.0
-            results["lbp_skewness"] = float(skewness)
+            results["lbp_skewness"] = skewness
 
-            # 尖度（kurtosis）
+            # 尖度 (excess kurtosis)
             if std > 0:
-                kurtosis = np.sum(((bin_centers - mean) ** 4) * hist) / (std**4) - 3.0
+                kurtosis = float(np.mean(((lbp_flat - mean) / std) ** 4) - 3.0)
             else:
                 kurtosis = 0.0
-            results["lbp_kurtosis"] = float(kurtosis)
+            results["lbp_kurtosis"] = kurtosis
 
             # 正規化エントロピー [0, 1] (FFT/SWT と統一)
             hist_nonzero = hist[hist > 0]


### PR DESCRIPTION
## Summary

- `lbp_mean`, `lbp_std`, `lbp_skewness`, `lbp_kurtosis` の計算元をヒストグラムのビン番号の加重統計から LBP 画像の値の直接統計に変更した.
- パターン番号の順序に依存しない, テクスチャ特性を反映する統計量になった.

## Related Issue

Closes #203

## Changes

- `pochivision/feature_extractors/lbp_texture.py`:
  - `_calculate_statistics`: ビン番号ベースの計算を `np.mean(lbp)`, `np.std(lbp)` 等に置換
  - docstring を更新

## Code Changes

```python
# 修正前: パターン番号の加重平均 (意味が薄い)
bin_centers = np.arange(len(hist))
mean = np.sum(bin_centers * hist)

# 修正後: LBP 画像の値から直接計算 (テクスチャ特性を反映)
lbp_flat = lbp.ravel().astype(np.float64)
mean = float(np.mean(lbp_flat))
std = float(np.std(lbp_flat))
```

## Test Plan

- [x] `uv run pytest` で全 364 テストがパス

## Checklist

- [x] mean/std/skewness/kurtosis が LBP 画像から直接計算される
- [x] entropy/energy はヒストグラムから計算 (変更なし)
- [x] `uv run pytest` が通る