### PR TITLE
feat: get_feature_extractor で Pydantic スキーマによる設定バリデーションを実行

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Brightness スキーマに `exclude_zero_pixels`, HLAC スキーマに `binarization_method` / `adaptive_block_size` / `adaptive_c` を追加. ([#228](https://github.com/kurorosu/pochivision/pull/228))
 - circle_counter の `blur_kernel_size` に偶数バリデーションを追加. ([#230](https://github.com/kurorosu/pochivision/pull/230))
 - RGB/HSV/Brightness の `exclude_black_pixels` / `exclude_zero_pixels` の動作を docstring とコメントに明記. (NA.)
+- `get_feature_extractor` で Pydantic スキーマによる設定バリデーションを実行するよう変更. 無効な設定値で `ValueError` を送出. (NA.)
 
 ### Removed
 - 無し

--- a/pochivision/feature_extractors/registry.py
+++ b/pochivision/feature_extractors/registry.py
@@ -10,9 +10,13 @@
         ...
 """
 
+import logging
 from typing import Any, Callable, Dict, Optional, Type
 
 from .base import BaseFeatureExtractor
+from .schema import EXTRACTOR_SCHEMA_MAP
+
+logger = logging.getLogger(__name__)
 
 # 名前とクラスのマッピングを保持する辞書
 FEATURE_EXTRACTOR_REGISTRY: Dict[str, Type[BaseFeatureExtractor]] = {}
@@ -61,5 +65,15 @@ def get_feature_extractor(
     if not extractor_class:
         raise ValueError(f"Feature extractor not found: {name}")
 
+    # スキーマによる設定バリデーション
+    user_config = config or {}
+    if user_config:
+        schema_class = EXTRACTOR_SCHEMA_MAP.get(name)
+        if schema_class:
+            try:
+                schema_class(**user_config)
+            except Exception as e:
+                raise ValueError(f"Invalid config for '{name}': {e}") from e
+
     # デフォルト設定の取得とマージはBaseFeatureExtractorで行われる
-    return extractor_class(name=name, config=config or {})
+    return extractor_class(name=name, config=user_config)

--- a/pochivision/feature_extractors/schema.py
+++ b/pochivision/feature_extractors/schema.py
@@ -262,3 +262,17 @@ class CircleCounterParams(BaseModel):
     enable_circularity_filter: Optional[StrictBool] = Field(
         default=True, description="真円度フィルタリングを有効にするかどうか"
     )
+
+
+# 抽出器名とスキーマクラスのマッピング
+EXTRACTOR_SCHEMA_MAP: dict[str, type[BaseModel]] = {
+    "brightness": BrightnessStatisticsParams,
+    "rgb": RGBStatisticsParams,
+    "hsv": HSVStatisticsParams,
+    "glcm": GLCMTextureParams,
+    "fft": FFTFrequencyParams,
+    "swt": SWTFrequencyParams,
+    "lbp": LBPTextureParams,
+    "hlac": HLACTextureParams,
+    "circle_counter": CircleCounterParams,
+}

--- a/tests/extractors/test_glcm_texture_extractor.py
+++ b/tests/extractors/test_glcm_texture_extractor.py
@@ -651,3 +651,16 @@ class TestGLCMBehavior:
         """ランダム画像の contrast は > 1000."""
         f = self.ext.extract(DummyImages.random())
         assert f["contrast_1_0"] > 1000
+
+
+def test_schema_validation_rejects_invalid_config():
+    """スキーマバリデーションが無効な設定を拒否することを確認."""
+    from pochivision.feature_extractors import get_feature_extractor
+
+    # levels が範囲外
+    with pytest.raises(ValueError, match="Invalid config"):
+        get_feature_extractor("glcm", {"levels": 1})
+
+    # levels が範囲外 (上限)
+    with pytest.raises(ValueError, match="Invalid config"):
+        get_feature_extractor("glcm", {"levels": 999})

--- a/tests/extractors/test_lbp_features.py
+++ b/tests/extractors/test_lbp_features.py
@@ -611,3 +611,19 @@ class TestLBPBehavior:
         f = self.ext.extract(DummyImages.random())
         assert "lbp_bin_0" in f
         assert "lbp_bin_9" in f
+
+
+def test_schema_validation_rejects_invalid_method():
+    """スキーマバリデーションが無効な method を拒否することを確認."""
+    from pochivision.feature_extractors import get_feature_extractor
+
+    with pytest.raises(ValueError, match="Invalid config"):
+        get_feature_extractor("lbp", {"method": "invalid_method"})
+
+
+def test_schema_validation_rejects_invalid_P():
+    """スキーマバリデーションが範囲外の P を拒否することを確認."""
+    from pochivision.feature_extractors import get_feature_extractor
+
+    with pytest.raises(ValueError, match="Invalid config"):
+        get_feature_extractor("lbp", {"P": 2})


### PR DESCRIPTION
## Summary

- `get_feature_extractor` で設定値を Pydantic スキーマでバリデーションするよう変更した.
- `EXTRACTOR_SCHEMA_MAP` で抽出器名とスキーマクラスを紐づけ, 無効な設定値で `ValueError` を早期送出.
- バリデーションテスト 3 件を追加.

## Related Issue

Closes #229

## Changes

- `pochivision/feature_extractors/schema.py`: `EXTRACTOR_SCHEMA_MAP` を追加 (9 抽出器の名前 → スキーマクラスのマッピング)
- `pochivision/feature_extractors/registry.py`: `get_feature_extractor` でスキーマバリデーションを実行
- `tests/extractors/test_glcm_texture_extractor.py`: `levels` 範囲外テスト
- `tests/extractors/test_lbp_features.py`: `method` 無効値テスト, `P` 範囲外テスト

## Code Changes

```python
# registry.py
user_config = config or {}
if user_config:
    schema_class = EXTRACTOR_SCHEMA_MAP.get(name)
    if schema_class:
        try:
            schema_class(**user_config)
        except Exception as e:
            raise ValueError(f"Invalid config for '{name}': {e}") from e
```

## Test Plan

- [x] `uv run pytest` で全 392 テストがパス

## Checklist

- [x] 無効な設定値で `ValueError` が発生する
- [x] 有効な設定値では正常に動作する
- [x] 全 9 抽出器がマッピングに含まれている
- [x] `uv run pytest` が通る