### PR TITLE
feat: ライブプレビューにヘルプオーバーレイ表示機能を追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 ## [Unreleased]
 
 ### Added
-- 無し
+- ライブプレビューに `h` キーでトグルするヘルプオーバーレイ表示機能を追加. 黒文字 + 白縁で表示し, 保存画像には影響しない. (NA.)
 
 ### Changed
 - 設定ファイル (`config.json`, `extractor_config.json`) を `config/` ディレクトリに移動し, CLI のデフォルトパスを更新. (NA.)

--- a/pochivision/capture_runner/help_overlay.py
+++ b/pochivision/capture_runner/help_overlay.py
@@ -1,0 +1,67 @@
+"""ライブプレビュー用ヘルプオーバーレイモジュール."""
+
+import cv2
+import numpy as np
+
+
+class HelpOverlay:
+    """プレビュー画面にキーバインドのヘルプを描画するクラス.
+
+    黒文字 + 白縁のテキストで画面下部に一行表示する.
+    プレビュー表示のみに適用し, 画像処理・保存パイプラインには影響しない.
+    """
+
+    HELP_TEXT = "c:Capture  r:Rec  t:Stop  s:Settings  h:Help  q:Quit"
+
+    def __init__(self) -> None:
+        """HelpOverlayのコンストラクタ."""
+        self.visible = True
+
+    def toggle(self) -> None:
+        """ヘルプ表示のオン/オフを切り替える."""
+        self.visible = not self.visible
+
+    def draw(self, frame: np.ndarray) -> np.ndarray:
+        """フレーム下部にヘルプテキストを一行描画する.
+
+        Args:
+            frame: 描画先のフレーム. このフレームを直接変更する.
+
+        Returns:
+            ヘルプテキストが描画されたフレーム.
+        """
+        if not self.visible:
+            return frame
+
+        h = frame.shape[0]
+        font = cv2.FONT_HERSHEY_SIMPLEX
+        font_scale = 0.5
+        thickness = 1
+        outline_thickness = thickness + 2
+        x = 10
+        y = h - 12
+
+        # 白縁 (outline)
+        cv2.putText(
+            frame,
+            self.HELP_TEXT,
+            (x, y),
+            font,
+            font_scale,
+            (255, 255, 255),
+            outline_thickness,
+            cv2.LINE_AA,
+        )
+        # 黒文字 (foreground)
+        cv2.putText(
+            frame,
+            self.HELP_TEXT,
+            (x, y),
+            font,
+            font_scale,
+            (0, 0, 0),
+            thickness,
+            cv2.LINE_AA,
+        )
+
+        return frame

--- a/pochivision/capture_runner/viewer.py
+++ b/pochivision/capture_runner/viewer.py
@@ -7,6 +7,7 @@ from typing import Optional
 import cv2
 import numpy as np
 
+from pochivision.capture_runner.help_overlay import HelpOverlay
 from pochivision.capturelib.log_manager import LogManager
 from pochivision.capturelib.recording_manager import RecordingManager
 from pochivision.constants import DEFAULT_PREVIEW_HEIGHT, DEFAULT_PREVIEW_WIDTH
@@ -48,6 +49,7 @@ class LivePreviewRunner:
         self.preview_size = preview_size
         self.os_name = platform.system()
         self.logger = LogManager().get_logger()
+        self.help_overlay = HelpOverlay()
 
     def _resize_for_preview(self, frame: np.ndarray) -> np.ndarray:
         """
@@ -108,6 +110,7 @@ class LivePreviewRunner:
         - 'r': 録画開始
         - 't': 録画停止
         - 's': カメラ設定
+        - 'h': ヘルプオーバーレイ表示/非表示
         - 'q': 終了
 
         Raises:
@@ -117,7 +120,7 @@ class LivePreviewRunner:
         self.logger.info(
             "Press 'c' to capture, 'r' to start recording, 't' to stop recording,"
         )
-        self.logger.info("'s' for camera settings, 'q' to quit.")
+        self.logger.info("'s' for camera settings, 'h' for help, 'q' to quit.")
 
         try:
             while True:
@@ -132,8 +135,10 @@ class LivePreviewRunner:
                 ):
                     self.recording_manager.add_frame(frame)
 
-                # プレビュー表示
-                cv2.imshow("Live View", self._resize_for_preview(frame))
+                # プレビュー表示 (リサイズ後にオーバーレイを描画)
+                preview = self._resize_for_preview(frame)
+                self.help_overlay.draw(preview)
+                cv2.imshow("Live View", preview)
 
                 key = cv2.waitKey(1) & 0xFF
                 if key == ord("c"):
@@ -155,6 +160,9 @@ class LivePreviewRunner:
                             f"Camera settings dialog is only supported on Windows. "
                             f"Current OS: {self.os_name}"
                         )
+                elif key == ord("h"):
+                    # ヘルプオーバーレイのトグル
+                    self.help_overlay.toggle()
                 elif key == ord("q"):
                     self.logger.info("Quit key pressed, exiting application")
                     break


### PR DESCRIPTION

## Summary
- ライブプレビュー画面下部にキーバインドのヘルプを一行オーバーレイ表示する機能を追加

## Related Issue

Closes #289

## Changes
- `pochivision/capture_runner/help_overlay.py`: `HelpOverlay` クラスを新規作成. 黒文字 + 白縁で画面下部に一行表示
- `pochivision/capture_runner/viewer.py`: `HelpOverlay` を統合. `_resize_for_preview()` 後, `cv2.imshow()` 前にオーバーレイ描画. `h` キーでトグル

```python
# pochivision/capture_runner/help_overlay.py
class HelpOverlay:
    HELP_TEXT = "c:Capture  r:Rec  t:Stop  s:Settings  h:Help  q:Quit"

    def __init__(self) -> None:
        self.visible = True  # 初期状態で表示

    def draw(self, frame: np.ndarray) -> np.ndarray:
        # _resize_for_preview() 後のフレームに描画
        # 白縁 → 黒文字の順で画面下部に一行表示
```

```python
# pochivision/capture_runner/viewer.py (run メソッド内)
preview = self._resize_for_preview(frame)
self.help_overlay.draw(preview)  # パイプライン・保存には影響しない
cv2.imshow("Live View", preview)
```

## Test Plan
- [x] `uv run pre-commit run --all-files` で全チェックが通る

## Checklist
- [x] `h` キーでヘルプオーバーレイがトグルされる
- [x] 初期状態でオーバーレイが表示される
- [x] オーバーレイは黒文字 + 白縁で画面下部に一行表示
- [x] 保存される画像にオーバーレイが含まれない
- [x] 既存テストが通る
