### PR TITLE
fix: mypy 型エラー 17 件の修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 ### Fixed
 - `ConfigHandler.save()` の `strftime` フォーマットを `%Y-%m%d-%H%M-%S` から `%Y%m%d_%H%M%S` に修正. ([#263](https://github.com/kurorosu/pochivision/pull/263))
 - `RecordingManager.start_recording()` で `VideoWriter` 初期化失敗時に `video_writer` を `None` にクリアするよう修正. ([#264](https://github.com/kurorosu/pochivision/pull/264))
+- mypy 型エラー 17 件を修正. `types-tqdm`, `scipy-stubs` を dev 依存に追加, `cv2.normalize` の `dst` 引数修正, `mask_composition.py` の `signedinteger` 変換修正など. (NA.)
 
 ### Removed
 - 未使用の `ExtractorRuntimeError` 例外クラスを削除. ([#265](https://github.com/kurorosu/pochivision/pull/265))

--- a/pochivision/capturelib/recording_manager.py
+++ b/pochivision/capturelib/recording_manager.py
@@ -157,7 +157,7 @@ class RecordingManager:
             )
 
             # VideoWriterを初期化
-            fourcc_code = cv2.VideoWriter_fourcc(*fourcc_str)
+            fourcc_code = cv2.VideoWriter.fourcc(*fourcc_str)
             self.video_writer = cv2.VideoWriter(
                 str(video_filename), fourcc_code, fps, frame_size
             )

--- a/pochivision/cli/commands/run.py
+++ b/pochivision/cli/commands/run.py
@@ -1,6 +1,9 @@
 """run サブコマンド: ライブプレビュー起動."""
 
+from typing import cast
+
 import click
+import cv2
 
 from pochivision.capture_runner import LivePreviewRunner
 from pochivision.capturelib.camera_setup import CameraSetup
@@ -114,7 +117,7 @@ def _setup_camera(
             profile_name=profile or "0",
         )
         camera_setup.load_camera_config()
-        cap = camera_setup.initialize_camera()
+        cap = cast(cv2.VideoCapture, camera_setup.initialize_camera())
 
         if not cap.isOpened():
             logger.error(f"Failed to open camera {camera_setup.camera_index}.")
@@ -187,7 +190,7 @@ def _run_preview(
             preview_config.get("height", DEFAULT_PREVIEW_HEIGHT),
         )
 
-        app = LivePreviewRunner(cap, pipeline, recording_manager, preview_size)
+        app = LivePreviewRunner(cap, pipeline, recording_manager, preview_size)  # type: ignore[arg-type]
         app.run()
 
     except Exception as e:

--- a/pochivision/core/fft_visualization.py
+++ b/pochivision/core/fft_visualization.py
@@ -88,9 +88,9 @@ class SimpleFFTVisualizer:
         self.fshift = np.fft.fftshift(f)
         magnitude_spectrum = 20 * np.log(np.abs(self.fshift) + 1)
 
-        self.spectrum_display = cv2.normalize(
-            magnitude_spectrum, None, 0, 255, cv2.NORM_MINMAX
-        ).astype(np.uint8)
+        dst = np.empty_like(magnitude_spectrum, dtype=np.float64)
+        cv2.normalize(magnitude_spectrum, dst, 0, 255, cv2.NORM_MINMAX)
+        self.spectrum_display = dst.astype(np.uint8)
 
     def apply_filter(self) -> np.ndarray:
         """現在のフィルタモードに応じて画像をフィルタリングする."""
@@ -120,10 +120,12 @@ class SimpleFFTVisualizer:
             ]
 
         f_ishift = np.fft.ifftshift(mask)
-        img_back = np.fft.ifft2(f_ishift)
-        img_back = np.abs(img_back)
+        img_back_complex = np.fft.ifft2(f_ishift)
+        img_back: np.ndarray = np.abs(img_back_complex).astype(np.float64)
 
-        return cv2.normalize(img_back, None, 0, 255, cv2.NORM_MINMAX).astype(np.uint8)
+        dst = np.empty_like(img_back)
+        cv2.normalize(img_back, dst, 0, 255, cv2.NORM_MINMAX)
+        return dst.astype(np.uint8)
 
     def update_display(self) -> None:
         """表示を更新する."""

--- a/pochivision/core/profile_processing.py
+++ b/pochivision/core/profile_processing.py
@@ -182,7 +182,8 @@ class ProfileProcessor:
                         results[processor_name] = result
 
                 if results:
-                    return list(results.values())[-1]
+                    last_result: np.ndarray = list(results.values())[-1]
+                    return last_result
                 return None
 
             else:

--- a/pochivision/processors/contour.py
+++ b/pochivision/processors/contour.py
@@ -123,9 +123,11 @@ class ContourProcessor(BaseProcessor):
 
         # 指定されたランク（0から始まる）の輪郭を選択
         if self._contour_rank < len(sorted_contours):
-            return sorted_contours[self._contour_rank]
+            result: np.ndarray = sorted_contours[self._contour_rank]
+            return result
         elif sorted_contours:
-            return sorted_contours[0]  # ランクが範囲外の場合は最大輪郭を返す
+            result = sorted_contours[0]  # ランクが範囲外の場合は最大輪郭を返す
+            return result
         else:
             return None
 
@@ -166,7 +168,7 @@ class ContourProcessor(BaseProcessor):
 
             if self._select_mode == "rank":
                 # ランクによる選択
-                selected_contour = self._select_contour_by_rank(contours)
+                selected_contour = self._select_contour_by_rank(list(contours))
                 if selected_contour is not None:
                     contours = [selected_contour]
                 else:

--- a/pochivision/processors/edge_detection.py
+++ b/pochivision/processors/edge_detection.py
@@ -64,9 +64,9 @@ class CannyEdgeProcessor(BaseProcessor):
                 gray_image = gray_image.astype(np.uint8)
             else:
                 try:
-                    gray_image = cv2.normalize(
-                        gray_image, None, 0, 255, cv2.NORM_MINMAX
-                    ).astype(np.uint8)
+                    dst = np.empty_like(gray_image, dtype=np.float64)
+                    cv2.normalize(gray_image, dst, 0, 255, cv2.NORM_MINMAX)
+                    gray_image = dst.astype(np.uint8)
                 except cv2.error as e:
                     raise ProcessorRuntimeError(
                         f"Failed to convert image to uint8 for Canny: {e}"

--- a/pochivision/processors/mask_composition.py
+++ b/pochivision/processors/mask_composition.py
@@ -124,19 +124,19 @@ class MaskCompositionProcessor(BaseProcessor):
             return None
 
         # Y軸（行）の最小・最大値
-        y_min = np.min(white_pixels[0])
-        y_max = np.max(white_pixels[0])
+        raw_y_min = int(np.min(white_pixels[0]))
+        raw_y_max = int(np.max(white_pixels[0]))
 
         # X軸（列）の最小・最大値
-        x_min = np.min(white_pixels[1])
-        x_max = np.max(white_pixels[1])
+        raw_x_min = int(np.min(white_pixels[1]))
+        raw_x_max = int(np.max(white_pixels[1]))
 
         # マージンを適用（画像境界を超えないように調整）
         height, width = mask.shape
-        y_min = max(0, y_min - self.crop_margin)
-        y_max = min(height - 1, y_max + self.crop_margin)
-        x_min = max(0, x_min - self.crop_margin)
-        x_max = min(width - 1, x_max + self.crop_margin)
+        y_min = max(0, raw_y_min - self.crop_margin)
+        y_max = min(height - 1, raw_y_max + self.crop_margin)
+        x_min = max(0, raw_x_min - self.crop_margin)
+        x_max = min(width - 1, raw_x_max + self.crop_margin)
 
         return (y_min, y_max, x_min, x_max)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,8 @@ dev = [
     "pre-commit>=4.0.0",
     "pydocstyle>=6.3.0",
     "pytest>=8.2.0",
+    "scipy-stubs>=1.17.1.3",
+    "types-tqdm>=4.67.3.20260402",
 ]
 
 [tool.black]
@@ -57,7 +59,7 @@ warn_unused_configs = true
 explicit_package_bases = true
 
 [[tool.mypy.overrides]]
-module = ["cv2", "dearpygui.*"]
+module = ["cv2", "dearpygui.*", "pywt"]
 ignore_missing_imports = true
 
 [tool.pydocstyle]

--- a/uv.lock
+++ b/uv.lock
@@ -624,6 +624,18 @@ wheels = [
 ]
 
 [[package]]
+name = "numpy-typing-compat"
+version = "20251206.2.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/5f/29fd5f29b0a5d96e2def96ecba3112fc330ecd16e8c97c2b332563c5e201/numpy_typing_compat-20251206.2.4.tar.gz", hash = "sha256:59882d23aaff054a2536da80564012cdce33487657be4d79c5925bb8705fcabc", size = 5011, upload-time = "2025-12-06T20:02:04.942Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/7c/5c2892e6bc0628a2ccf4e938e1e2db22794657ccb374672d66e20d73839e/numpy_typing_compat-20251206.2.4-py3-none-any.whl", hash = "sha256:a82e723bd20efaa4cf2886709d4264c144f1f2b609bda83d1545113b7e47a5b5", size = 6300, upload-time = "2025-12-06T20:01:57.578Z" },
+]
+
+[[package]]
 name = "opencv-python"
 version = "4.13.0.92"
 source = { registry = "https://pypi.org/simple" }
@@ -639,6 +651,24 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/55/b3b49a1b97aabcfbbd6c7326df9cb0b6fa0c0aefa8e89d500939e04aa229/opencv_python-4.13.0.92-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:620d602b8f7d8b8dab5f4b99c6eb353e78d3fb8b0f53db1bd258bb1aa001c1d5", size = 72927042, upload-time = "2026-02-05T06:59:23.389Z" },
     { url = "https://files.pythonhosted.org/packages/fb/17/de5458312bcb07ddf434d7bfcb24bb52c59635ad58c6e7c751b48949b009/opencv_python-4.13.0.92-cp37-abi3-win32.whl", hash = "sha256:372fe164a3148ac1ca51e5f3ad0541a4a276452273f503441d718fab9c5e5f59", size = 30932638, upload-time = "2026-02-05T07:02:14.98Z" },
     { url = "https://files.pythonhosted.org/packages/e9/a5/1be1516390333ff9be3a9cb648c9f33df79d5096e5884b5df71a588af463/opencv_python-4.13.0.92-cp37-abi3-win_amd64.whl", hash = "sha256:423d934c9fafb91aad38edf26efb46da91ffbc05f3f59c4b0c72e699720706f5", size = 40212062, upload-time = "2026-02-05T07:02:12.724Z" },
+]
+
+[[package]]
+name = "optype"
+version = "0.17.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/9f/3b13bab05debf685678b8af004e46b8c67c6f98ffa08eaf5d33bcf162c16/optype-0.17.0.tar.gz", hash = "sha256:31351a1e64d9eba7bf67e14deefb286e85c66458db63c67dd5e26dd72e4664e5", size = 53484, upload-time = "2026-03-08T23:03:12.594Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6b/44/dca78187415947d1bb90b2ee2a58e47d9573528331e8dc6196996b53612a/optype-0.17.0-py3-none-any.whl", hash = "sha256:8c2d88ff13149454bcf6eb47502f80d288bc542e7238fcc412ac4d222c439397", size = 65854, upload-time = "2026-03-08T23:03:11.425Z" },
+]
+
+[package.optional-dependencies]
+numpy = [
+    { name = "numpy" },
+    { name = "numpy-typing-compat" },
 ]
 
 [[package]]
