### PR TITLE
fix: 4 抽出器のエラーハンドリングを LogManager + raise に統一

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - 無し
 
 ### Changed
-- 無し
+- 全 9 抽出器のエラーハンドリングを `LogManager` + `raise` パターンに統一. brightness, rgb, hsv, circle_counter に try-except を追加. (NA.)
 
 ### Fixed
 - 無し

--- a/pochivision/feature_extractors/brightness_statistics.py
+++ b/pochivision/feature_extractors/brightness_statistics.py
@@ -5,6 +5,8 @@ from typing import Any, Dict, Optional, Union
 import cv2
 import numpy as np
 
+from pochivision.capturelib.log_manager import LogManager
+
 from .base import BaseFeatureExtractor
 from .registry import register_feature_extractor
 
@@ -75,41 +77,42 @@ class BrightnessStatisticsExtractor(BaseFeatureExtractor):
         if image is None or image.size == 0:
             raise ValueError("Input image is empty or None")
 
-        brightness_image = self._get_brightness_image(image)
-        pixels = brightness_image.flatten().astype(np.float64)
+        try:
+            brightness_image = self._get_brightness_image(image)
+            pixels = brightness_image.flatten().astype(np.float64)
 
-        # ゼロピクセル除外の処理
-        if self.exclude_zero_pixels:
-            # 輝度値0のピクセルを除外
-            non_zero_pixels = pixels[pixels > 0]
-            calculation_pixels = non_zero_pixels
-        else:
-            # すべてのピクセルを使用
-            calculation_pixels = pixels
+            # ゼロピクセル除外の処理
+            if self.exclude_zero_pixels:
+                non_zero_pixels = pixels[pixels > 0]
+                calculation_pixels = non_zero_pixels
+            else:
+                calculation_pixels = pixels
 
-        if len(calculation_pixels) == 0:
-            # 有効なピクセルがない場合
-            mean_val = 0.0
-            median_val = 0.0
-            variance_val = 0.0
-            std_dev_val = 0.0
-            cv_val = float("inf")
-        else:
-            mean_val = float(np.mean(calculation_pixels))
-            median_val = float(np.median(calculation_pixels))
-            variance_val = float(np.var(calculation_pixels))
-            std_dev_val = float(np.std(calculation_pixels))
+            if len(calculation_pixels) == 0:
+                mean_val = 0.0
+                median_val = 0.0
+                variance_val = 0.0
+                std_dev_val = 0.0
+                cv_val = float("inf")
+            else:
+                mean_val = float(np.mean(calculation_pixels))
+                median_val = float(np.median(calculation_pixels))
+                variance_val = float(np.var(calculation_pixels))
+                std_dev_val = float(np.std(calculation_pixels))
+                cv_val = (
+                    float(std_dev_val / mean_val) if mean_val != 0 else float("inf")
+                )
 
