### PR TITLE
docs: RGB/HSV/Brightness の黒ピクセル除外の動作を docstring に明記

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,13 @@
 - 無し
 
 ### Changed
-- 全 9 抽出器のエラーハンドリングを `LogManager` + `raise` パターンに統一. brightness, rgb, hsv, circle_counter に try-except を追加. (NA.)
+- 全 9 抽出器のエラーハンドリングを `LogManager` + `raise` パターンに統一. brightness, rgb, hsv, circle_counter に try-except を追加. ([#226](https://github.com/kurorosu/pochivision/pull/226))
 
 ### Fixed
-- brightness, rgb, hsv, circle_counter に float (0-1) 入力の uint8 スケール変換を追加. dtype 一致テスト 4 件も追加. (NA.)
-- Brightness スキーマに `exclude_zero_pixels`, HLAC スキーマに `binarization_method` / `adaptive_block_size` / `adaptive_c` を追加. (NA.)
-- circle_counter の `blur_kernel_size` に偶数バリデーションを追加. (NA.)
+- brightness, rgb, hsv, circle_counter に float (0-1) 入力の uint8 スケール変換を追加. dtype 一致テスト 4 件も追加. ([#227](https://github.com/kurorosu/pochivision/pull/227))
+- Brightness スキーマに `exclude_zero_pixels`, HLAC スキーマに `binarization_method` / `adaptive_block_size` / `adaptive_c` を追加. ([#228](https://github.com/kurorosu/pochivision/pull/228))
+- circle_counter の `blur_kernel_size` に偶数バリデーションを追加. ([#230](https://github.com/kurorosu/pochivision/pull/230))
+- RGB/HSV/Brightness の `exclude_black_pixels` / `exclude_zero_pixels` の動作を docstring とコメントに明記. (NA.)
 
 ### Removed
 - 無し

--- a/pochivision/feature_extractors/brightness_statistics.py
+++ b/pochivision/feature_extractors/brightness_statistics.py
@@ -26,7 +26,10 @@ class BrightnessStatisticsExtractor(BaseFeatureExtractor):
     - std_dev: 輝度標準偏差 [0-255]
     - cv: 変動係数（標準偏差/平均値） [ratio]
 
-    設定により、輝度値が0のピクセルを計算から除外することができます。
+    exclude_zero_pixels の動作:
+    - True: 輝度値が 0 のピクセルを統計から除外する.
+    - False: 全ピクセルを統計に含む.
+    - 用途: 背景が真っ黒の画像で, 背景領域を統計から除外したい場合に使用.
     """
 
     # 特徴量の単位定義
@@ -85,7 +88,7 @@ class BrightnessStatisticsExtractor(BaseFeatureExtractor):
             brightness_image = self._get_brightness_image(image)
             pixels = brightness_image.flatten().astype(np.float64)
 
-            # ゼロピクセル除外の処理
+            # 輝度値 0 のピクセルを除外 (背景の真っ黒部分を統計から除く)
             if self.exclude_zero_pixels:
                 non_zero_pixels = pixels[pixels > 0]
                 calculation_pixels = non_zero_pixels

--- a/pochivision/feature_extractors/hsv_statistics.py
+++ b/pochivision/feature_extractors/hsv_statistics.py
@@ -28,7 +28,11 @@ class HSVStatisticsExtractor(BaseFeatureExtractor):
     - std_dev: HSV標準偏差 [H: degree, S: intensity, V: intensity]
     - cv: 変動係数（標準偏差/平均値） [ratio]
 
-    設定により、RGB値がすべて0のピクセルを計算から除外することができます。
+    exclude_black_pixels の動作:
+    - True: 元の BGR 画像で B=0, G=0, R=0 のピクセル (完全な黒) のみを統計から除外する.
+      HSV 変換前の BGR 値で判定するため, 色味のあるピクセルは除外されない.
+    - False: 全ピクセルを統計に含む.
+    - 用途: 背景が真っ黒の画像で, 背景領域を統計から除外したい場合に使用.
     """
 
     # OpenCV の HSV Hue 範囲 (0-179)
@@ -103,6 +107,7 @@ class HSVStatisticsExtractor(BaseFeatureExtractor):
             results = {}
 
             if self.exclude_black_pixels:
+                # BGR 全チャンネル 0 の完全黒ピクセルを除外 (いずれかが非ゼロなら残す)
                 non_black_mask = np.any(bgr_image > 0, axis=2)
             else:
                 non_black_mask = np.ones(bgr_image.shape[:2], dtype=bool)

--- a/pochivision/feature_extractors/rgb_statistics.py
+++ b/pochivision/feature_extractors/rgb_statistics.py
@@ -26,7 +26,11 @@ class RGBStatisticsExtractor(BaseFeatureExtractor):
     - std_dev: RGB標準偏差 [0-255]
     - cv: 変動係数（標準偏差/平均値） [ratio]
 
-    設定により、RGB値がすべて0のピクセルを計算から除外することができます。
+    exclude_black_pixels の動作:
+    - True: R=0, G=0, B=0 のピクセル (完全な黒) のみを統計から除外する.
+      R=200, G=0, B=0 のようなピクセルは除外されない (いずれかのチャンネルが非ゼロ).
+    - False: 全ピクセルを統計に含む.
+    - 用途: 背景が真っ黒の画像で, 背景領域を統計から除外したい場合に使用.
     """
 
     # 特徴量の単位定義
@@ -87,6 +91,7 @@ class RGBStatisticsExtractor(BaseFeatureExtractor):
             results = {}
 
             if self.exclude_black_pixels:
+                # R=0, G=0, B=0 の完全黒ピクセルを除外 (いずれかが非ゼロなら残す)
                 non_black_mask = np.any(rgb_image > 0, axis=2)
             else:
                 non_black_mask = np.ones(rgb_image.shape[:2], dtype=bool)


### PR DESCRIPTION
## Summary

- `exclude_black_pixels` / `exclude_zero_pixels` の動作を docstring とコード内コメントに明記した.
- 「全チャンネル 0 の完全黒ピクセルのみ除外される」ことを明確にし, 個別チャンネルのゼロ値は除外されないことを説明.

## Related Issue

Closes #214

## Changes

- `pochivision/feature_extractors/rgb_statistics.py`: docstring に `exclude_black_pixels` の詳細動作を追記. コメント明確化.
- `pochivision/feature_extractors/hsv_statistics.py`: 同上. BGR 値で判定することを明記.
- `pochivision/feature_extractors/brightness_statistics.py`: docstring に `exclude_zero_pixels` の詳細動作を追記. コメント明確化.

## Test Plan

- [x] `uv run pytest` で全 389 テストがパス

## Checklist

- [x] 3 ファイルの docstring が動作を正確に記載している
- [x] コード内コメントが動作と一致している
- [x] `uv run pytest` が通る