@@ -839,6 +869,8 @@ dev = [
     { name = "pre-commit" },
     { name = "pydocstyle" },
     { name = "pytest" },
+    { name = "scipy-stubs" },
+    { name = "types-tqdm" },
 ]
 
 [package.metadata]
@@ -870,6 +902,8 @@ dev = [
     { name = "pre-commit", specifier = ">=4.0.0" },
     { name = "pydocstyle", specifier = ">=6.3.0" },
     { name = "pytest", specifier = ">=8.2.0" },
+    { name = "scipy-stubs", specifier = ">=1.17.1.3" },
+    { name = "types-tqdm", specifier = ">=4.67.3.20260402" },
 ]
 
 [[package]]
@@ -1328,6 +1362,18 @@ wheels = [
 ]
 
 [[package]]
+name = "scipy-stubs"
+version = "1.17.1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "optype", extra = ["numpy"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a7/59/59c6cc3f9970154b9ed6b1aff42a0185cdd60cef54adc0404b9e77972221/scipy_stubs-1.17.1.3.tar.gz", hash = "sha256:5eb87a8d23d726706259b012ebe76a4a96a9ae9e141fc59bf55fc8eac2ed9e0f", size = 392185, upload-time = "2026-03-22T22:11:58.34Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/d4/94304532c0a75a55526119043dd44a9bd1541a21e14483cbb54261c527d2/scipy_stubs-1.17.1.3-py3-none-any.whl", hash = "sha256:7b91d3f05aa47da06fbca14eb6c5bb4c28994e9245fd250cc847e375bab31297", size = 597933, upload-time = "2026-03-22T22:11:56.525Z" },
+]
+
+[[package]]
 name = "seaborn"
 version = "0.13.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1384,6 +1430,30 @@ wheels = [
 ]
 
 [[package]]
