### PR TITLE
fix: Brightness/HLAC スキーマに不足フィールドを追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Fixed
 - brightness, rgb, hsv, circle_counter に float (0-1) 入力の uint8 スケール変換を追加. dtype 一致テスト 4 件も追加. (NA.)
+- Brightness スキーマに `exclude_zero_pixels`, HLAC スキーマに `binarization_method` / `adaptive_block_size` / `adaptive_c` を追加. (NA.)
 
 ### Removed
 - 無し

--- a/pochivision/feature_extractors/schema.py
+++ b/pochivision/feature_extractors/schema.py
@@ -15,6 +15,9 @@ class BrightnessStatisticsParams(BaseModel):
     color_mode: Optional[StrictStr] = Field(
         default="gray", pattern="^(gray|lab_l|hsv_v)$"
     )
+    exclude_zero_pixels: Optional[StrictBool] = Field(
+        default=True, description="輝度値0のピクセルを計算から除外するかどうか"
+    )
 
 
 class RGBStatisticsParams(BaseModel):
@@ -194,6 +197,17 @@ class HLACTextureParams(BaseModel):
     )
     aspect_ratio_mode: Optional[StrictStr] = Field(
         default="width", pattern="^(width|height)$", description="基準軸"
+    )
+    binarization_method: Optional[StrictStr] = Field(
+        default="adaptive",
+        pattern="^(otsu|adaptive)$",
+        description="二値化方式 (otsu or adaptive)",
+    )
+    adaptive_block_size: Optional[StrictInt] = Field(
+        default=11, ge=3, description="adaptive 二値化のブロックサイズ (奇数)"
+    )
+    adaptive_c: Optional[Union[StrictInt, StrictFloat]] = Field(
+        default=2, description="adaptive 二値化の定数 C"
     )
 
 


### PR DESCRIPTION
## Summary

- `BrightnessStatisticsParams` に `exclude_zero_pixels` を追加.
- `HLACTextureParams` に `binarization_method`, `adaptive_block_size`, `adaptive_c` を追加.
- スキーマと `get_default_config()` の整合性を確保.

## Related Issue

Closes #212

## Changes

- `pochivision/feature_extractors/schema.py`:
  - `BrightnessStatisticsParams`: `exclude_zero_pixels: Optional[StrictBool]` を追加
  - `HLACTextureParams`: `binarization_method`, `adaptive_block_size`, `adaptive_c` を追加

## Test Plan

- [x] `uv run pytest` で全 389 テストがパス

## Checklist

- [x] 全 9 抽出器のスキーマが `get_default_config()` と一致している
- [x] `uv run pytest` が通る