### PR TITLE
fix: LBP の例外握りつぶしを廃止しエラー伝播に変更

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@
 - LBP エントロピーを `log2(n_bins)` で正規化し [0, 1] 範囲に変更. 単位を `normalized` に統一. ([#218](https://github.com/kurorosu/pochivision/pull/218))
 - LBP `lbp_uniformity` を `lbp_energy` にリネームし GLCM の energy (ASM) と名称を統一. ([#219](https://github.com/kurorosu/pochivision/pull/219))
 - リサイズ対応 5 抽出器 (GLCM, FFT, SWT, LBP, HLAC) のスキーマに `preserve_aspect_ratio` / `aspect_ratio_mode` を追加. FFT/SWT スキーマに `resize_shape` を追加. ([#220](https://github.com/kurorosu/pochivision/pull/220))
-- LBP の mean/std/skewness/kurtosis をヒストグラムのビン番号統計から LBP 画像の直接統計に変更. (NA.)
+- LBP の mean/std/skewness/kurtosis をヒストグラムのビン番号統計から LBP 画像の直接統計に変更. ([#221](https://github.com/kurorosu/pochivision/pull/221))
+- LBP の `except Exception` を `LogManager` ログ出力 + `raise` に変更. ([#205](https://github.com/kurorosu/pochivision/pull/205)) (NA.)
 
 ### Removed
 - 無し

--- a/pochivision/feature_extractors/lbp_texture.py
+++ b/pochivision/feature_extractors/lbp_texture.py
@@ -6,6 +6,7 @@ import cv2
 import numpy as np
 from skimage.feature import local_binary_pattern
 
+from pochivision.capturelib.log_manager import LogManager
 from pochivision.processors.resize import ResizeProcessor
 
 from .base import BaseFeatureExtractor
@@ -172,8 +173,8 @@ class LBPTextureExtractor(BaseFeatureExtractor):
             return results
 
         except Exception:
-            # エラーが発生した場合、デフォルト値で埋める
-            return self._get_default_results()
+            LogManager().get_logger().exception("LBP feature extraction failed")
+            raise
 
     def _calculate_statistics(
         self, hist: np.ndarray, lbp: np.ndarray
@@ -230,17 +231,8 @@ class LBPTextureExtractor(BaseFeatureExtractor):
             results["lbp_energy"] = float(energy)
 
         except Exception:
-            # 統計量計算でエラーが発生した場合、0で埋める
-            results.update(
-                {
-                    "lbp_mean": 0.0,
-                    "lbp_std": 0.0,
-                    "lbp_skewness": 0.0,
-                    "lbp_kurtosis": 0.0,
-                    "lbp_entropy": 0.0,
-                    "lbp_energy": 0.0,
-                }
-            )
+            LogManager().get_logger().exception("LBP statistics calculation failed")
+            raise
 
         return results
 


### PR DESCRIPTION
## Summary

- `extract()` と `_calculate_statistics()` の `except Exception` 2 箇所を `LogManager` によるログ出力 + `raise` に変更した.
- 以下の修正済み抽出器と同じパターンに統一:
  - FFT ([#150](https://github.com/kurorosu/pochivision/pull/150))
  - GLCM ([#161](https://github.com/kurorosu/pochivision/pull/161))
  - HLAC ([#174](https://github.com/kurorosu/pochivision/pull/174))
  - SWT ([#197](https://github.com/kurorosu/pochivision/pull/197))

## Related Issue

Closes #205

## Changes

- `pochivision/feature_extractors/lbp_texture.py`:
  - `extract()`: `return self._get_default_results()` → `LogManager` + `raise`
  - `_calculate_statistics()`: all-zero dict 返却 → `LogManager` + `raise`
  - `LogManager` のインポートを追加

## Test Plan

- [x] `uv run pytest` で全 364 テストがパス

## Checklist

- [x] 例外がログ出力後に伝播する
- [x] all-zero での握りつぶしが廃止されている
- [x] 全 5 抽出器のエラーハンドリングが統一されている
- [x] `uv run pytest` が通る