### PR TITLE
fix: RecordingManager のスレッド安全性改善

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@
 - 無し
 
 ### Fixed
-- `ImageSaver.save()` で `cv2.imwrite()` の戻り値を検証し, 保存失敗時に警告ログを出力するよう修正. (NA.)
+- `ImageSaver.save()` で `cv2.imwrite()` の戻り値を検証し, 保存失敗時に警告ログを出力するよう修正. ([#291](https://github.com/kurorosu/pochivision/pull/291))
+- `RecordingManager.add_frame()` のロック外チェックを削除しスレッド安全性を改善. `start_recording()` にフレームサイズ検証を追加. (NA.)
 
 ### Removed
 - 無し

--- a/pochivision/capturelib/recording_manager.py
+++ b/pochivision/capturelib/recording_manager.py
@@ -137,6 +137,11 @@ class RecordingManager:
             self.logger.warning("Recording is already in progress")
             return False
 
+        # フレームサイズの検証
+        if len(frame_size) != 2 or frame_size[0] <= 0 or frame_size[1] <= 0:
+            self.logger.error(f"Invalid frame size: {frame_size}")
+            return False
+
         # 設定された動画形式を使用
         format_info = VideoFormat.get_format_info(self.video_format)
         if format_info is None:
@@ -248,9 +253,6 @@ class RecordingManager:
         Returns:
             bool: フレーム追加に成功した場合True、失敗した場合False
         """
-        if not self.is_recording or self.video_writer is None:
-            return False
-
         try:
             with self.lock:
                 if self.is_recording and self.video_writer is not None:


### PR DESCRIPTION
## Summary

- `RecordingManager` のスレッド安全性を改善し, フレームサイズ検証を追加

## Related Issue

Closes #286

## Changes

- `pochivision/capturelib/recording_manager.py`: `add_frame()` のロック外 `is_recording` チェックを削除. ロック内のみでチェックするよう変更
- `pochivision/capturelib/recording_manager.py`: `start_recording()` にフレームサイズ (`frame_size`) の検証を追加

```python
# add_frame() - ロック外チェックを削除
def add_frame(self, frame: np.ndarray) -> bool:
    try:
        with self.lock:
            if self.is_recording and self.video_writer is not None:
                self.video_writer.write(frame)
                ...

# start_recording() - フレームサイズ検証を追加
if len(frame_size) != 2 or frame_size[0] <= 0 or frame_size[1] <= 0:
    self.logger.error(f"Invalid frame size: {frame_size}")
    return False
```

## Test Plan

- [x] `uv run pre-commit run --all-files` で全チェックが通る

## Checklist

- [x] `add_frame()` のロック外チェックが削除されている
- [x] `start_recording()` にフレームサイズ検証が追加されている
- [x] 既存テストが通る
