### PR TITLE
refactor: BaseProcessor / BaseFeatureExtractor に abc.ABC 継承を追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 ## [Unreleased]
 
 ### Added
-- `exceptions/extractor.py` を新設し `ExtractorValidationError` / `ExtractorRuntimeError` を追加. 全 9 抽出器の `ValueError` を `ExtractorValidationError` に置換. (NA.)
+- `exceptions/extractor.py` を新設し `ExtractorValidationError` / `ExtractorRuntimeError` を追加. 全例外に標準例外の多重継承を適用. ([#235](https://github.com/kurorosu/pochivision/pull/235))
+- `BaseProcessor` / `BaseFeatureExtractor` に `abc.ABC` 継承を追加し抽象メソッドを強制. (NA.)
 
 ### Changed
 - 全 9 抽出器のエラーハンドリングを `LogManager` + `raise` パターンに統一. brightness, rgb, hsv, circle_counter に try-except を追加. ([#226](https://github.com/kurorosu/pochivision/pull/226))

--- a/pochivision/feature_extractors/base.py
+++ b/pochivision/feature_extractors/base.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, Union
 import numpy as np
 
 
-class BaseFeatureExtractor:
+class BaseFeatureExtractor(abc.ABC):
     """
     すべての画像特徴量抽出器の基底クラス.
 

--- a/pochivision/processors/base.py
+++ b/pochivision/processors/base.py
@@ -6,7 +6,7 @@ from typing import Any, Dict
 import numpy as np
 
 
-class BaseProcessor:
+class BaseProcessor(abc.ABC):
     """
     すべての画像処理プロセッサの基底クラス.
 


### PR DESCRIPTION
## Summary

- `BaseProcessor` と `BaseFeatureExtractor` に `abc.ABC` を継承させ, `@abc.abstractmethod` が実際に強制されるようにした.
- これにより抽象メソッド未実装のサブクラスをインスタンス化すると `TypeError` が発生する.

## Related Issue

Closes #111

## Changes

- `pochivision/processors/base.py`: `class BaseProcessor:` → `class BaseProcessor(abc.ABC):`
- `pochivision/feature_extractors/base.py`: `class BaseFeatureExtractor:` → `class BaseFeatureExtractor(abc.ABC):`

## Test Plan

- [x] `uv run pytest` で全 392 テストがパス

## Checklist

- [x] `BaseProcessor` が `abc.ABC` を継承している
- [x] `BaseFeatureExtractor` が `abc.ABC` を継承している
- [x] `uv run pytest` が通る