### PR TITLE
refactor: _get_image_files の重複を統合

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 - 無し
 
 ### Changed
-- `FeatureExtractionRunner` と `ProfileProcessor` の `_load_config()` を `ConfigHandler.load_json()` に統合. (NA.)
+- `FeatureExtractionRunner` と `ProfileProcessor` の `_load_config()` を `ConfigHandler.load_json()` に統合. ([#267](https://github.com/kurorosu/pochivision/pull/267))
+- `extract.py` と `process.py` の `_get_image_files()` を `utils/image.py` の `get_image_files()` に統合. (NA.)
 
 ### Fixed
 - `ConfigHandler.save()` の `strftime` フォーマットを `%Y-%m%d-%H%M-%S` から `%Y%m%d_%H%M%S` に修正. ([#263](https://github.com/kurorosu/pochivision/pull/263))

--- a/pochivision/cli/commands/extract.py
+++ b/pochivision/cli/commands/extract.py
@@ -14,6 +14,7 @@ import cv2
 from pochivision.capturelib.config_handler import ConfigHandler
 from pochivision.exceptions.config import ConfigLoadError
 from pochivision.feature_extractors.registry import get_feature_extractor
+from pochivision.utils.image import get_image_files
 from pochivision.workspace import OutputManager
 
 
@@ -112,21 +113,7 @@ class FeatureExtractionRunner:
             "case_sensitive", False
         )
 
-        image_files: List[Path] = []
-        for ext in extensions:
-            if case_sensitive:
-                pattern = f"*{ext}"
-            else:
-                pattern_lower = f"*{ext.lower()}"
-                pattern_upper = f"*{ext.upper()}"
-                image_files.extend(self.input_dir.glob(pattern_lower))
-                image_files.extend(self.input_dir.glob(pattern_upper))
-                continue
-
-            image_files.extend(self.input_dir.glob(pattern))
-
-        image_files = list(set(image_files))
-        image_files.sort()
+        image_files = get_image_files(self.input_dir, extensions, case_sensitive)
 
         if not image_files:
             print(

--- a/pochivision/cli/commands/process.py
+++ b/pochivision/cli/commands/process.py
@@ -14,6 +14,7 @@ import numpy as np
 from pochivision.capturelib.config_handler import ConfigHandler
 from pochivision.exceptions.config import ConfigLoadError, ConfigValidationError
 from pochivision.processors.registry import get_processor
+from pochivision.utils.image import DEFAULT_IMAGE_EXTENSIONS, get_image_files
 from pochivision.workspace import OutputManager
 
 
@@ -112,18 +113,11 @@ class ProfileProcessor:
             print(f"エラー: 入力ディレクトリが存在しません: {input_dir}")
             sys.exit(1)
 
-        extensions = [".jpg", ".jpeg", ".png", ".bmp", ".tiff", ".tif"]
-        image_files: List[Path] = []
-
-        for ext in extensions:
-            image_files.extend(input_dir.glob(f"*{ext.lower()}"))
-            image_files.extend(input_dir.glob(f"*{ext.upper()}"))
-
-        image_files = sorted(list(set(image_files)))
+        image_files = get_image_files(input_dir)
 
         if not image_files:
             print(f"警告: 入力ディレクトリに画像ファイルが見つかりません: {input_dir}")
-            print(f"対象拡張子: {extensions}")
+            print(f"対象拡張子: {DEFAULT_IMAGE_EXTENSIONS}")
 
         return image_files
 

--- a/pochivision/utils/image.py
+++ b/pochivision/utils/image.py
@@ -1,7 +1,41 @@
 """画像処理に関する共通ユーティリティ関数を提供するモジュール."""
 
+from pathlib import Path
+from typing import List, Optional
+
 import cv2
 import numpy as np
+
+DEFAULT_IMAGE_EXTENSIONS = [".jpg", ".jpeg", ".png", ".bmp", ".tiff", ".tif"]
+
+
+def get_image_files(
+    directory: Path,
+    extensions: Optional[List[str]] = None,
+    case_sensitive: bool = False,
+) -> List[Path]:
+    """ディレクトリから画像ファイルのパスリストを取得する.
+
+    Args:
+        directory: 検索対象ディレクトリ.
+        extensions: 対象拡張子のリスト. None の場合はデフォルト拡張子を使用.
+        case_sensitive: True の場合, 拡張子の大文字小文字を区別する.
+
+    Returns:
+        画像ファイルのパスリスト (ソート済み).
+    """
+    if extensions is None:
+        extensions = DEFAULT_IMAGE_EXTENSIONS
+
+    image_files: List[Path] = []
+    for ext in extensions:
+        if case_sensitive:
+            image_files.extend(directory.glob(f"*{ext}"))
+        else:
+            image_files.extend(directory.glob(f"*{ext.lower()}"))
+            image_files.extend(directory.glob(f"*{ext.upper()}"))
+
+    return sorted(set(image_files))
 
 
 def to_grayscale(image: np.ndarray) -> np.ndarray:


### PR DESCRIPTION
## Summary

- `extract.py` と `process.py` で重複していた画像ファイル取得ロジックを `utils/image.py` に統合

## Related Issue

Closes #254

## Changes

- `pochivision/utils/image.py` に `get_image_files()` と `DEFAULT_IMAGE_EXTENSIONS` を追加
- `pochivision/cli/commands/extract.py` の `_get_image_files()` から glob ロジックを `get_image_files()` に委譲
- `pochivision/cli/commands/process.py` も同様に変更

```python
# pochivision/utils/image.py
DEFAULT_IMAGE_EXTENSIONS = [".jpg", ".jpeg", ".png", ".bmp", ".tiff", ".tif"]

def get_image_files(
    directory: Path,
    extensions: Optional[List[str]] = None,
    case_sensitive: bool = False,
) -> List[Path]:
    """ディレクトリから画像ファイルのパスリストを取得する."""
    if extensions is None:
        extensions = DEFAULT_IMAGE_EXTENSIONS
    image_files: List[Path] = []
    for ext in extensions:
        if case_sensitive:
            image_files.extend(directory.glob(f"*{ext}"))
        else:
            image_files.extend(directory.glob(f"*{ext.lower()}"))
            image_files.extend(directory.glob(f"*{ext.upper()}"))
    return sorted(set(image_files))
```

## Test Plan

- [x] `uv run pre-commit run --all-files` で全チェックが通る

## Checklist

- [x] 画像ファイル取得ロジックが `utils/image.py` に統合されている
- [x] `extract.py` は設定ベースの拡張子と `case_sensitive` オプションを維持
- [x] `process.py` はデフォルト拡張子を使用
- [x] 既存テストが通る
