### PR TITLE
fix: 統計系抽出器に float (0-1) 入力の uint8 スケール変換を追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - 全 9 抽出器のエラーハンドリングを `LogManager` + `raise` パターンに統一. brightness, rgb, hsv, circle_counter に try-except を追加. (NA.)
 
 ### Fixed
-- 無し
+- brightness, rgb, hsv, circle_counter に float (0-1) 入力の uint8 スケール変換を追加. dtype 一致テスト 4 件も追加. (NA.)
 
 ### Removed
 - 無し

--- a/pochivision/feature_extractors/brightness_statistics.py
+++ b/pochivision/feature_extractors/brightness_statistics.py
@@ -78,6 +78,10 @@ class BrightnessStatisticsExtractor(BaseFeatureExtractor):
             raise ValueError("Input image is empty or None")
 
         try:
+            # float (0-1) 入力を uint8 スケールに変換
+            if np.issubdtype(image.dtype, np.floating) and image.max() <= 1.0:
+                image = (image * 255).astype(np.uint8)
+
             brightness_image = self._get_brightness_image(image)
             pixels = brightness_image.flatten().astype(np.float64)
 

--- a/pochivision/feature_extractors/circle_counter.py
+++ b/pochivision/feature_extractors/circle_counter.py
@@ -93,6 +93,10 @@ class CircleCounterExtractor(BaseFeatureExtractor):
             raise ValueError("Input image is empty or None")
 
         try:
+            # float (0-1) 入力を uint8 スケールに変換
+            if np.issubdtype(image.dtype, np.floating) and image.max() <= 1.0:
+                image = (image * 255).astype(np.uint8)
+
             gray = to_grayscale(image)
 
             if self.blur_kernel_size > 0:

--- a/pochivision/feature_extractors/hsv_statistics.py
+++ b/pochivision/feature_extractors/hsv_statistics.py
@@ -93,6 +93,10 @@ class HSVStatisticsExtractor(BaseFeatureExtractor):
             raise ValueError("Input image is empty or None")
 
         try:
+            # float (0-1) 入力を uint8 スケールに変換
+            if np.issubdtype(image.dtype, np.floating) and image.max() <= 1.0:
+                image = (image * 255).astype(np.uint8)
+
             bgr_image = to_bgr(image)
             hsv_image = cv2.cvtColor(bgr_image, cv2.COLOR_BGR2HSV)
 

--- a/pochivision/feature_extractors/rgb_statistics.py
+++ b/pochivision/feature_extractors/rgb_statistics.py
@@ -78,6 +78,10 @@ class RGBStatisticsExtractor(BaseFeatureExtractor):
             raise ValueError("Input image is empty or None")
 
         try:
+            # float (0-1) 入力を uint8 スケールに変換
+            if np.issubdtype(image.dtype, np.floating) and image.max() <= 1.0:
+                image = (image * 255).astype(np.uint8)
+
             rgb_image = to_rgb(image)
 
             results = {}

--- a/tests/extractors/test_brightness_features.py
+++ b/tests/extractors/test_brightness_features.py
@@ -7,6 +7,7 @@ from pochivision.feature_extractors import (
     BrightnessStatisticsExtractor,
     get_feature_extractor,
 )
+from tests.extractors.conftest import DummyImages
 
 
 def test_brightness_statistics():
@@ -320,3 +321,18 @@ if __name__ == "__main__":
     test_edge_cases()
     test_feature_names_and_units()
     print("\n=== 輝度統計特徴量抽出テスト完了 ===")
+
+
+def test_dtype_float01_equals_uint8():
+    """float (0-1) と uint8 で同じ特徴量が返ることを確認."""
+    ext = BrightnessStatisticsExtractor()
+    img_uint8 = DummyImages.random()
+    img_float = img_uint8.astype(np.float32) / 255.0
+
+    f_u = ext.extract(img_uint8)
+    f_f = ext.extract(img_float)
+
+    for key in f_u:
+        if f_u[key] == float("inf"):
+            continue
+        assert abs(f_u[key] - f_f[key]) < 0.5, f"{key}: {f_u[key]} vs {f_f[key]}"

--- a/tests/extractors/test_circle_counter.py
+++ b/tests/extractors/test_circle_counter.py
@@ -5,6 +5,7 @@ import numpy as np
 import pytest  # noqa: F401
 
 from pochivision.feature_extractors import CircleCounterExtractor, get_feature_extractor
+from tests.extractors.conftest import DummyImages
 
 
 def test_circle_counter_basic():