+name = "types-requests"
+version = "2.33.0.20260402"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c1/7b/a06527d20af1441d813360b8e0ce152a75b7d8e4aab7c7d0a156f405d7ec/types_requests-2.33.0.20260402.tar.gz", hash = "sha256:1bdd3ada9b869741c5c4b887d2c8b4e38284a1449751823b5ebbccba3eefd9da", size = 23851, upload-time = "2026-04-02T04:19:55.942Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/65/3853bb6bac5ae789dc7e28781154705c27859eccc8e46282c3f36780f5f5/types_requests-2.33.0.20260402-py3-none-any.whl", hash = "sha256:c98372d7124dd5d10af815ee25c013897592ff92af27b27e22c98984102c3254", size = 20739, upload-time = "2026-04-02T04:19:54.955Z" },
+]
+
+[[package]]
+name = "types-tqdm"
+version = "4.67.3.20260402"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "types-requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/54/42/e9e6688891d8db77b5795ec02b329524170892ff81bec63c4c4ca7425b30/types_tqdm-4.67.3.20260402.tar.gz", hash = "sha256:e0739f3bc5d1c801999a202f0537280aa1bc2e669c49f5be91bfb99376690624", size = 18077, upload-time = "2026-04-02T04:22:23.049Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/73/a6cf75de5be376d7b57ce6c934ae9bc90aa5be6ada4ac50a99ecbdf9763e/types_tqdm-4.67.3.20260402-py3-none-any.whl", hash = "sha256:b5d1a65fe3286e1a855e51ddebf63d3641daf9bad285afd1ec56808eb59df76e", size = 24562, upload-time = "2026-04-02T04:22:22.114Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1411,6 +1481,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/c202b344c5ca7daf398f3b8a477eeb205cf3b6f32e7ec3a6bac0629ca975/tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7", size = 196772, upload-time = "2025-12-13T17:45:35.667Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/b0/003792df09decd6849a5e39c28b513c06e84436a54440380862b5aeff25d/tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1", size = 348521, upload-time = "2025-12-13T17:45:33.889Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- `uv run mypy .` の型エラー 17 件を全て修正

