### PR TITLE
refactor: PipelineExecutor の File I/O 責務を分離

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@
 - CLI コマンドの `sys.exit(1)` を `click.ClickException` に置換. ([#270](https://github.com/kurorosu/pochivision/pull/270))
 - `extract.py` と `process.py` の `print()` を `LogManager` に統一. ([#271](https://github.com/kurorosu/pochivision/pull/271))
 - マジックナンバーを `pochivision/constants.py` に定数化. ([#273](https://github.com/kurorosu/pochivision/pull/273))
-- CLI コマンドからビジネスロジッククラスを `core/` に分離. (NA.)
+- CLI コマンドからビジネスロジッククラスを `core/` に分離. ([#274](https://github.com/kurorosu/pochivision/pull/274))
+- `PipelineExecutor` の File I/O 責務を `ImageSaver` クラスに分離. (NA.)
 
 ### Fixed
 - `ConfigHandler.save()` の `strftime` フォーマットを `%Y-%m%d-%H%M-%S` から `%Y%m%d_%H%M%S` に修正. ([#263](https://github.com/kurorosu/pochivision/pull/263))

--- a/pochivision/core/__init__.py
+++ b/pochivision/core/__init__.py
@@ -3,5 +3,6 @@
 # flake8: noqa: F401
 from .feature_extraction import FeatureExtractionRunner
 from .fft_visualization import SimpleFFTVisualizer
+from .image_saver import ImageSaver
 from .pipeline_executor import PipelineExecutor
 from .profile_processing import ProfileProcessor

--- a/pochivision/core/image_saver.py
+++ b/pochivision/core/image_saver.py
@@ -1,0 +1,69 @@
+"""画像の保存・ディレクトリ管理を行うモジュール."""
+
+import time
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+from pochivision.capturelib import LogManager
+from pochivision.utils.file_naming import get_file_naming_manager
+
+
+class ImageSaver:
+    """画像ファイルの保存とディレクトリ管理を担当するクラス.
+
+    Attributes:
+        output_dir: 処理結果の保存先ルートディレクトリ.
+        camera_index: このセーバーが対応するカメラのインデックス.
+    """
+
+    def __init__(self, output_dir: Path, camera_index: int = 0) -> None:
+        """ImageSaverのコンストラクタ.
+
+        Args:
+            output_dir: 処理結果の保存先ディレクトリ.
+            camera_index: カメラのインデックス.
+        """
+        self.output_dir = output_dir
+        self.camera_index = camera_index
+        self.logger = LogManager().get_logger()
+
+    def get_processing_dir(self, process_name: str) -> Path:
+        """処理結果保存用のサブディレクトリを取得する.
+
+        Args:
+            process_name: 処理の名前. 例: 'grayscale', 'gaussian_blur'.
+
+        Returns:
+            処理結果保存用ディレクトリのパス.
+        """
+        path = self.output_dir / process_name
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+
+    def save(self, image: np.ndarray, processor_name: str) -> None:
+        """処理された画像を保存する.
+
+        Args:
+            image: 処理済み画像.
+            processor_name: 処理に使われたプロセッサの名前.
+        """
+        save_dir = self.get_processing_dir(processor_name)
+
+        filename, id_index, image_index = get_file_naming_manager().get_filename(
+            processor_name, self.camera_index
+        )
+        path = save_dir / filename
+
+        save_start = time.time()
+        try:
+            cv2.imwrite(str(path), image)
+            save_time = time.time() - save_start
+            self.logger.info(
+                f"Image saved ({processor_name}): {path} "
+                f"({image.shape[1]}x{image.shape[0]}, "
+                f"id={id_index}, image={image_index}, {save_time:.3f} sec)"
+            )
+        except Exception as e:
+            self.logger.error(f"Failed to save image ({processor_name}): {e}")

--- a/pochivision/core/pipeline_executor.py
+++ b/pochivision/core/pipeline_executor.py
@@ -4,18 +4,18 @@ import time
 from pathlib import Path
 from typing import Any, Dict, List
 
-import cv2
 import numpy as np
 
 from pochivision.capturelib import LogManager
 from pochivision.capturelib.config_handler import CameraConfigHandler
+from pochivision.core.image_saver import ImageSaver
 from pochivision.processors import BaseProcessor
 from pochivision.processors.registry import PROCESSOR_REGISTRY
 from pochivision.utils.file_naming import get_file_naming_manager
 
 
 class PipelineExecutor:
-    """画像処理プロセッサ群を管理し, 処理と保存を行うパイプライン実行クラス.
+    """画像処理プロセッサ群を管理し, 処理を行うパイプライン実行クラス.
 
     Attributes:
         processors: 実行対象の画像処理プロセッサのリスト.
@@ -24,6 +24,7 @@ class PipelineExecutor:
         camera_index: このパイプラインが対応するカメラのインデックス.
         id_interval: ID値が増加する画像数の間隔.
         config_fps: 設定ファイルから取得したFPS値.
+        saver: 画像保存を担当する ImageSaver インスタンス.
     """
 
     def __init__(
@@ -58,6 +59,7 @@ class PipelineExecutor:
         self.id_interval = id_interval
         self.config_fps = config_fps
         self.logger = LogManager().get_logger()
+        self.saver = ImageSaver(output_dir, camera_index)
 
         for processor in processors:
             if hasattr(processor, "set_pipeline_mode"):
@@ -133,19 +135,6 @@ class PipelineExecutor:
             logger.error(f"Failed to create pipeline from config: {e}")
             raise
 
-    def _get_processing_dir(self, process_name: str) -> Path:
-        """処理結果保存用のサブディレクトリを取得する.
-
-        Args:
-            process_name: 処理の名前. 例: 'grayscale', 'gaussian_blur'.
-
-        Returns:
-            処理結果保存用ディレクトリのパス.
-        """
-        path = self.output_dir / process_name
-        path.mkdir(parents=True, exist_ok=True)
-        return path
-
     def run(self, image: np.ndarray) -> None:
         """指定された画像に対してプロセッサを適用し, 処理結果を保存する.
 
@@ -154,20 +143,7 @@ class PipelineExecutor:
         """
         start_time = time.time()
 
-        original_dir = self._get_processing_dir("original")
-        filename, id_index, image_index = get_file_naming_manager().get_filename(
-            "original", self.camera_index
-        )
-        original_path = original_dir / filename
-        try:
-            cv2.imwrite(str(original_path), image)
-            self.logger.info(
-                f"Original image saved: {original_path} "
-                f"({image.shape[1]}x{image.shape[0]}, "
-                f"id={id_index}, image={image_index})"
-            )
-        except Exception as e:
-            self.logger.error(f"Failed to save original image: {e}")
+        self.saver.save(image, "original")
 
         processed_images = {"original": image.copy()}
         if self.mode == "parallel":
@@ -180,7 +156,7 @@ class PipelineExecutor:
                         f"Processing time ({processor.name}): {proc_time:.3f} sec"
                     )
                     processed_images[processor.name] = result
-                    self._save(result, processor.name)
+                    self.saver.save(result, processor.name)
                 except Exception as e:
                     self.logger.error(
                         f"Processor '{processor.name}' failed, skipping: {e}"
@@ -221,33 +197,7 @@ class PipelineExecutor:
                         f"Processor '{processor.name}' failed, skipping: {e}"
                     )
 
-            self._save(result, "pipeline")
+            self.saver.save(result, "pipeline")
 
         total_time = time.time() - start_time
         self.logger.info(f"Total processing time: {total_time:.3f} sec")
-
-    def _save(self, image: np.ndarray, processor_name: str) -> None:
-        """処理された画像を保存する.
-
-        Args:
-            image: 処理済み画像.
-            processor_name: 処理に使われたプロセッサの名前.
-        """
-        save_dir = self._get_processing_dir(processor_name)
-
-        filename, id_index, image_index = get_file_naming_manager().get_filename(
-            processor_name, self.camera_index
-        )
-        path = save_dir / filename
-
-        save_start = time.time()
-        try:
-            cv2.imwrite(str(path), image)
-            save_time = time.time() - save_start
-            self.logger.info(
-                f"Image saved ({processor_name}): {path} "
-                f"({image.shape[1]}x{image.shape[0]}, "
-                f"id={id_index}, image={image_index}, {save_time:.3f} sec)"
-            )
-        except Exception as e:
-            self.logger.error(f"Failed to save image ({processor_name}): {e}")


### PR DESCRIPTION
## Summary

- `PipelineExecutor` から File I/O 責務を `ImageSaver` クラスに分離

## Related Issue

Closes #260

## Changes

- `pochivision/core/image_saver.py` を新設 — `get_processing_dir()` と `save()` を担当
- `pochivision/core/pipeline_executor.py` から `_get_processing_dir()`, `_save()`, `cv2.imwrite` 直接呼び出しを除去し, `self.saver` に委譲
- `pochivision/core/__init__.py` に `ImageSaver` のエクスポートを追加

```python
# pochivision/core/pipeline_executor.py
self.saver = ImageSaver(output_dir, camera_index)

# run() 内
self.saver.save(image, "original")
self.saver.save(result, processor.name)
self.saver.save(result, "pipeline")
```

## Test Plan

- [x] `uv run pre-commit run --all-files` で全チェックが通る

## Checklist

- [x] `PipelineExecutor` から `cv2.imwrite` の直接呼び出しが排除されている
- [x] File I/O が `ImageSaver` クラスに委譲されている
- [x] 既存テストが通る
