### PR TITLE
refactor: sys.exit を click.ClickException に置換

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@
 ### Changed
 - `FeatureExtractionRunner` と `ProfileProcessor` の `_load_config()` を `ConfigHandler.load_json()` に統合. ([#267](https://github.com/kurorosu/pochivision/pull/267))
 - `extract.py` と `process.py` の `_get_image_files()` を `utils/image.py` の `get_image_files()` に統合. ([#268](https://github.com/kurorosu/pochivision/pull/268))
-- `cv2.imread` + None チェックパターンを `utils/image.py` の `load_image()` に統合. (NA.)
+- `cv2.imread` + None チェックパターンを `utils/image.py` の `load_image()` に統合. ([#269](https://github.com/kurorosu/pochivision/pull/269))
+- CLI コマンドの `sys.exit(1)` を `click.ClickException` に置換. (NA.)
 
 ### Fixed
 - `ConfigHandler.save()` の `strftime` フォーマットを `%Y-%m%d-%H%M-%S` から `%Y%m%d_%H%M%S` に修正. ([#263](https://github.com/kurorosu/pochivision/pull/263))

--- a/pochivision/cli/commands/extract.py
+++ b/pochivision/cli/commands/extract.py
@@ -3,7 +3,6 @@
 import csv
 import inspect
 import shutil
-import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List
@@ -52,8 +51,7 @@ class FeatureExtractionRunner:
         try:
             return ConfigHandler.load_json(config_path)
         except ConfigLoadError as e:
-            print(f"エラー: {e}")
-            sys.exit(1)
+            raise click.ClickException(str(e))
 
     def _copy_config_to_output(self) -> None:
         """使用した設定ファイルを出力ディレクトリにコピーする."""
@@ -90,8 +88,7 @@ class FeatureExtractionRunner:
                 print(f"警告: 特徴量抽出器の初期化に失敗しました ({name}): {e}")
 
         if not extractors:
-            print("エラー: 使用可能な特徴量抽出器がありません")
-            sys.exit(1)
+            raise click.ClickException("使用可能な特徴量抽出器がありません")
 
         return extractors
 
@@ -102,8 +99,9 @@ class FeatureExtractionRunner:
             画像ファイルのパスリスト.
         """
         if not self.input_dir.exists():
-            print(f"エラー: 入力ディレクトリが存在しません: {self.input_dir}")
-            sys.exit(1)
+            raise click.ClickException(
+                f"入力ディレクトリが存在しません: {self.input_dir}"
+            )
 
         extensions = self.config.get("file_filters", {}).get(
             "extensions", [".jpg", ".png"]

--- a/pochivision/cli/commands/fft.py
+++ b/pochivision/cli/commands/fft.py
@@ -1,6 +1,5 @@
 """fft サブコマンド: FFT ビジュアライザー."""
 
-import sys
 from pathlib import Path
 from typing import Optional
 
@@ -297,5 +296,4 @@ def fft(input_path: str) -> None:
     except KeyboardInterrupt:
         print("\n中断されました")
     except Exception as e:
-        print(f"エラーが発生しました: {e}")
-        sys.exit(1)
+        raise click.ClickException(str(e))

--- a/pochivision/cli/commands/process.py
+++ b/pochivision/cli/commands/process.py
@@ -2,7 +2,6 @@
 
 import json
 import shutil
-import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -59,8 +58,7 @@ class ProfileProcessor:
         try:
             return ConfigHandler.load(config_path)
         except (ConfigLoadError, ConfigValidationError) as e:
-            print(f"エラー: {e}")
-            sys.exit(1)
+            raise click.ClickException(str(e))
 
     def _get_profile_config(self, profile_name: str) -> Dict[str, Any]:
         """指定されたプロファイルの設定を取得する.
@@ -74,9 +72,10 @@ class ProfileProcessor:
         cameras = self.config.get("cameras", {})
         if profile_name not in cameras:
             available_profiles = list(cameras.keys())
-            print(f"エラー: プロファイル '{profile_name}' が見つかりません")
-            print(f"利用可能なプロファイル: {available_profiles}")
-            sys.exit(1)
+            raise click.ClickException(
+                f"プロファイル '{profile_name}' が見つかりません. "
+                f"利用可能なプロファイル: {available_profiles}"
+            )
 
         result: Dict[str, Any] = cameras[profile_name]
         return result
@@ -114,8 +113,7 @@ class ProfileProcessor:
             画像ファイルのパスリスト.
         """
         if not input_dir.exists():
-            print(f"エラー: 入力ディレクトリが存在しません: {input_dir}")
-            sys.exit(1)
+            raise click.ClickException(f"入力ディレクトリが存在しません: {input_dir}")
 
         image_files = get_image_files(input_dir)
 


### PR DESCRIPTION
## Summary

- CLI コマンド (`extract.py`, `process.py`, `fft.py`) の `sys.exit(1)` を `click.ClickException` に置換

## Related Issue

Closes #256

## Changes

- `pochivision/cli/commands/extract.py` の 3 箇所を `raise click.ClickException()` に置換, `sys` インポート削除
- `pochivision/cli/commands/process.py` の 3 箇所を同様に置換, `sys` インポート削除
- `pochivision/cli/commands/fft.py` の 1 箇所を同様に置換, `sys` インポート削除

```python
# Before
print(f"エラー: {e}")
sys.exit(1)

# After
raise click.ClickException(str(e))
```

## Test Plan

- [x] `uv run pre-commit run --all-files` で全チェックが通る

## Checklist

- [x] `sys.exit()` が CLI コマンドファイルから排除されている
- [x] `sys` モジュールのインポートが削除されている
- [x] 既存テストが通る
