### PR TITLE
fix: ConfigHandler.save の strftime フォーマットを修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - 無し
 
 ### Fixed
-- 無し
+- `ConfigHandler.save()` の `strftime` フォーマットを `%Y-%m%d-%H%M-%S` から `%Y%m%d_%H%M%S` に修正. (NA.)
 
 ### Removed
 - 無し

--- a/pochivision/capturelib/config_handler.py
+++ b/pochivision/capturelib/config_handler.py
@@ -73,7 +73,7 @@ class ConfigHandler:
             config (dict): 保存する設定辞書。
             output_dir (Path): 保存先ディレクトリのパス。
         """
-        timestamp = datetime.now().strftime("%Y-%m%d-%H%M-%S")
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
         filename = output_dir / f"{timestamp}_config.json"
 
         config_copy = config.copy()


### PR DESCRIPTION
## Summary

- `ConfigHandler.save()` の `strftime` フォーマット文字列を修正

## Related Issue

Closes #249

## Changes

- `pochivision/capturelib/config_handler.py`: `strftime("%Y-%m%d-%H%M-%S")` → `strftime("%Y%m%d_%H%M%S")` に修正. `%m` と `%d` の間のハイフン欠落を修正し, 他の出力ディレクトリ (`YYYYMMDD_{suffix}`) と命名規則を統一

## Test Plan

- [x] `uv run pre-commit run --all-files` で全チェックが通る

## Checklist

- [x] strftime フォーマットが修正されている
- [x] 既存テストが通る