-            # 変動係数の計算（平均値が0の場合は無限大になるため特別処理）
-            cv_val = float(std_dev_val / mean_val) if mean_val != 0 else float("inf")
-
-        return {
-            "mean": mean_val,
-            "median": median_val,
-            "variance": variance_val,
-            "std_dev": std_dev_val,
-            "cv": cv_val,
-        }
+            return {
+                "mean": mean_val,
+                "median": median_val,
+                "variance": variance_val,
+                "std_dev": std_dev_val,
+                "cv": cv_val,
+            }
+        except Exception:
+            LogManager().get_logger().exception("Brightness feature extraction failed")
+            raise
 
     def _get_brightness_image(self, image: np.ndarray) -> np.ndarray:
         """

--- a/pochivision/feature_extractors/circle_counter.py
+++ b/pochivision/feature_extractors/circle_counter.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, Optional, Union
 import cv2
 import numpy as np
 
+from pochivision.capturelib.log_manager import LogManager
 from pochivision.utils.image import to_grayscale
 
 from .base import BaseFeatureExtractor
@@ -91,53 +92,50 @@ class CircleCounterExtractor(BaseFeatureExtractor):
         if image is None or image.size == 0:
             raise ValueError("Input image is empty or None")
 
-        gray = to_grayscale(image)
+        try:
+            gray = to_grayscale(image)
 
-        # ガウシアンブラーでノイズ除去
-        if self.blur_kernel_size > 0:
-            gray = cv2.GaussianBlur(
-                gray, (self.blur_kernel_size, self.blur_kernel_size), 0
+            if self.blur_kernel_size > 0:
+                gray = cv2.GaussianBlur(
+                    gray, (self.blur_kernel_size, self.blur_kernel_size), 0
+                )
+
+            height, width = gray.shape
+            image_area = height * width
+
+            if self.max_radius > 0:
+                user_max_radius = self.max_radius
+                image_limit = min(height, width) // 2
+                max_radius = min(user_max_radius, image_limit)
+            else:
+                max_radius = min(height, width) // 4
+
+            min_dist = max(1, int(max_radius * self.min_dist_ratio))
+            circles = cv2.HoughCircles(
+                gray,
+                cv2.HOUGH_GRADIENT,
+                dp=1,
+                minDist=min_dist,
+                param1=self.param1,
+                param2=self.param2,
+                minRadius=self.min_radius,
+                maxRadius=max_radius,
             )
 
-        height, width = gray.shape
-        image_area = height * width
+            if circles is not None:
+                circles = np.round(circles[0, :]).astype("int")
 
-        # 最大半径の動的調整（画像サイズに応じて）
-        # ロジック:
-        # 1. max_radius > 0 の場合: ユーザー指定値を使用
-        # 2. max_radius = 0 の場合: 画像短辺の1/4を使用（自動計算）
-        # 3. ただし、画像短辺の1/2を上限とする（画像全体を占める円を防ぐ）
-        if self.max_radius > 0:
-            # ユーザー指定値を使用するが、画像サイズの制約を適用
-            user_max_radius = self.max_radius
-            image_limit = min(height, width) // 2  # 画像短辺の半分が上限
-            max_radius = min(user_max_radius, image_limit)
-        else:
-            # 自動計算: 画像短辺の1/4（一般的に適切なデフォルト値）
-            max_radius = min(height, width) // 4
+                if self.enable_circularity_filter:
+                    circles = self._filter_by_circularity(gray, circles)
+            else:
+                circles = np.array([])
 
-        min_dist = max(1, int(max_radius * self.min_dist_ratio))
-        circles = cv2.HoughCircles(
-            gray,
-            cv2.HOUGH_GRADIENT,
-            dp=1,
-            minDist=min_dist,
-            param1=self.param1,
-            param2=self.param2,
-            minRadius=self.min_radius,
-            maxRadius=max_radius,
-        )
-
-        if circles is not None:
-            circles = np.round(circles[0, :]).astype("int")
-
-            # 真円度フィルタリング
-            if self.enable_circularity_filter:
-                circles = self._filter_by_circularity(gray, circles)
-        else:
-            circles = np.array([])
-
-        return self._calculate_features(circles, image_area, max_radius)
+            return self._calculate_features(circles, image_area, max_radius)
+        except Exception:
+            LogManager().get_logger().exception(
+                "CircleCounter feature extraction failed"
+            )
+            raise
 
     def _filter_by_circularity(
         self, gray: np.ndarray, circles: np.ndarray

--- a/pochivision/feature_extractors/hsv_statistics.py
+++ b/pochivision/feature_extractors/hsv_statistics.py
@@ -6,6 +6,7 @@ import cv2
 import numpy as np
 from scipy.stats import circmean, circstd
 
+from pochivision.capturelib.log_manager import LogManager
 from pochivision.utils.image import to_bgr
 
 from .base import BaseFeatureExtractor
@@ -91,65 +92,56 @@ class HSVStatisticsExtractor(BaseFeatureExtractor):
         if image is None or image.size == 0:
             raise ValueError("Input image is empty or None")
 
-        # 任意の形状の画像をBGR形式に変換（グレースケール対応）
-        bgr_image = to_bgr(image)
+        try:
+            bgr_image = to_bgr(image)
+            hsv_image = cv2.cvtColor(bgr_image, cv2.COLOR_BGR2HSV)
 
-        hsv_image = cv2.cvtColor(bgr_image, cv2.COLOR_BGR2HSV)
+            results = {}
 
-        results = {}
-
-        # 黒ピクセル除外の処理
-        if self.exclude_black_pixels:
-            # BGR画像ですべてのチャンネルが0でないピクセルのマスクを作成
-            non_black_mask = np.any(bgr_image > 0, axis=2)
-        else:
-            # すべてのピクセルを使用
-            non_black_mask = np.ones(bgr_image.shape[:2], dtype=bool)
-
-        # チャンネル名の定義
-        channel_names = ["hue", "saturation", "value"]
-
-        for i, channel_name in enumerate(channel_names):
-            channel_data = hsv_image[:, :, i]
-
-            # マスクを適用してピクセル値を取得
             if self.exclude_black_pixels:
-                pixels = channel_data[non_black_mask].astype(np.float64)
+                non_black_mask = np.any(bgr_image > 0, axis=2)
             else:
-                pixels = channel_data.flatten().astype(np.float64)
+                non_black_mask = np.ones(bgr_image.shape[:2], dtype=bool)
 
-            # 統計値の計算
-            if len(pixels) == 0:
-                # 有効なピクセルがない場合
-                mean_val = 0.0
-                median_val = 0.0
-                variance_val = 0.0
-                std_dev_val = 0.0
-                cv_val = float("inf")
-            elif channel_name == "hue":
-                # Hue は循環データのため循環統計を使用
-                mean_val, median_val, variance_val, std_dev_val, cv_val = (
-                    self._compute_circular_stats(pixels)
-                )
-            else:
-                mean_val = float(np.mean(pixels))
-                median_val = float(np.median(pixels))
-                variance_val = float(np.var(pixels))
-                std_dev_val = float(np.std(pixels))
+            channel_names = ["hue", "saturation", "value"]
 
-                # 変動係数の計算（平均値が0の場合は無限大になるため特別処理）
-                cv_val = (
-                    float(std_dev_val / mean_val) if mean_val != 0 else float("inf")
-                )
+            for i, channel_name in enumerate(channel_names):
+                channel_data = hsv_image[:, :, i]
 
-            # 結果に追加
-            results[f"{channel_name}_mean"] = mean_val
-            results[f"{channel_name}_median"] = median_val
-            results[f"{channel_name}_variance"] = variance_val
-            results[f"{channel_name}_std_dev"] = std_dev_val
-            results[f"{channel_name}_cv"] = cv_val
+                if self.exclude_black_pixels:
+                    pixels = channel_data[non_black_mask].astype(np.float64)
+                else:
+                    pixels = channel_data.flatten().astype(np.float64)
 
-        return results
+                if len(pixels) == 0:
+                    mean_val = 0.0
+                    median_val = 0.0
+                    variance_val = 0.0
+                    std_dev_val = 0.0
+                    cv_val = float("inf")
+                elif channel_name == "hue":
+                    mean_val, median_val, variance_val, std_dev_val, cv_val = (
+                        self._compute_circular_stats(pixels)
+                    )
+                else:
+                    mean_val = float(np.mean(pixels))
+                    median_val = float(np.median(pixels))
+                    variance_val = float(np.var(pixels))
+                    std_dev_val = float(np.std(pixels))
+                    cv_val = (
+                        float(std_dev_val / mean_val) if mean_val != 0 else float("inf")
+                    )
+
+                results[f"{channel_name}_mean"] = mean_val
+                results[f"{channel_name}_median"] = median_val
+                results[f"{channel_name}_variance"] = variance_val
+                results[f"{channel_name}_std_dev"] = std_dev_val
+                results[f"{channel_name}_cv"] = cv_val
+
+            return results
+        except Exception:
+            LogManager().get_logger().exception("HSV feature extraction failed")
+            raise
 
     def _compute_circular_stats(
         self, pixels: np.ndarray

--- a/pochivision/feature_extractors/rgb_statistics.py
+++ b/pochivision/feature_extractors/rgb_statistics.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, Optional, Union
 
 import numpy as np
 
+from pochivision.capturelib.log_manager import LogManager
 from pochivision.utils.image import to_rgb
 
 from .base import BaseFeatureExtractor
@@ -76,58 +77,51 @@ class RGBStatisticsExtractor(BaseFeatureExtractor):
         if image is None or image.size == 0:
             raise ValueError("Input image is empty or None")
 
-        # 任意の形状の画像をRGB形式に変換（グレースケール対応）
-        rgb_image = to_rgb(image)
+        try:
+            rgb_image = to_rgb(image)
 
-        results = {}
+            results = {}
 
-        # 黒ピクセル除外の処理
-        if self.exclude_black_pixels:
-            # すべてのチャンネルが0でないピクセルのマスクを作成
-            non_black_mask = np.any(rgb_image > 0, axis=2)
-        else:
-            # すべてのピクセルを使用
-            non_black_mask = np.ones(rgb_image.shape[:2], dtype=bool)
-
-        # チャンネル名の定義
-        channel_names = ["red", "green", "blue"]
-
-        for i, channel_name in enumerate(channel_names):
-            channel_data = rgb_image[:, :, i]
-
-            # マスクを適用してピクセル値を取得
             if self.exclude_black_pixels:
-                pixels = channel_data[non_black_mask].astype(np.float64)
+                non_black_mask = np.any(rgb_image > 0, axis=2)
             else:
-                pixels = channel_data.flatten().astype(np.float64)
+                non_black_mask = np.ones(rgb_image.shape[:2], dtype=bool)
 
-            # 統計値の計算
-            if len(pixels) == 0:
-                # 有効なピクセルがない場合
-                mean_val = 0.0
-                median_val = 0.0
-                variance_val = 0.0
-                std_dev_val = 0.0
-                cv_val = float("inf")
-            else:
-                mean_val = float(np.mean(pixels))
-                median_val = float(np.median(pixels))
-                variance_val = float(np.var(pixels))
-                std_dev_val = float(np.std(pixels))
+            channel_names = ["red", "green", "blue"]
 
-                # 変動係数の計算（平均値が0の場合は無限大になるため特別処理）
-                cv_val = (
-                    float(std_dev_val / mean_val) if mean_val != 0 else float("inf")
-                )
+            for i, channel_name in enumerate(channel_names):
+                channel_data = rgb_image[:, :, i]
 
-            # 結果に追加
-            results[f"{channel_name}_mean"] = mean_val
-            results[f"{channel_name}_median"] = median_val
-            results[f"{channel_name}_variance"] = variance_val
-            results[f"{channel_name}_std_dev"] = std_dev_val
-            results[f"{channel_name}_cv"] = cv_val
+                if self.exclude_black_pixels:
+                    pixels = channel_data[non_black_mask].astype(np.float64)
+                else:
+                    pixels = channel_data.flatten().astype(np.float64)
 
-        return results
+                if len(pixels) == 0:
+                    mean_val = 0.0
+                    median_val = 0.0
+                    variance_val = 0.0
+                    std_dev_val = 0.0
+                    cv_val = float("inf")
+                else:
+                    mean_val = float(np.mean(pixels))
+                    median_val = float(np.median(pixels))
+                    variance_val = float(np.var(pixels))
+                    std_dev_val = float(np.std(pixels))
+                    cv_val = (
+                        float(std_dev_val / mean_val) if mean_val != 0 else float("inf")
+                    )
+
+                results[f"{channel_name}_mean"] = mean_val
+                results[f"{channel_name}_median"] = median_val
+                results[f"{channel_name}_variance"] = variance_val
+                results[f"{channel_name}_std_dev"] = std_dev_val
+                results[f"{channel_name}_cv"] = cv_val
+
+            return results
+        except Exception:
+            LogManager().get_logger().exception("RGB feature extraction failed")
+            raise
 
     @staticmethod
     def get_default_config() -> Dict[str, Any]:


### PR DESCRIPTION
## Summary

- brightness, rgb, hsv, circle_counter の 4 抽出器に `LogManager` + try-except を追加した.
- これで全 9 抽出器のエラーハンドリングが統一された.

## Related Issue

Closes #210

## Changes

- `pochivision/feature_extractors/brightness_statistics.py`: `LogManager` インポート + extract を try-except で囲む
- `pochivision/feature_extractors/rgb_statistics.py`: 同上
- `pochivision/feature_extractors/hsv_statistics.py`: 同上
- `pochivision/feature_extractors/circle_counter.py`: 同上

## Test Plan

- [x] `uv run pytest` で全 385 テストがパス

## Checklist

- [x] 全 9 抽出器で `LogManager` + `raise` パターンが適用されている
- [x] `uv run pytest` が通る