### PR TITLE
refactor: CameraConfigHandler の未使用メソッドを削除

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@
 - `RecordingManager.start_recording()` で `VideoWriter` 初期化失敗時に `video_writer` を `None` にクリアするよう修正. ([#264](https://github.com/kurorosu/pochivision/pull/264))
 
 ### Removed
-- 未使用の `ExtractorRuntimeError` 例外クラスを削除. (NA.)
+- 未使用の `ExtractorRuntimeError` 例外クラスを削除. ([#265](https://github.com/kurorosu/pochivision/pull/265))
+- `CameraConfigHandler` の未使用メソッド (`get_camera_config`, `get_all_camera_indices`, `get_selected_camera_index`) を削除. (NA.)
 
 ## [0.2.0] - 2026-04-02
 

--- a/pochivision/capturelib/config_handler.py
+++ b/pochivision/capturelib/config_handler.py
@@ -7,7 +7,7 @@
 import json
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, Tuple
 
 from pydantic import ValidationError
 
@@ -95,41 +95,6 @@ class CameraConfigHandler:
     _logger = LogManager().get_logger()
 
     @staticmethod
-    def get_camera_config(config: Dict[str, Any], camera_index: int) -> Dict[str, Any]:
-        """
-        指定されたカメラインデックスの設定を取得する.
-
-        カメラインデックスが指定されていない場合はselected_camera_indexの設定を使用。
-
-        Args:
-            config (dict): 設定辞書。
-            camera_index (int, optional): カメラインデックス。Noneの場合はselected_camera_indexを使用。
-
-        Returns:
-            dict: カメラ設定の辞書。
-
-        Raises:
-            CameraConfigError: カメラ設定がない場合、または指定されたカメラインデックスの設定がない場合。
-        """
-        if "cameras" not in config:
-            raise CameraConfigError("No camera configurations found in config")
-
-        if camera_index is None:
-            if "selected_camera_index" in config:
-                camera_index = config["selected_camera_index"]
-            else:
-                raise CameraConfigError("No selected camera index specified in config")
-
-        camera_id_str = str(camera_index)
-        if camera_id_str not in config["cameras"]:
-            raise CameraConfigError(
-                f"No configuration found for camera index: {camera_index}"
-            )
-
-        result: Dict[str, Any] = config["cameras"][camera_id_str]
-        return result
-
-    @staticmethod
     def get_camera_processors(config: Dict[str, Any], profile_name: str) -> Tuple:
         """
         指定されたカメラプロファイルのプロセッサ設定を取得する.
@@ -178,46 +143,3 @@ class CameraConfigHandler:
         mode = camera_config.get("mode", "parallel")
 
         return processors, processor_configs, mode
-
-    @staticmethod
-    def get_all_camera_indices(config: Dict[str, Any]) -> List[int]:
-        """
-        設定ファイルに定義されているすべてのカメラインデックスを取得する.
-
-        Args:
-            config (dict): 設定辞書。
-
-        Returns:
-            List[int]: カメラインデックスのリスト。
-
-        Raises:
-            CameraConfigError: カメラ設定が設定ファイルに存在しない場合。
-        """
-        if "cameras" not in config:
-            raise CameraConfigError("No camera configurations found in config")
-
-        # 文字列のカメラインデックスを整数に変換して返す
-        return [int(camera_id) for camera_id in config["cameras"].keys()]
-
-    @staticmethod
-    def get_selected_camera_index(config: Dict[str, Any]) -> int:
-        """
-        選択されたカメラインデックスを取得する.
-
-        Args:
-            config (dict): 設定辞書。
-
-        Returns:
-            int: 選択されたカメラインデックス。
-
-        Raises:
-            CameraConfigError: 選択されたカメラインデックスの指定がない場合。
-        """
-        if "selected_camera_index" in config:
-            return int(config["selected_camera_index"])
-
-        # カメラが定義されていれば、最初のカメラを選択
-        if "cameras" in config and config["cameras"]:
-            return int(list(config["cameras"].keys())[0])
-
-        raise CameraConfigError("No selected camera index specified in config")

--- a/tests/capturelib/test_config_handler.py
+++ b/tests/capturelib/test_config_handler.py
@@ -99,44 +99,6 @@ class TestConfigHandlerSave:
         assert "timestamp" in saved
 
 
-class TestCameraConfigHandlerGetCameraConfig:
-    """CameraConfigHandler.get_camera_config のテスト."""
-
-    def test_get_camera_config_by_index(self):
-        """カメラインデックスで設定を取得できる."""
-        config = _minimal_config()
-        result = CameraConfigHandler.get_camera_config(config, 0)
-
-        assert result["width"] == 1920
-        assert result["height"] == 1080
-
-    def test_get_camera_config_no_cameras_key(self):
-        """cameras キーがない場合 CameraConfigError."""
-        with pytest.raises(CameraConfigError, match="No camera configurations"):
-            CameraConfigHandler.get_camera_config({}, 0)
-
-    def test_get_camera_config_missing_index(self):
-        """指定インデックスが存在しない場合 CameraConfigError."""
-        config = _minimal_config()
-        with pytest.raises(CameraConfigError, match="No configuration found"):
-            CameraConfigHandler.get_camera_config(config, 99)
-
-    def test_get_camera_config_none_index_uses_selected(self):
-        """camera_index=None で selected_camera_index を使用する."""
-        config = _minimal_config()
-        result = CameraConfigHandler.get_camera_config(config, None)
-
-        assert result["width"] == 1920
-
-    def test_get_camera_config_none_index_no_selected(self):
-        """camera_index=None かつ selected_camera_index なしで CameraConfigError."""
-        config = _minimal_config()
-        del config["selected_camera_index"]
-
-        with pytest.raises(CameraConfigError, match="No selected camera index"):
-            CameraConfigHandler.get_camera_config(config, None)
-
-
 class TestCameraConfigHandlerGetProcessors:
     """CameraConfigHandler.get_camera_processors のテスト."""
 
@@ -185,39 +147,3 @@ class TestCameraConfigHandlerGetProcessors:
 
         _, _, mode = CameraConfigHandler.get_camera_processors(config, "0")
         assert mode == "parallel"
-
-
-class TestCameraConfigHandlerUtilities:
-    """ユーティリティメソッドのテスト."""
-
-    def test_get_all_camera_indices(self):
-        """全カメラインデックスを取得できる."""
-        config = _minimal_config()
-        indices = CameraConfigHandler.get_all_camera_indices(config)
-
-        assert indices == [0]
-
-    def test_get_all_camera_indices_no_cameras(self):
-        """cameras キーがない場合 CameraConfigError."""
-        with pytest.raises(CameraConfigError):
-            CameraConfigHandler.get_all_camera_indices({})
-
-    def test_get_selected_camera_index(self):
-        """選択されたカメラインデックスを取得できる."""
-        config = _minimal_config()
-        index = CameraConfigHandler.get_selected_camera_index(config)
-
-        assert index == 0
-
-    def test_get_selected_camera_index_fallback(self):
-        """selected_camera_index なしの場合, 最初のカメラを返す."""
-        config = _minimal_config()
-        del config["selected_camera_index"]
-
-        index = CameraConfigHandler.get_selected_camera_index(config)
-        assert index == 0
-
-    def test_get_selected_camera_index_no_cameras(self):
-        """カメラ設定がない場合 CameraConfigError."""
-        with pytest.raises(CameraConfigError, match="No selected camera index"):
-            CameraConfigHandler.get_selected_camera_index({})


### PR DESCRIPTION
## Summary

- `CameraConfigHandler` の未使用メソッド 3 件とその関連テストを削除

## Related Issue

Closes #252

## Changes

- `pochivision/capturelib/config_handler.py` から `get_camera_config()`, `get_all_camera_indices()`, `get_selected_camera_index()` を削除
- `typing` の未使用インポート `List` を削除
- `tests/capturelib/test_config_handler.py` から `TestCameraConfigHandlerGetCameraConfig`, `TestCameraConfigHandlerUtilities` クラスを削除

## Test Plan

- [x] `uv run pre-commit run --all-files` で全チェックが通る

## Checklist

- [x] 3 メソッドが削除されている
- [x] 関連テストが削除されている
- [x] 未使用インポートが削除されている
- [x] 既存テストが通る
