### PR TITLE
refactor: 特徴量抽出器用カスタム例外クラスを追加し全例外に標準例外の多重継承を適用

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 ## [Unreleased]
 
 ### Added
-- 無し
+- `exceptions/extractor.py` を新設し `ExtractorValidationError` / `ExtractorRuntimeError` を追加. 全 9 抽出器の `ValueError` を `ExtractorValidationError` に置換. (NA.)
 
 ### Changed
 - 全 9 抽出器のエラーハンドリングを `LogManager` + `raise` パターンに統一. brightness, rgb, hsv, circle_counter に try-except を追加. ([#226](https://github.com/kurorosu/pochivision/pull/226))
@@ -17,7 +17,7 @@
 - circle_counter の `blur_kernel_size` に偶数バリデーションを追加. ([#230](https://github.com/kurorosu/pochivision/pull/230))
 - RGB/HSV/Brightness の `exclude_black_pixels` / `exclude_zero_pixels` の動作を docstring とコメントに明記. ([#231](https://github.com/kurorosu/pochivision/pull/231))
 - `get_feature_extractor` で Pydantic スキーマによる設定バリデーションを実行するよう変更. ([#232](https://github.com/kurorosu/pochivision/pull/232))
-- スキーマの関心分離, プロセッサバリデーション追加, 例外階層の統一. (NA.)
+- スキーマの関心分離, プロセッサバリデーション追加, 例外階層の統一. ([#233](https://github.com/kurorosu/pochivision/pull/233))
   - プロセッサスキーマを `processors/schema.py` に分離し `config_schema.py` を `schema.py` にリネーム
   - `get_processor` で Pydantic スキーマによる設定バリデーションを実行するよう変更
   - `ConfigLoadError` / `CameraConfigError` を `exceptions/config.py` に移動し `VisionCaptureError` 階層に統一

--- a/pochivision/exceptions/__init__.py
+++ b/pochivision/exceptions/__init__.py
@@ -2,6 +2,7 @@
 
 from .base import VisionCaptureError
 from .config import CameraConfigError, ConfigLoadError, ConfigValidationError
+from .extractor import ExtractorRuntimeError, ExtractorValidationError
 from .processor import ProcessorRuntimeError, ProcessorValidationError
 
 __all__ = [
@@ -11,4 +12,6 @@ __all__ = [
     "ConfigValidationError",
     "ConfigLoadError",
     "CameraConfigError",
+    "ExtractorValidationError",
+    "ExtractorRuntimeError",
 ]

--- a/pochivision/exceptions/config.py
+++ b/pochivision/exceptions/config.py
@@ -3,19 +3,19 @@
 from .base import VisionCaptureError
 
 
-class ConfigValidationError(VisionCaptureError):
+class ConfigValidationError(VisionCaptureError, ValueError):
     """設定ファイルのバリデーションエラー用例外クラス."""
 
     pass
 
 
-class ConfigLoadError(VisionCaptureError):
+class ConfigLoadError(VisionCaptureError, OSError):
     """設定ファイルの読み込みエラー用例外クラス."""
 
     pass
 
 
-class CameraConfigError(VisionCaptureError):
+class CameraConfigError(VisionCaptureError, ValueError):
     """カメラ設定のエラー用例外クラス."""
 
     pass

--- a/pochivision/exceptions/extractor.py
+++ b/pochivision/exceptions/extractor.py
@@ -1,0 +1,15 @@
+"""特徴量抽出器関連の例外クラスを定義するモジュール."""
+
+from .base import VisionCaptureError
+
+
+class ExtractorValidationError(VisionCaptureError, ValueError):
+    """特徴量抽出器の入力バリデーションエラー用例外クラス."""
+
+    pass
+
+
+class ExtractorRuntimeError(VisionCaptureError, RuntimeError):
+    """特徴量抽出器の実行時エラー用例外クラス."""
+
+    pass

--- a/pochivision/exceptions/processor.py
+++ b/pochivision/exceptions/processor.py
@@ -3,13 +3,13 @@
 from .base import VisionCaptureError
 
 
-class ProcessorValidationError(VisionCaptureError):
+class ProcessorValidationError(VisionCaptureError, ValueError):
     """プロセッサのバリデーションエラー用例外クラス."""
 
     pass
 
 
-class ProcessorRuntimeError(VisionCaptureError):
+class ProcessorRuntimeError(VisionCaptureError, RuntimeError):
     """プロセッサ実行時のエラー用例外クラス."""
 
     pass

--- a/pochivision/feature_extractors/brightness_statistics.py
+++ b/pochivision/feature_extractors/brightness_statistics.py
@@ -6,6 +6,7 @@ import cv2
 import numpy as np
 
 from pochivision.capturelib.log_manager import LogManager
+from pochivision.exceptions.extractor import ExtractorValidationError
 
 from .base import BaseFeatureExtractor
 from .registry import register_feature_extractor
@@ -78,7 +79,7 @@ class BrightnessStatisticsExtractor(BaseFeatureExtractor):
             ValueError: 画像が空の場合や無効な形状の場合.
         """
         if image is None or image.size == 0:
-            raise ValueError("Input image is empty or None")
+            raise ExtractorValidationError("Input image is empty or None")
 
         try:
             # float (0-1) 入力を uint8 スケールに変換
@@ -150,9 +151,11 @@ class BrightnessStatisticsExtractor(BaseFeatureExtractor):
                 hsv = cv2.cvtColor(image, cv2.COLOR_BGR2HSV)
                 return hsv[:, :, 2]  # V成分
             else:
-                raise ValueError(f"Unsupported color_mode: {self.color_mode}")
+                raise ExtractorValidationError(
+                    f"Unsupported color_mode: {self.color_mode}"
+                )
         else:
-            raise ValueError(f"Unsupported image shape: {image.shape}")
+            raise ExtractorValidationError(f"Unsupported image shape: {image.shape}")
 
     @staticmethod
     def get_default_config() -> Dict[str, Any]:

--- a/pochivision/feature_extractors/circle_counter.py
+++ b/pochivision/feature_extractors/circle_counter.py
@@ -6,6 +6,7 @@ import cv2
 import numpy as np
 
 from pochivision.capturelib.log_manager import LogManager
+from pochivision.exceptions.extractor import ExtractorValidationError
 from pochivision.utils.image import to_grayscale
 
 from .base import BaseFeatureExtractor
@@ -75,7 +76,7 @@ class CircleCounterExtractor(BaseFeatureExtractor):
         self.circularity_threshold = self.config["circularity_threshold"]
         self.blur_kernel_size = self.config["blur_kernel_size"]
         if self.blur_kernel_size > 0 and self.blur_kernel_size % 2 == 0:
-            raise ValueError(
+            raise ExtractorValidationError(
                 f"blur_kernel_size must be an odd number or 0, got {self.blur_kernel_size}"
             )
         self.enable_circularity_filter = self.config["enable_circularity_filter"]
@@ -94,7 +95,7 @@ class CircleCounterExtractor(BaseFeatureExtractor):
             ValueError: 画像が空の場合や無効な形状の場合.
         """
         if image is None or image.size == 0:
-            raise ValueError("Input image is empty or None")
+            raise ExtractorValidationError("Input image is empty or None")
 
         try:
             # float (0-1) 入力を uint8 スケールに変換

--- a/pochivision/feature_extractors/fft_frequency.py
+++ b/pochivision/feature_extractors/fft_frequency.py
@@ -7,6 +7,7 @@ import numpy as np
 from scipy.ndimage import maximum_filter
 
 from pochivision.capturelib.log_manager import LogManager
+from pochivision.exceptions.extractor import ExtractorValidationError
 from pochivision.processors.resize import ResizeProcessor
 
 from .base import BaseFeatureExtractor
@@ -111,7 +112,7 @@ class FFTFrequencyExtractor(BaseFeatureExtractor):
             )
 
         if self.mm_per_pixel is not None and self.mm_per_pixel <= 0:
-            raise ValueError(
+            raise ExtractorValidationError(
                 f"mm_per_pixel must be a positive number, got {self.mm_per_pixel}"
             )
 
@@ -406,21 +407,23 @@ class FFTFrequencyExtractor(BaseFeatureExtractor):
             ValueError: 画像が空の場合や無効な形状の場合.
         """
         if image is None or image.size == 0:
-            raise ValueError("Input image is empty or None")
+            raise ExtractorValidationError("Input image is empty or None")
 
         if len(image.shape) == 3:
             gray_image = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
         elif len(image.shape) == 2:
             gray_image = image.copy()
         else:
-            raise ValueError(f"Input image must be 2D or 3D, got shape: {image.shape}")
+            raise ExtractorValidationError(
+                f"Input image must be 2D or 3D, got shape: {image.shape}"
+            )
 
         if self.resize_processor is not None:
             gray_image = self.resize_processor.process(gray_image)
 
         _MIN_FFT_SIZE = 4
         if gray_image.shape[0] < _MIN_FFT_SIZE or gray_image.shape[1] < _MIN_FFT_SIZE:
-            raise ValueError(
+            raise ExtractorValidationError(
                 f"Image too small for FFT: {gray_image.shape}. "
                 f"Minimum size is {_MIN_FFT_SIZE}x{_MIN_FFT_SIZE}."
             )

--- a/pochivision/feature_extractors/glcm_texture.py
+++ b/pochivision/feature_extractors/glcm_texture.py
@@ -7,6 +7,7 @@ import numpy as np
 from skimage.feature import graycomatrix, graycoprops
 
 from pochivision.capturelib.log_manager import LogManager
+from pochivision.exceptions.extractor import ExtractorValidationError
 from pochivision.processors.resize import ResizeProcessor
 
 from .base import BaseFeatureExtractor
@@ -104,15 +105,15 @@ class GLCMTextureExtractor(BaseFeatureExtractor):
             ValueError: 無効な角度設定の場合
         """
         if not isinstance(angles_config, list):
-            raise ValueError("Angles must be a list of numbers")
+            raise ExtractorValidationError("Angles must be a list of numbers")
 
         if not angles_config:
-            raise ValueError("Angles list cannot be empty")
+            raise ExtractorValidationError("Angles list cannot be empty")
 
         # すべての要素が数値かチェック
         for angle in angles_config:
             if not isinstance(angle, (int, float)):
-                raise ValueError("All angles must be numeric values")
+                raise ExtractorValidationError("All angles must be numeric values")
 
         # 度数をラジアンに変換
         return [np.radians(float(angle)) for angle in angles_config]
@@ -133,7 +134,7 @@ class GLCMTextureExtractor(BaseFeatureExtractor):
             ValueError: 画像が空の場合や無効な形状の場合.
         """
         if image is None or image.size == 0:
-            raise ValueError("Input image is empty or None")
+            raise ExtractorValidationError("Input image is empty or None")
 
         # 画像の型を適切に変換（OpenCVがサポートしていない型の場合）
         if image.dtype not in [np.uint8, np.uint16, np.float32, np.float64]:
@@ -154,7 +155,9 @@ class GLCMTextureExtractor(BaseFeatureExtractor):
         elif len(image.shape) == 2:
             gray_image = image.copy()
         else:
-            raise ValueError(f"Input image must be 2D or 3D, got shape: {image.shape}")
+            raise ExtractorValidationError(
+                f"Input image must be 2D or 3D, got shape: {image.shape}"
+            )
 
         # リサイズ (設定されている場合)
         if self.resize_processor is not None:

--- a/pochivision/feature_extractors/hlac_texture.py
+++ b/pochivision/feature_extractors/hlac_texture.py
@@ -7,6 +7,7 @@ import numpy as np
 from scipy.signal import correlate2d
 
 from pochivision.capturelib.log_manager import LogManager
+from pochivision.exceptions.extractor import ExtractorValidationError
 from pochivision.processors.base import BaseProcessor
 from pochivision.processors.binarization import (
     GaussianAdaptiveBinarizationProcessor,
@@ -124,7 +125,7 @@ class HLACTextureExtractor(BaseFeatureExtractor):
             ValueError: 画像が空の場合や無効な形状の場合.
         """
         if image is None or image.size == 0:
-            raise ValueError("Input image is empty or None")
+            raise ExtractorValidationError("Input image is empty or None")
 
         try:
             # 画像の型を適切に変換
@@ -146,7 +147,7 @@ class HLACTextureExtractor(BaseFeatureExtractor):
             elif len(image.shape) == 2:
                 gray_image = image.copy()
             else:
-                raise ValueError(
+                raise ExtractorValidationError(
                     f"Input image must be 2D or 3D, got shape: {image.shape}"
                 )
 

--- a/pochivision/feature_extractors/hsv_statistics.py
+++ b/pochivision/feature_extractors/hsv_statistics.py
@@ -7,6 +7,7 @@ import numpy as np
 from scipy.stats import circmean, circstd
 
 from pochivision.capturelib.log_manager import LogManager
+from pochivision.exceptions.extractor import ExtractorValidationError
 from pochivision.utils.image import to_bgr
 
 from .base import BaseFeatureExtractor
@@ -94,7 +95,7 @@ class HSVStatisticsExtractor(BaseFeatureExtractor):
             ValueError: 画像が空の場合や無効な形状の場合.
         """
         if image is None or image.size == 0:
-            raise ValueError("Input image is empty or None")
+            raise ExtractorValidationError("Input image is empty or None")
 
         try:
             # float (0-1) 入力を uint8 スケールに変換

--- a/pochivision/feature_extractors/lbp_texture.py
+++ b/pochivision/feature_extractors/lbp_texture.py
@@ -7,6 +7,7 @@ import numpy as np
 from skimage.feature import local_binary_pattern
 
 from pochivision.capturelib.log_manager import LogManager
+from pochivision.exceptions.extractor import ExtractorValidationError
 from pochivision.processors.resize import ResizeProcessor
 
 from .base import BaseFeatureExtractor
@@ -106,7 +107,7 @@ class LBPTextureExtractor(BaseFeatureExtractor):
             ValueError: 画像が空の場合や無効な形状の場合.
         """
         if image is None or image.size == 0:
-            raise ValueError("Input image is empty or None")
+            raise ExtractorValidationError("Input image is empty or None")
 
         try:
             # 画像の型を適切に変換
@@ -128,7 +129,7 @@ class LBPTextureExtractor(BaseFeatureExtractor):
             elif len(image.shape) == 2:
                 gray_image = image.copy()
             else:
-                raise ValueError(
+                raise ExtractorValidationError(
                     f"Input image must be 2D or 3D, got shape: {image.shape}"
                 )
 

--- a/pochivision/feature_extractors/rgb_statistics.py
+++ b/pochivision/feature_extractors/rgb_statistics.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, Optional, Union
 import numpy as np
 
 from pochivision.capturelib.log_manager import LogManager
+from pochivision.exceptions.extractor import ExtractorValidationError
 from pochivision.utils.image import to_rgb
 
 from .base import BaseFeatureExtractor
@@ -79,7 +80,7 @@ class RGBStatisticsExtractor(BaseFeatureExtractor):
             ValueError: 画像が空の場合や無効な形状の場合.
         """
         if image is None or image.size == 0:
-            raise ValueError("Input image is empty or None")
+            raise ExtractorValidationError("Input image is empty or None")
 
         try:
             # float (0-1) 入力を uint8 スケールに変換

--- a/pochivision/feature_extractors/swt_frequency.py
+++ b/pochivision/feature_extractors/swt_frequency.py
@@ -6,6 +6,7 @@ import numpy as np
 import pywt
 
 from pochivision.capturelib.log_manager import LogManager
+from pochivision.exceptions.extractor import ExtractorValidationError
 from pochivision.processors.resize import ResizeProcessor
 from pochivision.utils.image import to_grayscale
 
@@ -310,7 +311,7 @@ class SWTFrequencyExtractor(BaseFeatureExtractor):
         """
         _MIN_SWT_SIZE = 4
         if image is None or image.size == 0:
-            raise ValueError("Input image is empty or None")
+            raise ExtractorValidationError("Input image is empty or None")
 
         try:
             gray_image = to_grayscale(image)
@@ -322,7 +323,7 @@ class SWTFrequencyExtractor(BaseFeatureExtractor):
                 gray_image.shape[0] < _MIN_SWT_SIZE
                 or gray_image.shape[1] < _MIN_SWT_SIZE
             ):
-                raise ValueError(
+                raise ExtractorValidationError(
                     f"Image too small for SWT: {gray_image.shape}. "
                     f"Minimum size is {_MIN_SWT_SIZE}x{_MIN_SWT_SIZE}."
                 )

--- a/tests/extractors/test_circle_counter.py
+++ b/tests/extractors/test_circle_counter.py
@@ -4,6 +4,7 @@ import cv2
 import numpy as np
 import pytest  # noqa: F401
 
+from pochivision.exceptions.extractor import ExtractorValidationError
 from pochivision.feature_extractors import CircleCounterExtractor, get_feature_extractor
 from tests.extractors.conftest import DummyImages
 
@@ -293,11 +294,11 @@ def test_edge_cases():
     extractor = CircleCounterExtractor()
 
     # 空の画像で ValueError
-    with pytest.raises(ValueError, match="empty or None"):
+    with pytest.raises((ValueError, ExtractorValidationError), match="empty or None"):
         extractor.extract(np.array([]))
 
     # None画像で ValueError
-    with pytest.raises(ValueError, match="empty or None"):
+    with pytest.raises((ValueError, ExtractorValidationError), match="empty or None"):
         extractor.extract(None)
 
     # 非常に小さい画像でも処理できる

--- a/tests/extractors/test_fft_features.py
+++ b/tests/extractors/test_fft_features.py
@@ -3,6 +3,7 @@
 import numpy as np
 import pytest
 
+from pochivision.exceptions.extractor import ExtractorValidationError
 from pochivision.feature_extractors.fft_frequency import FFTFrequencyExtractor
 from tests.extractors.conftest import DummyImages
 
@@ -117,12 +118,16 @@ class TestFFTFrequencyExtractor:
         """空の画像での例外処理をテスト."""
         empty_image = np.array([])
 
-        with pytest.raises(ValueError, match="Input image is empty or None"):
+        with pytest.raises(
+            (ValueError, ExtractorValidationError), match="Input image is empty or None"
+        ):
             self.extractor.extract(empty_image)
 
     def test_extract_none_image(self):
         """None画像での例外処理をテスト."""
-        with pytest.raises(ValueError, match="Input image is empty or None"):
+        with pytest.raises(
+            (ValueError, ExtractorValidationError), match="Input image is empty or None"
+        ):
             self.extractor.extract(None)
 
     def test_extract_invalid_shape(self):
@@ -130,14 +135,18 @@ class TestFFTFrequencyExtractor:
         # 1次元配列
         invalid_image = np.array([1, 2, 3, 4])
 
-        with pytest.raises(ValueError, match="Input image must be 2D or 3D"):
+        with pytest.raises(
+            (ValueError, ExtractorValidationError), match="Input image must be 2D or 3D"
+        ):
             self.extractor.extract(invalid_image)
 
     def test_extract_too_small_image(self):
         """極小画像で ValueError が発生することを確認."""
         for size in [(1, 1), (2, 2), (3, 3), (3, 64), (64, 3)]:
             small_image = np.ones(size, dtype=np.uint8) * 128
-            with pytest.raises(ValueError, match="Image too small for FFT"):
+            with pytest.raises(
+                (ValueError, ExtractorValidationError), match="Image too small for FFT"
+            ):
                 self.extractor.extract(small_image)
 
     def test_extract_minimum_size_works(self):

--- a/tests/extractors/test_glcm_texture_extractor.py
+++ b/tests/extractors/test_glcm_texture_extractor.py
@@ -3,6 +3,7 @@
 import numpy as np
 import pytest
 
+from pochivision.exceptions.extractor import ExtractorValidationError
 from pochivision.feature_extractors.glcm_texture import GLCMTextureExtractor
 from tests.extractors.conftest import DummyImages
 
@@ -82,15 +83,23 @@ class TestGLCMTextureExtractor:
     def test_invalid_angle_input(self):
         """無効な角度入力のエラーハンドリングをテスト."""
         # 文字列での指定（プリセットは廃止）
-        with pytest.raises(ValueError, match="Angles must be a list of numbers"):
+        with pytest.raises(
+            (ValueError, ExtractorValidationError),
+            match="Angles must be a list of numbers",
+        ):
             GLCMTextureExtractor(config={"angles": "invalid_preset"})
 
         # 空のリスト
-        with pytest.raises(ValueError, match="Angles list cannot be empty"):
+        with pytest.raises(
+            (ValueError, ExtractorValidationError), match="Angles list cannot be empty"
+        ):
             GLCMTextureExtractor(config={"angles": []})
 
         # 数値以外の要素を含むリスト
-        with pytest.raises(ValueError, match="All angles must be numeric values"):
+        with pytest.raises(
+            (ValueError, ExtractorValidationError),
+            match="All angles must be numeric values",
+        ):
             GLCMTextureExtractor(config={"angles": [0, "45", 90]})
 
     def test_extract_basic_functionality(self):
@@ -229,11 +238,15 @@ class TestGLCMTextureExtractor:
         extractor = GLCMTextureExtractor()
 
         # 空の画像
-        with pytest.raises(ValueError, match="Input image is empty or None"):
+        with pytest.raises(
+            (ValueError, ExtractorValidationError), match="Input image is empty or None"
+        ):
             extractor.extract(np.array([]))
 
         # None画像
-        with pytest.raises(ValueError, match="Input image is empty or None"):
+        with pytest.raises(
+            (ValueError, ExtractorValidationError), match="Input image is empty or None"
+        ):
             extractor.extract(None)
 
     def test_extract_invalid_shape_error(self):
@@ -241,11 +254,15 @@ class TestGLCMTextureExtractor:
         extractor = GLCMTextureExtractor()
 
         # 1次元画像
-        with pytest.raises(ValueError, match="Input image must be 2D or 3D"):
+        with pytest.raises(
+            (ValueError, ExtractorValidationError), match="Input image must be 2D or 3D"
+        ):
             extractor.extract(np.array([1, 2, 3]))
 
         # 4次元画像
-        with pytest.raises(ValueError, match="Input image must be 2D or 3D"):
+        with pytest.raises(
+            (ValueError, ExtractorValidationError), match="Input image must be 2D or 3D"
+        ):
             extractor.extract(np.random.randint(0, 256, (10, 10, 3, 3)))
 
     def test_get_default_config(self):
@@ -658,9 +675,9 @@ def test_schema_validation_rejects_invalid_config():
     from pochivision.feature_extractors import get_feature_extractor
 
     # levels が範囲外
-    with pytest.raises(ValueError, match="Invalid config"):
+    with pytest.raises((ValueError, ExtractorValidationError), match="Invalid config"):
         get_feature_extractor("glcm", {"levels": 1})
 
     # levels が範囲外 (上限)
-    with pytest.raises(ValueError, match="Invalid config"):
+    with pytest.raises((ValueError, ExtractorValidationError), match="Invalid config"):
         get_feature_extractor("glcm", {"levels": 999})

--- a/tests/extractors/test_hlac_features.py
+++ b/tests/extractors/test_hlac_features.py
@@ -3,6 +3,7 @@
 import numpy as np
 import pytest  # noqa: F401
 
+from pochivision.exceptions.extractor import ExtractorValidationError
 from pochivision.feature_extractors import HLACTextureExtractor, get_feature_extractor
 from tests.extractors.conftest import DummyImages
 
@@ -304,11 +305,11 @@ def test_hlac_error_handling():
     extractor = HLACTextureExtractor()
 
     # 空の画像で ValueError
-    with pytest.raises(ValueError, match="empty or None"):
+    with pytest.raises((ValueError, ExtractorValidationError), match="empty or None"):
         extractor.extract(np.array([]))
 
     # None画像で ValueError
-    with pytest.raises(ValueError, match="empty or None"):
+    with pytest.raises((ValueError, ExtractorValidationError), match="empty or None"):
         extractor.extract(None)
 
 

--- a/tests/extractors/test_hsv_features.py
+++ b/tests/extractors/test_hsv_features.py
@@ -4,6 +4,7 @@ import cv2
 import numpy as np
 import pytest  # noqa: F401
 
+from pochivision.exceptions.extractor import ExtractorValidationError
 from pochivision.feature_extractors import HSVStatisticsExtractor, get_feature_extractor
 from tests.extractors.conftest import DummyImages
 
@@ -231,7 +232,7 @@ def test_edge_cases():
         empty_image = np.array([])
         extractor.extract(empty_image)
         print("エラー: 空の画像が受け入れられました")
-    except ValueError as e:
+    except (ValueError, ExtractorValidationError) as e:
         print(f"正常: 空の画像でエラー発生 - {e}")
 
 

--- a/tests/extractors/test_lbp_features.py
+++ b/tests/extractors/test_lbp_features.py
@@ -3,6 +3,7 @@
 import numpy as np
 import pytest  # noqa: F401
 
+from pochivision.exceptions.extractor import ExtractorValidationError
 from pochivision.feature_extractors import LBPTextureExtractor, get_feature_extractor
 
 
@@ -255,11 +256,11 @@ def test_lbp_error_handling():
     extractor = LBPTextureExtractor()
 
     # 空の画像で ValueError
-    with pytest.raises(ValueError, match="empty or None"):
+    with pytest.raises((ValueError, ExtractorValidationError), match="empty or None"):
         extractor.extract(np.array([]))
 
     # None画像で ValueError
-    with pytest.raises(ValueError, match="empty or None"):
+    with pytest.raises((ValueError, ExtractorValidationError), match="empty or None"):
         extractor.extract(None)
 
 
@@ -617,7 +618,7 @@ def test_schema_validation_rejects_invalid_method():
     """スキーマバリデーションが無効な method を拒否することを確認."""
     from pochivision.feature_extractors import get_feature_extractor
 
-    with pytest.raises(ValueError, match="Invalid config"):
+    with pytest.raises((ValueError, ExtractorValidationError), match="Invalid config"):
         get_feature_extractor("lbp", {"method": "invalid_method"})
 
 
@@ -625,5 +626,5 @@ def test_schema_validation_rejects_invalid_P():
     """スキーマバリデーションが範囲外の P を拒否することを確認."""
     from pochivision.feature_extractors import get_feature_extractor
 
-    with pytest.raises(ValueError, match="Invalid config"):
+    with pytest.raises((ValueError, ExtractorValidationError), match="Invalid config"):
         get_feature_extractor("lbp", {"P": 2})

--- a/tests/extractors/test_swt_frequency.py
+++ b/tests/extractors/test_swt_frequency.py
@@ -3,6 +3,7 @@
 import numpy as np
 import pytest  # noqa: F401
 
+from pochivision.exceptions.extractor import ExtractorValidationError
 from pochivision.feature_extractors.swt_frequency import SWTFrequencyExtractor
 from tests.extractors.conftest import DummyImages
 
@@ -527,7 +528,9 @@ class TestSWTBehavior:
         """4x4 未満の画像で ValueError が発生."""
         for size in [(1, 1), (2, 2), (3, 3), (3, 64), (64, 3)]:
             small = np.ones(size, dtype=np.uint8) * 128
-            with pytest.raises(ValueError, match="Image too small for SWT"):
+            with pytest.raises(
+                (ValueError, ExtractorValidationError), match="Image too small for SWT"
+            ):
                 self.ext.extract(small)
 
     def test_minimum_size_works(self):


### PR DESCRIPTION
## Summary

- `exceptions/extractor.py` に `ExtractorValidationError` / `ExtractorRuntimeError` を新設.
- 全 9 抽出器の `raise ValueError` を `raise ExtractorValidationError` に置換.
- 全例外クラスに標準例外の多重継承を追加し, `except ValueError` 等でも捕捉可能に (後方互換).

## Related Issue

Closes #234

## Changes

### 例外クラスの新設と多重継承
- `pochivision/exceptions/extractor.py`: 新規作成
  - `ExtractorValidationError(VisionCaptureError, ValueError)`
  - `ExtractorRuntimeError(VisionCaptureError, RuntimeError)`
- `pochivision/exceptions/processor.py`: 多重継承に変更
  - `ProcessorValidationError(VisionCaptureError, ValueError)`
  - `ProcessorRuntimeError(VisionCaptureError, RuntimeError)`
- `pochivision/exceptions/config.py`: 多重継承に変更
  - `ConfigValidationError(VisionCaptureError, ValueError)`
  - `ConfigLoadError(VisionCaptureError, OSError)`
  - `CameraConfigError(VisionCaptureError, ValueError)`
- `pochivision/exceptions/__init__.py`: エクスポートに追加

### 抽出器の例外置換
- `pochivision/feature_extractors/*.py` (9 ファイル): `raise ValueError` → `raise ExtractorValidationError`
- `tests/extractors/*.py` (7 ファイル): テストのアサーションを更新

## Test Plan

- [x] `uv run pytest` で全 392 テストがパス

## Checklist

- [x] 全例外が `VisionCaptureError` 階層に属する
- [x] 全例外が標準例外も多重継承している
- [x] 全 9 抽出器がカスタム例外を使用している
- [x] `uv run pytest` が通る