### PR TITLE
fix: プロセッサスキーマの検証漏れを補完し MaskCompositionParams を新設

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 - `exceptions/extractor.py` を新設し `ExtractorValidationError` / `ExtractorRuntimeError` を追加. 全例外に標準例外の多重継承を適用. ([#235](https://github.com/kurorosu/pochivision/pull/235))
 - `BaseProcessor` / `BaseFeatureExtractor` に `abc.ABC` 継承を追加し抽象メソッドを強制. ([#236](https://github.com/kurorosu/pochivision/pull/236))
 - プロセッサ / 特徴量抽出器の両レジストリに重複登録時の警告ログを追加. ([#237](https://github.com/kurorosu/pochivision/pull/237))
-- バリデータの `validate_config` を削除しスキーマに一本化. パラメータ解析をプロセッサの `__init__` に移動. (NA.)
+- バリデータの `validate_config` を削除しスキーマに一本化. パラメータ解析をプロセッサの `__init__` に移動. ([#238](https://github.com/kurorosu/pochivision/pull/238))
+- プロセッサスキーマの検証漏れを補完. `MaskCompositionParams` を新設. `@field_validator` / `@model_validator` で複合条件を追加. (NA.)
 
 ### Changed
 - 全 9 抽出器のエラーハンドリングを `LogManager` + `raise` パターンに統一. brightness, rgb, hsv, circle_counter に try-except を追加. ([#226](https://github.com/kurorosu/pochivision/pull/226))

--- a/pochivision/processors/schema.py
+++ b/pochivision/processors/schema.py
@@ -4,16 +4,26 @@
 各プロセッサのパラメータ構造を型安全に管理する.
 """
 
-from typing import List, Optional
+from typing import List, Optional, Union
 
-from pydantic import BaseModel, ConfigDict, Field, StrictFloat, StrictInt, StrictStr
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    StrictBool,
+    StrictFloat,
+    StrictInt,
+    StrictStr,
+    field_validator,
+    model_validator,
+)
 
 
 class GaussianBlurParams(BaseModel):
     """ガウシアンブラーのパラメータスキーマ."""
 
     kernel_size: List[StrictInt]
-    sigma: StrictFloat
+    sigma: StrictFloat = Field(ge=0)
 
 
 class AverageBlurParams(BaseModel):
@@ -37,7 +47,7 @@ class GrayscaleParams(BaseModel):
 class StandardBinarizationParams(BaseModel):
     """標準2値化のパラメータスキーマ."""
 
-    threshold: StrictInt
+    threshold: StrictInt = Field(ge=0, le=255)
 
 
 class OtsuBinarizationParams(BaseModel):
@@ -49,15 +59,31 @@ class OtsuBinarizationParams(BaseModel):
 class GaussianAdaptiveBinarizationParams(BaseModel):
     """ガウシアン適応的2値化のパラメータスキーマ."""
 
-    block_size: StrictInt
-    c: StrictFloat
+    block_size: StrictInt = Field(ge=3)
+    c: Union[StrictInt, StrictFloat]
+
+    @field_validator("block_size")
+    @classmethod
+    def block_size_must_be_odd(cls, v: int) -> int:
+        """block_size は奇数でなければならない."""
+        if v % 2 == 0:
+            raise ValueError(f"block_size must be odd, got {v}")
+        return v
 
 
 class MeanAdaptiveBinarizationParams(BaseModel):
     """平均適応的2値化のパラメータスキーマ."""
 
-    block_size: StrictInt
-    c: StrictFloat
+    block_size: StrictInt = Field(ge=3)
+    c: Union[StrictInt, StrictFloat]
+
+    @field_validator("block_size")
+    @classmethod
+    def block_size_must_be_odd(cls, v: int) -> int:
+        """block_size は奇数でなければならない."""
+        if v % 2 == 0:
+            raise ValueError(f"block_size must be odd, got {v}")
+        return v
 
 
 class BilateralFilterParams(BaseModel):
@@ -80,9 +106,9 @@ class MotionBlurParams(BaseModel):
 class ResizeParams(BaseModel):
     """リサイズプロセッサーのパラメータスキーマ."""
 
-    width: Optional[StrictInt] = None
-    height: Optional[StrictInt] = None
-    preserve_aspect_ratio: Optional[bool] = Field(default=False)
+    width: Optional[StrictInt] = Field(default=None, gt=0)
+    height: Optional[StrictInt] = Field(default=None, gt=0)
+    preserve_aspect_ratio: Optional[StrictBool] = Field(default=False)
     aspect_ratio_mode: Optional[StrictStr] = Field(
         default="width", pattern="^(width|height)$"
     )
@@ -107,10 +133,28 @@ class CLAHEParams(BaseModel):
 class CannyEdgeParams(BaseModel):
     """Cannyエッジ検出のパラメータスキーマ."""
 
-    threshold1: StrictFloat
-    threshold2: StrictFloat
+    threshold1: StrictFloat = Field(ge=0)
+    threshold2: StrictFloat = Field(ge=0)
     aperture_size: Optional[StrictInt] = Field(default=3, ge=3, le=7)
-    l2_gradient: Optional[bool] = Field(default=False)
+    l2_gradient: Optional[StrictBool] = Field(default=False)
+
+    @field_validator("aperture_size")
+    @classmethod
+    def aperture_size_must_be_odd(cls, v: int) -> int:
+        """aperture_size は奇数でなければならない."""
+        if v is not None and v % 2 == 0:
+            raise ValueError(f"aperture_size must be odd, got {v}")
+        return v
+
+    @model_validator(mode="after")
+    def threshold1_le_threshold2(self) -> "CannyEdgeParams":
+        """threshold1 <= threshold2 でなければならない."""
+        if self.threshold1 > self.threshold2:
+            raise ValueError(
+                f"threshold1 ({self.threshold1}) must be <= "
+                f"threshold2 ({self.threshold2})"
+            )
+        return self
 
 
 class ContourParams(BaseModel):
@@ -133,6 +177,15 @@ class ContourParams(BaseModel):
     )
 
 
+class MaskCompositionParams(BaseModel):
+    """マスク合成プロセッサのパラメータスキーマ."""
+
+    target_image: Optional[StrictStr] = Field(default="original")
+    use_white_pixels: Optional[StrictBool] = Field(default=True)
+    enable_cropping: Optional[StrictBool] = Field(default=False)
+    crop_margin: Optional[StrictInt] = Field(default=0, ge=0)
+
+
 # プロセッサ名とスキーマクラスのマッピング
 PROCESSOR_SCHEMA_MAP: dict[str, type[BaseModel]] = {
     "gaussian_blur": GaussianBlurParams,
@@ -150,4 +203,5 @@ PROCESSOR_SCHEMA_MAP: dict[str, type[BaseModel]] = {
     "clahe": CLAHEParams,
     "canny_edge": CannyEdgeParams,
     "contour": ContourParams,
+    "mask_composition": MaskCompositionParams,
 }


### PR DESCRIPTION
## Summary

- `validate_config` 削除 (#238) で漏れていた検証をスキーマに追加した.
- `MaskCompositionParams` を新設し `PROCESSOR_SCHEMA_MAP` に追加した.
- `@field_validator` で奇数制約, `@model_validator` でフィールド間関係を検証.

## Related Issue

Closes #239

## Changes

- `pochivision/processors/schema.py`:
  - `StandardBinarizationParams`: `threshold` に `ge=0, le=255` を追加
  - `GaussianAdaptiveBinarizationParams` / `MeanAdaptiveBinarizationParams`: `block_size` に `ge=3` + `@field_validator` で奇数制約
  - `ResizeParams`: `width` / `height` に `gt=0` を追加, `StrictBool` に変更
  - `CannyEdgeParams`: `threshold1` / `threshold2` に `ge=0`, `@field_validator` で `aperture_size` 奇数制約, `@model_validator` で `threshold1 <= threshold2`
  - `MaskCompositionParams`: 新設 (`target_image`, `use_white_pixels`, `enable_cropping`, `crop_margin >= 0`)
  - `PROCESSOR_SCHEMA_MAP` に `mask_composition` を追加

## Test Plan

- [x] `uv run pytest` で全 372 テストがパス

## Checklist

- [x] 全ての検証漏れがスキーマで表現されている
- [x] `MaskCompositionParams` が定義されている
- [x] `@field_validator` / `@model_validator` で複合条件が検証される
- [x] `uv run pytest` が通る
