### PR TITLE
fix: VideoWriter 初期化失敗時のクリーンアップ不足を修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@
 - 無し
 
 ### Fixed
-- `ConfigHandler.save()` の `strftime` フォーマットを `%Y-%m%d-%H%M-%S` から `%Y%m%d_%H%M%S` に修正. (NA.)
+- `ConfigHandler.save()` の `strftime` フォーマットを `%Y-%m%d-%H%M-%S` から `%Y%m%d_%H%M%S` に修正. ([#263](https://github.com/kurorosu/pochivision/pull/263))
+- `RecordingManager.start_recording()` で `VideoWriter` 初期化失敗時に `video_writer` を `None` にクリアするよう修正. (NA.)
 
 ### Removed
 - 無し

--- a/pochivision/capturelib/recording_manager.py
+++ b/pochivision/capturelib/recording_manager.py
@@ -166,6 +166,8 @@ class RecordingManager:
                 self.logger.error(
                     f"Failed to initialize VideoWriter with format {self.video_format}"
                 )
+                self.video_writer.release()
+                self.video_writer = None
                 return False
 
             # 録画フラグを設定
@@ -182,6 +184,9 @@ class RecordingManager:
 
         except Exception as e:
             self.logger.error(f"Error occurred while starting recording: {e}")
+            if self.video_writer is not None:
+                self.video_writer.release()
+                self.video_writer = None
             return False
 
     def stop_recording(self) -> bool:


### PR DESCRIPTION
## Summary

- `RecordingManager.start_recording()` で `VideoWriter` 初期化失敗時のクリーンアップ不足を修正

## Related Issue

Closes #250

## Changes

- `pochivision/capturelib/recording_manager.py`: `VideoWriter.isOpened()` 失敗時と例外キャッチ時に `release()` + `self.video_writer = None` を追加

## Code Changes

```python
# pochivision/capturelib/recording_manager.py
# isOpened() 失敗時
if not self.video_writer.isOpened():
    self.logger.error(
        f"Failed to initialize VideoWriter with format {self.video_format}"
    )
    self.video_writer.release()
    self.video_writer = None
    return False

# 例外キャッチ時
except Exception as e:
    self.logger.error(f"Error occurred while starting recording: {e}")
    if self.video_writer is not None:
        self.video_writer.release()
        self.video_writer = None
    return False
```

## Test Plan

- [x] `uv run pre-commit run --all-files` で全チェックが通る

## Checklist

- [x] `VideoWriter.isOpened()` 失敗時に `video_writer` が `None` にクリアされる
- [x] 例外発生時にも `video_writer` が `None` にクリアされる
- [x] 既存テストが通る
