### PR TITLE
docs: README を CLI サブコマンド構成に合わせて更新

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,11 @@
 - プロセッサスキーマの検証漏れを補完. `MaskCompositionParams` を新設. `@field_validator` / `@model_validator` で複合条件を追加. ([#240](https://github.com/kurorosu/pochivision/pull/240))
 - `extractor_config.json` に `extractors` リストを追加し, 選択した抽出器のみ実行する機能を追加. ([#241](https://github.com/kurorosu/pochivision/pull/241))
 - `pochi` CLI を click サブコマンド構成に変更. `pochi run` / `pochi extract` / `pochi process` / `pochi aggregate` / `pochi fft` を追加. ([#242](https://github.com/kurorosu/pochivision/pull/242))
-- CLI サブコマンドを `commands/` ディレクトリに分離. tools/ のスクリプト本体を移動し, `sys.argv` 操作を排除. `tqdm` を依存に追加. (NA.)
+- CLI サブコマンドを `commands/` ディレクトリに分離. tools/ のスクリプト本体を移動し, `sys.argv` 操作を排除. `tqdm` を依存に追加. ([#245](https://github.com/kurorosu/pochivision/pull/245))
 
 ### Changed
 - 全 9 抽出器のエラーハンドリングを `LogManager` + `raise` パターンに統一. brightness, rgb, hsv, circle_counter に try-except を追加. ([#226](https://github.com/kurorosu/pochivision/pull/226))
+- README.md / README.en.md を CLI サブコマンド構成に合わせて更新. ディレクトリ構成・アーキテクチャセクションを削除. CLAUDE.md の CLI・tools 記述を更新. (NA.)
 
 ### Fixed
 - brightness, rgb, hsv, circle_counter に float (0-1) 入力の uint8 スケール変換を追加. dtype 一致テスト 4 件も追加. ([#227](https://github.com/kurorosu/pochivision/pull/227))

--- a/README.en.md
+++ b/README.en.md
@@ -21,25 +21,6 @@ Real-time image capture & preprocessing engine for AI vision applications, featu
 - Recording with selectable codec
 - Command-line interface for easy configuration
 
-## Directory Structure
-
-```
-pochivision/
-├── pochivision/
-│   ├── cli/                  # CLI entrypoint (vcc command)
-│   ├── capture_runner/       # Camera capture and preview runner
-│   ├── capturelib/           # Camera setup, config, logging, recording
-│   ├── core/                 # Pipeline executor
-│   ├── exceptions/           # Custom exception classes
-│   ├── feature_extractors/   # Feature extraction plugins
-│   ├── processors/           # Image processing pipeline
-│   ├── tools/                # Utility scripts
-│   └── utils/                # Shared utilities
-├── tests/                    # Test suite
-├── config.json               # Application configuration
-└── pyproject.toml            # Project metadata & dependencies
-```
-
 ## Installation
 
 ```bash
@@ -64,34 +45,44 @@ uv sync --group dev
 Run the application with default settings:
 
 ```bash
-uv run pochi
+uv run pochi run
 ```
 
 ## Command-Line Interface
 
-pochivision provides a flexible command-line interface via the `pochi` command:
+pochivision provides a CLI built on subcommands via the `pochi` command:
 
 ```bash
-# Use a specific camera device (by index)
-uv run pochi --camera 1
-
-# Use a specific camera profile from config
-uv run pochi --profile "high_res"
-
-# Use both a specific camera and profile
-uv run pochi --camera 2 --profile "high_fps"
-
-# List all available camera profiles
-uv run pochi --list-profiles
-
-# Use an alternative config file
-uv run pochi --config "my_config.json"
-
-# Disable recording
-uv run pochi --no-recording
+# Show available subcommands
+uv run pochi --help
 ```
 
-### CLI Arguments
+### `pochi run` - Launch live preview
+
+Start the camera preview with real-time image processing. This is the main entry point equivalent to the previous `pochi` command.
+
+```bash
+# Launch with default settings
+uv run pochi run
+
+# Use a specific camera device (by index)
+uv run pochi run --camera 1
+
+# Use a specific camera profile from config
+uv run pochi run --profile "high_res"
+
+# Use both a specific camera and profile
+uv run pochi run --camera 2 --profile "high_fps"
+
+# List all available camera profiles
+uv run pochi run --list-profiles
+
+# Use an alternative config file
+uv run pochi run --config "my_config.json"
+
+# Disable recording
+uv run pochi run --no-recording
+```
 
 | Argument | Short | Description |
 |----------|-------|-------------|
@@ -100,6 +91,78 @@ uv run pochi --no-recording
 | `--list-profiles` | `-l` | Display all available camera profiles |
 | `--config` | | Specify a config file path (default: config.json) |
 | `--no-recording` | | Disable recording functionality |
+
+### `pochi extract` - Extract features from images
+
+Run feature extraction on images using the extractor configuration file.
+
+```bash
+# Use default config (extractor_config.json)
+uv run pochi extract
+
+# Use a custom config file
+uv run pochi extract --config my_extractor_config.json
+```
+
+| Argument | Short | Description |
+|----------|-------|-------------|
+| `--config` | `-c` | Extractor config file path (default: extractor_config.json) |
+
+### `pochi process` - Apply camera profile processing to images
+
+Apply the image processing pipeline defined in a camera profile to a directory of images.
+
+```bash
+# Process images with a specific profile
+uv run pochi process --input ./images --profile all_para
+
+# Process with a custom config and output directory
+uv run pochi process --config my_config.json --input ./images --output ./processed --profile high_res
+
+# List available profiles
+uv run pochi process --list-profiles
+
+# Skip saving original images
+uv run pochi process --input ./images --profile all_para --no-save-original
+```
+
+| Argument | Short | Description |
+|----------|-------|-------------|
+| `--config` | `-c` | Config file path (default: config.json) |
+| `--input` | `-i` | Input image directory (required) |
+| `--output` | `-o` | Output directory (default: auto-generated) |
+| `--profile` | `-p` | Camera profile name (required) |
+| `--no-save-original` | | Do not save original images alongside processed ones |
+| `--list-profiles` | | Display all available camera profiles |
+
+### `pochi aggregate` - Aggregate images
+
+Collect and organize images from nested directories into a single directory.
+
+```bash
+# Aggregate images (copy mode)
+uv run pochi aggregate --input ./captured_images
+
+# Aggregate images (move mode)
+uv run pochi aggregate --input ./captured_images --mode move
+```
+
+| Argument | Short | Description |
+|----------|-------|-------------|
+| `--input` | `-i` | Input directory containing images (required) |
+| `--mode` | `-m` | Aggregation mode: `copy` or `move` (default: copy) |
+
+### `pochi fft` - FFT visualizer
+
+Visualize the FFT (Fast Fourier Transform) spectrum of images.
+
+```bash
+uv run pochi fft --input image.png
+```
+
+| Argument | Short | Description |
+|----------|-------|-------------|
+| `--input` | `-i` | Input image path (required) |
 
 ## Configuration
 
@@ -168,17 +231,6 @@ The application uses a JSON configuration file to define camera profiles, proces
 - When only `--camera` is specified on the command line, profile "0" will be used
 - Each camera profile can specify different processors and settings
 - Specifying an unregistered processor will result in an error
-
-## Architecture
-
-pochivision follows SOLID principles with a modular architecture:
-
-- **CLI**: Command-line entrypoint (`pochi` command)
-- **Core**: Central pipeline execution (pipeline / parallel modes)
-- **CaptureLib**: Camera setup, config handling, logging, recording
-- **Processors**: Image processing modules (registry pattern)
-- **Feature Extractors**: Feature extraction plugins (registry pattern)
-- **Capture Runner**: Live preview and application control
 
 ## Available Processors
 

--- a/README.md
+++ b/README.md
@@ -21,26 +21,6 @@
 - コーデック選択可能な録画機能
 - 柔軟なコマンドラインインターフェース
 
-## ディレクトリ構成
-
-```
-pochivision/
-├── pochivision/
-│   ├── cli/                  # CLI エントリーポイント (pochi コマンド)
-│   ├── capture_runner/       # カメラキャプチャとプレビュー実行
-│   ├── capturelib/           # カメラセットアップ, 設定, ログ, 録画
-│   ├── core/                 # パイプラインエグゼキュータ
-│   ├── exceptions/           # カスタム例外クラス
-│   ├── feature_extractors/   # 特徴量抽出プラグイン
-│   ├── processors/           # 画像処理パイプライン
-│   └── utils/                # 共通ユーティリティ
-├── tools/                    # スタンドアロンユーティリティスクリプト
-├── docs/                     # 特徴量ガイド等のドキュメント
-├── tests/                    # テストスイート
-├── config.json               # アプリケーション設定
-└── pyproject.toml            # プロジェクトメタデータ・依存関係
-```
-
 ## インストール
 
 ```bash
@@ -65,34 +45,35 @@ uv sync --group dev
 デフォルト設定でアプリケーションを実行:
 
 ```bash
-uv run pochi
+uv run pochi run
 ```
 
 ## コマンドラインインターフェース
 
-pochivision は `pochi` コマンドによる柔軟な CLI を提供しています:
+pochivision は `pochi` コマンドによるサブコマンド構成の CLI を提供しています:
 
 ```bash
-# 特定のカメラデバイスを使用 (インデックスで指定)
-uv run pochi --camera 1
-
-# 設定から特定のカメラプロファイルを使用
-uv run pochi --profile "high_res"
-
-# 特定のカメラとプロファイルの両方を使用
-uv run pochi --camera 2 --profile "high_fps"
-
-# 利用可能な全てのカメラプロファイルを一覧表示
-uv run pochi --list-profiles
-
-# 代替設定ファイルを使用
-uv run pochi --config "my_config.json"
-
-# 録画機能を無効にして起動
-uv run pochi --no-recording
+# サブコマンド一覧を表示
+uv run pochi --help
 ```
 
-### CLI 引数
+### `pochi run` - ライブプレビュー起動
+
+カメラからのリアルタイムキャプチャとプレビューを起動します.
+
+```bash
+# デフォルト設定で起動
+uv run pochi run
+
+# 特定のカメラデバイスとプロファイルを指定
+uv run pochi run --camera 2 --profile "high_fps"
+
+# 利用可能な全てのカメラプロファイルを一覧表示
+uv run pochi run --list-profiles
+
+# 録画機能を無効にして起動
+uv run pochi run --no-recording
+```
 
 | 引数 | 短縮形 | 説明 |
 |----------|-------|-------------|
@@ -101,6 +82,75 @@ uv run pochi --no-recording
 | `--list-profiles` | `-l` | 利用可能な全てのカメラプロファイルを表示 |
 | `--config` | | 設定ファイルのパスを指定 (デフォルト: config.json) |
 | `--no-recording` | | 録画機能を無効にして起動 |
+
+### `pochi extract` - 特徴量抽出
+
+画像から特徴量を抽出し, CSV ファイルに出力します.
+
+```bash
+# デフォルト設定ファイルで実行
+uv run pochi extract
+
+# 設定ファイルを指定して実行
+uv run pochi extract --config my_extractor_config.json
+```
+
+| 引数 | 短縮形 | 説明 |
+|----------|-------|-------------|
+| `--config` | `-c` | 設定ファイルのパスを指定 (デフォルト: extractor_config.json) |
+
+### `pochi process` - プロファイル適用
+
+カメラプロファイルの処理パイプラインを画像に適用します.
+
+```bash
+# 入力ディレクトリの画像にプロファイルを適用
+uv run pochi process --input ./images --profile "high_res"
+
+# 出力先を指定し, 元画像の保存をスキップ
+uv run pochi process --input ./images --output ./processed --profile "high_res" --no-save-original
+
+# 利用可能なプロファイルを一覧表示
+uv run pochi process --list-profiles
+```
+
+| 引数 | 短縮形 | 説明 |
+|----------|-------|-------------|
+| `--config` | `-c` | 設定ファイルのパスを指定 (デフォルト: config.json) |
+| `--input` | `-i` | 入力画像ディレクトリ (必須) |
+| `--output` | `-o` | 出力ディレクトリ |
+| `--profile` | `-p` | 適用するカメラプロファイル名 (必須) |
+| `--no-save-original` | | 元画像の保存をスキップ |
+| `--list-profiles` | | 利用可能な全てのカメラプロファイルを表示 |
+
+### `pochi aggregate` - 画像集約
+
+複数ディレクトリから画像を1つのディレクトリに集約します.
+
+```bash
+# 画像をコピーして集約
+uv run pochi aggregate --input ./data
+
+# 画像を移動して集約
+uv run pochi aggregate --input ./data --mode move
+```
+
+| 引数 | 短縮形 | 説明 |
+|----------|-------|-------------|
+| `--input` | `-i` | 入力ディレクトリ (必須) |
+| `--mode` | `-m` | 集約モード: `copy` または `move` (デフォルト: copy) |
+
+### `pochi fft` - FFT ビジュアライザー
+
+画像の FFT (高速フーリエ変換) スペクトルを可視化します.
+
+```bash
+uv run pochi fft --input image.png
+```
+
+| 引数 | 短縮形 | 説明 |
+|----------|-------|-------------|
+| `--input` | `-i` | 入力画像パス (必須) |
 
 ## 設定
 
@@ -169,17 +219,6 @@ uv run pochi --no-recording
 - コマンドラインで `--camera` のみ指定した場合, プロファイル "0" を使用します
 - カメラプロファイルごとに異なるプロセッサと設定を指定できます
 - 登録されていないプロセッサを指定するとエラーになります
-
-## アーキテクチャ
-
-pochivision は SOLID 原則に従ったモジュール式アーキテクチャを採用しています:
-
-- **CLI**: コマンドラインエントリーポイント (`pochi` コマンド)
-- **Core**: パイプライン実行 (pipeline / parallel モード)
-- **CaptureLib**: カメラセットアップ, 設定管理, ログ, 録画
-- **Processors**: 画像処理モジュール (レジストリパターン)
-- **Feature Extractors**: 特徴量抽出プラグイン (レジストリパターン)
-- **Capture Runner**: ライブプレビューとアプリケーション制御
 
 ## 利用可能なプロセッサ
 


### PR DESCRIPTION
## Summary

- README.md / README.en.md を CLI サブコマンド構成 (#245) に合わせて更新
- 不要なディレクトリ構成・アーキテクチャセクションを削除
- CLAUDE.md の CLI コマンド例と tools/ の記述を更新

## Related Issue

無し

## Changes

- `README.md`: クイックスタートを `pochi run` に変更. CLI セクションをサブコマンド構成 (`run`, `extract`, `process`, `aggregate`, `fft`) に全面書き換え. ディレクトリ構成・アーキテクチャセクションを削除
- `README.en.md`: 同上 (英語版)
- `CLAUDE.md`: Running セクションに全サブコマンドの使用例を追加. Architecture セクションの tools/ 記述を更新し `cli/commands/` を追加

## Test Plan

- [x] `uv run pre-commit run --all-files` で全チェックが通る

## Checklist

- [x] README.md が CLI サブコマンド構成を反映している
- [x] README.en.md が CLI サブコマンド構成を反映している
- [x] CLAUDE.md の CLI・tools 記述が最新の状態を反映している
- [x] ディレクトリ構成・アーキテクチャセクションが削除されている
