### PR TITLE
refactor: プロセッサ / 特徴量抽出器のレジストリに重複登録チェックを追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 
 ### Added
 - `exceptions/extractor.py` を新設し `ExtractorValidationError` / `ExtractorRuntimeError` を追加. 全例外に標準例外の多重継承を適用. ([#235](https://github.com/kurorosu/pochivision/pull/235))
-- `BaseProcessor` / `BaseFeatureExtractor` に `abc.ABC` 継承を追加し抽象メソッドを強制. (NA.)
+- `BaseProcessor` / `BaseFeatureExtractor` に `abc.ABC` 継承を追加し抽象メソッドを強制. ([#236](https://github.com/kurorosu/pochivision/pull/236))
+- プロセッサ / 特徴量抽出器の両レジストリに重複登録時の警告ログを追加. (NA.)
 
 ### Changed
 - 全 9 抽出器のエラーハンドリングを `LogManager` + `raise` パターンに統一. brightness, rgb, hsv, circle_counter に try-except を追加. ([#226](https://github.com/kurorosu/pochivision/pull/226))

--- a/pochivision/feature_extractors/registry.py
+++ b/pochivision/feature_extractors/registry.py
@@ -36,6 +36,12 @@ def register_feature_extractor(
     """
 
     def decorator(cls: Type[BaseFeatureExtractor]) -> Type[BaseFeatureExtractor]:
+        if name in FEATURE_EXTRACTOR_REGISTRY:
+            logger.warning(
+                f"Feature extractor '{name}' is already registered "
+                f"({FEATURE_EXTRACTOR_REGISTRY[name].__name__}), "
+                f"overwriting with {cls.__name__}"
+            )
         FEATURE_EXTRACTOR_REGISTRY[name] = cls
         return cls
 

--- a/pochivision/processors/registry.py
+++ b/pochivision/processors/registry.py
@@ -10,7 +10,10 @@
         ...
 """
 
+import logging
 from typing import Any, Callable, Dict, Type
+
+logger = logging.getLogger(__name__)
 
 from .base import BaseProcessor
 from .schema import PROCESSOR_SCHEMA_MAP
@@ -33,6 +36,12 @@ def register_processor(
     """
 
     def decorator(cls: Type[BaseProcessor]) -> Type[BaseProcessor]:
+        if name in PROCESSOR_REGISTRY:
+            logger.warning(
+                f"Processor '{name}' is already registered "
+                f"({PROCESSOR_REGISTRY[name].__name__}), "
+                f"overwriting with {cls.__name__}"
+            )
         PROCESSOR_REGISTRY[name] = cls
         return cls
 


### PR DESCRIPTION
## Summary

- `register_processor` と `register_feature_extractor` のデコレータに重複登録時の警告ログを追加した.
- 同じ名前で 2 回登録された場合, 警告を出力してから上書きする.

## Related Issue

Closes #112

## Changes

- `pochivision/processors/registry.py`: 重複チェック + `logger.warning` を追加. `import logging` と `logger` を追加.
- `pochivision/feature_extractors/registry.py`: 重複チェック + `logger.warning` を追加 (logger は既存).

## Code Changes

```python
if name in PROCESSOR_REGISTRY:
    logger.warning(
        f"Processor '{name}' is already registered "
        f"({PROCESSOR_REGISTRY[name].__name__}), "
        f"overwriting with {cls.__name__}"
    )
PROCESSOR_REGISTRY[name] = cls
```

## Test Plan

- [x] `uv run pytest` で全 392 テストがパス

## Checklist

- [x] プロセッサレジストリに重複チェックがある
- [x] 特徴量抽出器レジストリに重複チェックがある
- [x] 重複時に警告ログが出力される
- [x] `uv run pytest` が通る