### PR TITLE
refactor: 未使用の ExtractorRuntimeError を削除

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,10 @@
 
 ### Fixed
 - `ConfigHandler.save()` の `strftime` フォーマットを `%Y-%m%d-%H%M-%S` から `%Y%m%d_%H%M%S` に修正. ([#263](https://github.com/kurorosu/pochivision/pull/263))
-- `RecordingManager.start_recording()` で `VideoWriter` 初期化失敗時に `video_writer` を `None` にクリアするよう修正. (NA.)
+- `RecordingManager.start_recording()` で `VideoWriter` 初期化失敗時に `video_writer` を `None` にクリアするよう修正. ([#264](https://github.com/kurorosu/pochivision/pull/264))
 
 ### Removed
-- 無し
+- 未使用の `ExtractorRuntimeError` 例外クラスを削除. (NA.)
 
 ## [0.2.0] - 2026-04-02
 

--- a/pochivision/exceptions/__init__.py
+++ b/pochivision/exceptions/__init__.py
@@ -2,7 +2,7 @@
 
 from .base import VisionCaptureError
 from .config import CameraConfigError, ConfigLoadError, ConfigValidationError
-from .extractor import ExtractorRuntimeError, ExtractorValidationError
+from .extractor import ExtractorValidationError
 from .processor import ProcessorRuntimeError, ProcessorValidationError
 
 __all__ = [
@@ -13,5 +13,4 @@ __all__ = [
     "ConfigLoadError",
     "CameraConfigError",
     "ExtractorValidationError",
-    "ExtractorRuntimeError",
 ]

--- a/pochivision/exceptions/extractor.py
+++ b/pochivision/exceptions/extractor.py
@@ -7,9 +7,3 @@ class ExtractorValidationError(VisionCaptureError, ValueError):
     """特徴量抽出器の入力バリデーションエラー用例外クラス."""
 
     pass
-
-
-class ExtractorRuntimeError(VisionCaptureError, RuntimeError):
-    """特徴量抽出器の実行時エラー用例外クラス."""
-
-    pass


### PR DESCRIPTION
## Summary

- 定義のみで未使用の `ExtractorRuntimeError` 例外クラスを削除

## Related Issue

Closes #251

## Changes

- `pochivision/exceptions/extractor.py` から `ExtractorRuntimeError` クラスを削除
- `pochivision/exceptions/__init__.py` からエクスポートを削除

## Test Plan

- [x] `uv run pre-commit run --all-files` で全チェックが通る

## Checklist

- [x] `ExtractorRuntimeError` が削除されている
- [x] `__init__.py` のエクスポートが更新されている
- [x] 既存テストが通る
