### PR TITLE
fix: circle_counter の blur_kernel_size に偶数バリデーションを追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Fixed
 - brightness, rgb, hsv, circle_counter に float (0-1) 入力の uint8 スケール変換を追加. dtype 一致テスト 4 件も追加. (NA.)
 - Brightness スキーマに `exclude_zero_pixels`, HLAC スキーマに `binarization_method` / `adaptive_block_size` / `adaptive_c` を追加. (NA.)
+- circle_counter の `blur_kernel_size` に偶数バリデーションを追加. (NA.)
 
 ### Removed
 - 無し

--- a/pochivision/feature_extractors/circle_counter.py
+++ b/pochivision/feature_extractors/circle_counter.py
@@ -74,6 +74,10 @@ class CircleCounterExtractor(BaseFeatureExtractor):
         self.param2 = self.config["param2"]
         self.circularity_threshold = self.config["circularity_threshold"]
         self.blur_kernel_size = self.config["blur_kernel_size"]
+        if self.blur_kernel_size > 0 and self.blur_kernel_size % 2 == 0:
+            raise ValueError(
+                f"blur_kernel_size must be an odd number or 0, got {self.blur_kernel_size}"
+            )
         self.enable_circularity_filter = self.config["enable_circularity_filter"]
 
     def extract(self, image: np.ndarray) -> Dict[str, Union[float, int]]:


### PR DESCRIPTION
## Summary

- `blur_kernel_size` が偶数の場合に `ValueError` を送出するバリデーションを `__init__` に追加した.
- `cv2.GaussianBlur` は奇数カーネルサイズのみ受け付けるため, 偶数指定時にクラッシュしていた問題を早期検出.

## Related Issue

Closes #213

## Changes

- `pochivision/feature_extractors/circle_counter.py`:
  - `__init__` で `blur_kernel_size > 0 and blur_kernel_size % 2 == 0` の場合に `ValueError` を送出

## Code Changes

```python
if self.blur_kernel_size > 0 and self.blur_kernel_size % 2 == 0:
    raise ValueError(
        f"blur_kernel_size must be an odd number or 0, got {self.blur_kernel_size}"
    )
```

## Test Plan

- [x] `uv run pytest` で全 389 テストがパス

## Checklist

- [x] 偶数で明確なエラーが発生する
- [x] 0 (無効化) は許容される
- [x] 奇数は正常に動作する
- [x] `uv run pytest` が通る