## Related Issue

Closes #277

## Changes

### ライブラリスタブ
- `types-tqdm`, `scipy-stubs` を dev 依存に追加
- `pyproject.toml` の mypy overrides に `pywt` を追加

### cv2.normalize の修正
- `pochivision/core/fft_visualization.py`: `dst=None` を `dst=np.empty_like(...)` に変更 (2箇所)
- `pochivision/processors/edge_detection.py`: 同様に修正

### その他の型修正
- `pochivision/capturelib/recording_manager.py`: `cv2.VideoWriter_fourcc` → `cv2.VideoWriter.fourcc`
- `pochivision/core/profile_processing.py`: parallel モードの戻り値に型アノテーション追加
- `pochivision/processors/contour.py`: 戻り値に型アノテーション追加, `list()` でキャスト
- `pochivision/processors/mask_composition.py`: `np.min/max` の結果を `int()` で変換
- `pochivision/cli/commands/run.py`: `cast()` と `type: ignore[arg-type]` で cv2 スタブ問題を回避

## Test Plan

- [x] `uv run mypy .` でエラー 0 件
- [x] `uv run pre-commit run --all-files` で全チェックが通る

## Checklist

- [x] mypy エラーが 0 件になっている
- [x] ライブラリスタブが dev 依存に追加されている
- [x] 既存テストが通る
