### PR TITLE
refactor: cv2.imread パターンの重複を統合

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
 
 ### Changed
 - `FeatureExtractionRunner` と `ProfileProcessor` の `_load_config()` を `ConfigHandler.load_json()` に統合. ([#267](https://github.com/kurorosu/pochivision/pull/267))
-- `extract.py` と `process.py` の `_get_image_files()` を `utils/image.py` の `get_image_files()` に統合. (NA.)
+- `extract.py` と `process.py` の `_get_image_files()` を `utils/image.py` の `get_image_files()` に統合. ([#268](https://github.com/kurorosu/pochivision/pull/268))
+- `cv2.imread` + None チェックパターンを `utils/image.py` の `load_image()` に統合. (NA.)
 
 ### Fixed
 - `ConfigHandler.save()` の `strftime` フォーマットを `%Y-%m%d-%H%M-%S` から `%Y%m%d_%H%M%S` に修正. ([#263](https://github.com/kurorosu/pochivision/pull/263))

--- a/pochivision/cli/commands/extract.py
+++ b/pochivision/cli/commands/extract.py
@@ -9,12 +9,11 @@ from pathlib import Path
 from typing import Any, Dict, List
 
 import click
-import cv2
 
 from pochivision.capturelib.config_handler import ConfigHandler
 from pochivision.exceptions.config import ConfigLoadError
 from pochivision.feature_extractors.registry import get_feature_extractor
-from pochivision.utils.image import get_image_files
+from pochivision.utils.image import get_image_files, load_image
 from pochivision.workspace import OutputManager
 
 
@@ -170,7 +169,7 @@ class FeatureExtractionRunner:
             抽出された特徴量の辞書.
         """
         try:
-            image = cv2.imread(str(image_path))
+            image = load_image(image_path)
             if image is None:
                 print(f"警告: 画像の読み込みに失敗しました: {image_path}")
                 return {}

--- a/pochivision/cli/commands/fft.py
+++ b/pochivision/cli/commands/fft.py
@@ -8,6 +8,8 @@ import click
 import cv2
 import numpy as np
 
+from pochivision.utils.image import load_image
+
 
 class SimpleFFTVisualizer:
     """シンプルなFFTビジュアライザークラス."""
@@ -32,7 +34,7 @@ class SimpleFFTVisualizer:
             print(f"エラー: 画像ファイルが見つかりません: {self.image_path}")
             return False
 
-        original_img = cv2.imread(str(self.image_path))
+        original_img = load_image(self.image_path)
 
         if original_img is None:
             print(f"エラー: 画像ファイルを読み込めません: {self.image_path}")

--- a/pochivision/cli/commands/process.py
+++ b/pochivision/cli/commands/process.py
@@ -14,7 +14,11 @@ import numpy as np
 from pochivision.capturelib.config_handler import ConfigHandler
 from pochivision.exceptions.config import ConfigLoadError, ConfigValidationError
 from pochivision.processors.registry import get_processor
-from pochivision.utils.image import DEFAULT_IMAGE_EXTENSIONS, get_image_files
+from pochivision.utils.image import (
+    DEFAULT_IMAGE_EXTENSIONS,
+    get_image_files,
+    load_image,
+)
 from pochivision.workspace import OutputManager
 
 
@@ -139,7 +143,7 @@ class ProfileProcessor:
             処理された画像. エラーの場合は None.
         """
         try:
-            image = cv2.imread(str(image_path))
+            image = load_image(image_path)
             if image is None:
                 print(f"警告: 画像の読み込みに失敗しました: {image_path}")
                 return None

--- a/pochivision/utils/image.py
+++ b/pochivision/utils/image.py
@@ -9,6 +9,21 @@ import numpy as np
 DEFAULT_IMAGE_EXTENSIONS = [".jpg", ".jpeg", ".png", ".bmp", ".tiff", ".tif"]
 
 
+def load_image(image_path: Path) -> Optional[np.ndarray]:
+    """画像ファイルを読み込む.
+
+    Args:
+        image_path: 画像ファイルのパス.
+
+    Returns:
+        読み込んだ画像. 失敗時は None.
+    """
+    image = cv2.imread(str(image_path))
+    if image is None:
+        return None
+    return image
+
+
 def get_image_files(
     directory: Path,
     extensions: Optional[List[str]] = None,


### PR DESCRIPTION
## Summary

- `extract.py`, `process.py`, `fft.py` で重複していた `cv2.imread` + None チェックパターンを `utils/image.py` の `load_image()` に統合

## Related Issue

Closes #255

## Changes

- `pochivision/utils/image.py` に `load_image()` 関数を追加
- `pochivision/cli/commands/extract.py`, `process.py`, `fft.py` の `cv2.imread` を `load_image()` に置換
- `extract.py` から不要になった `cv2` インポートを削除

```python
# pochivision/utils/image.py
def load_image(image_path: Path) -> Optional[np.ndarray]:
    """画像ファイルを読み込む."""
    image = cv2.imread(str(image_path))
    if image is None:
        return None
    return image
```

## Test Plan

- [x] `uv run pre-commit run --all-files` で全チェックが通る

## Checklist

- [x] `cv2.imread` + None チェックが `load_image()` に統合されている
- [x] `extract.py`, `process.py`, `fft.py` の 3 箇所が置換されている
- [x] 不要な `cv2` インポートが削除されている
- [x] 既存テストが通る
