### PR TITLE
fix: cv2.imwrite() の戻り値未検証

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - 無し
 
 ### Fixed
-- 無し
+- `ImageSaver.save()` で `cv2.imwrite()` の戻り値を検証し, 保存失敗時に警告ログを出力するよう修正. (NA.)
 
 ### Removed
 - 無し

--- a/pochivision/core/image_saver.py
+++ b/pochivision/core/image_saver.py
@@ -58,12 +58,15 @@ class ImageSaver:
 
         save_start = time.time()
         try:
-            cv2.imwrite(str(path), image)
+            success = cv2.imwrite(str(path), image)
             save_time = time.time() - save_start
-            self.logger.info(
-                f"Image saved ({processor_name}): {path} "
-                f"({image.shape[1]}x{image.shape[0]}, "
-                f"id={id_index}, image={image_index}, {save_time:.3f} sec)"
-            )
+            if success:
+                self.logger.info(
+                    f"Image saved ({processor_name}): {path} "
+                    f"({image.shape[1]}x{image.shape[0]}, "
+                    f"id={id_index}, image={image_index}, {save_time:.3f} sec)"
+                )
+            else:
+                self.logger.warning(f"Failed to save image ({processor_name}): {path}")
         except Exception as e:
             self.logger.error(f"Failed to save image ({processor_name}): {e}")


### PR DESCRIPTION
## Summary

- `ImageSaver.save()` で `cv2.imwrite()` の戻り値を検証し, 保存失敗時に警告ログを出力するよう修正

## Related Issue

Closes #285

## Changes

- `pochivision/core/image_saver.py`: `cv2.imwrite()` の戻り値を `success` で受け取り, `False` の場合に `logger.warning` を出力

```python
# pochivision/core/image_saver.py
success = cv2.imwrite(str(path), image)
if success:
    self.logger.info(...)
else:
    self.logger.warning(f"Failed to save image ({processor_name}): {path}")
```

## Test Plan

- [x] `uv run pre-commit run --all-files` で全チェックが通る

## Checklist

- [x] `cv2.imwrite()` の戻り値が検証されている
- [x] 保存失敗時に警告ログが出力される
- [x] 既存テストが通る
