### PR TITLE
refactor: extractor_config.json の未使用設定キーを削除

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - 未使用の `ExtractorRuntimeError` 例外クラスを削除. ([#265](https://github.com/kurorosu/pochivision/pull/265))
 - `CameraConfigHandler` の未使用メソッド (`get_camera_config`, `get_all_camera_indices`, `get_selected_camera_index`) を削除. ([#266](https://github.com/kurorosu/pochivision/pull/266))
 - `tools/` ディレクトリを全削除. ([#278](https://github.com/kurorosu/pochivision/pull/278))
+- `extractor_config.json` から未使用の `output_directory`, `include_filename` キーを削除. (NA.)
 
 ## [0.2.0] - 2026-04-02
 

--- a/extractor_config.json
+++ b/extractor_config.json
@@ -1,6 +1,5 @@
 {
   "input_directory": "data",
-  "output_directory": "extraction_results",
   "output_format": "csv",
   "extractors": [
     "brightness",
@@ -100,7 +99,6 @@
     "case_sensitive": false
   },
   "output_settings": {
-    "include_filename": true,
     "include_timestamp": true,
     "csv_separator": ",",
     "output_filename": "features.csv",


### PR DESCRIPTION
## Summary

- `extractor_config.json` から未使用の設定キーを削除

## Related Issue

Closes #272

## Changes

- `extractor_config.json` から `output_directory` を削除 (`OutputManager` が出力先を管理しておりコードから参照されていない)
- `extractor_config.json` から `include_filename` を削除 (`filename` は常にハードコードで追加されておりこの設定は参照されていない)

## Test Plan

- [x] `uv run pre-commit run --all-files` で全チェックが通る

## Checklist

- [x] `output_directory` が削除されている
- [x] `include_filename` が削除されている
- [x] 既存テストが通る