@@ -414,3 +415,16 @@ if __name__ == "__main__":
     test_unit_for_feature_method()
 
     print("\n=== すべてのテスト完了 ===")
+
+
+def test_dtype_float01_equals_uint8():
+    """float (0-1) と uint8 で同じ特徴量が返ることを確認."""
+    ext = CircleCounterExtractor()
+    img_uint8 = DummyImages.random()
+    img_float = img_uint8.astype(np.float32) / 255.0
+
+    f_u = ext.extract(img_uint8)
+    f_f = ext.extract(img_float)
+
+    for key in f_u:
+        assert abs(f_u[key] - f_f[key]) < 0.5, f"{key}: {f_u[key]} vs {f_f[key]}"

--- a/tests/extractors/test_hsv_features.py
+++ b/tests/extractors/test_hsv_features.py
@@ -5,6 +5,7 @@ import numpy as np
 import pytest  # noqa: F401
 
 from pochivision.feature_extractors import HSVStatisticsExtractor, get_feature_extractor
+from tests.extractors.conftest import DummyImages
 
 
 def test_hsv_statistics():
@@ -466,3 +467,18 @@ if __name__ == "__main__":
     test_feature_names_and_units()
     test_unit_for_feature_method()
     print("\n=== HSV統計特徴量抽出テスト完了 ===")
+
+
+def test_dtype_float01_equals_uint8():
+    """float (0-1) と uint8 で同じ特徴量が返ることを確認."""
+    ext = HSVStatisticsExtractor()
+    img_uint8 = np.stack([DummyImages.random(seed=i) for i in range(3)], axis=2)
+    img_float = img_uint8.astype(np.float32) / 255.0
+
+    f_u = ext.extract(img_uint8)
+    f_f = ext.extract(img_float)
+
+    for key in f_u:
+        if f_u[key] == float("inf"):
+            continue
+        assert abs(f_u[key] - f_f[key]) < 0.5, f"{key}: {f_u[key]} vs {f_f[key]}"

--- a/tests/extractors/test_rgb_features.py
+++ b/tests/extractors/test_rgb_features.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest  # noqa: F401
 
 from pochivision.feature_extractors import RGBStatisticsExtractor, get_feature_extractor
+from tests.extractors.conftest import DummyImages
 
 
 def test_rgb_statistics_basic():
@@ -432,3 +433,18 @@ if __name__ == "__main__":
     test_feature_names_and_units()
     test_unit_for_feature_method()
     print("\n=== RGB統計特徴量抽出テスト完了 ===")
+
+
+def test_dtype_float01_equals_uint8():
+    """float (0-1) と uint8 で同じ特徴量が返ることを確認."""
+    ext = RGBStatisticsExtractor()
+    img_uint8 = np.stack([DummyImages.random(seed=i) for i in range(3)], axis=2)
+    img_float = img_uint8.astype(np.float32) / 255.0
+
+    f_u = ext.extract(img_uint8)
+    f_f = ext.extract(img_float)
+
+    for key in f_u:
+        if f_u[key] == float("inf"):
+            continue
+        assert abs(f_u[key] - f_f[key]) < 0.5, f"{key}: {f_u[key]} vs {f_f[key]}"


### PR DESCRIPTION
## Summary

- brightness, rgb, hsv, circle_counter の 4 抽出器に float (0-1) 入力を uint8 スケールに変換する処理を追加した.
- uint8 画像と float32 (0-1) 画像で同じ特徴量が得られるようになった.

## Related Issue

Closes #211

## Changes

- `pochivision/feature_extractors/brightness_statistics.py`: extract 冒頭に float (0-1) → uint8 変換
- `pochivision/feature_extractors/rgb_statistics.py`: 同上
- `pochivision/feature_extractors/hsv_statistics.py`: 同上
- `pochivision/feature_extractors/circle_counter.py`: 同上

各ファイルに追加したコード:
```python
if np.issubdtype(image.dtype, np.floating) and image.max() <= 1.0:
    image = (image * 255).astype(np.uint8)
```

**FFT は設計意図により変更なし** (float64 のまま処理しコントラスト情報を保持).

## Test Plan

- [x] `uv run pytest` で全 389 テストがパス (dtype 一致テスト 4 件追加)

## Checklist

- [x] float (0-1) 入力が uint8 スケールに変換される
- [x] FFT は意図的に変更なし
- [x] SWT/GLCM/HLAC/LBP は既に対応済み
- [x] `uv run pytest` が通る