### PR TITLE
refactor: feature_extractors/__init__.py の未使用 Params エクスポート削除

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 - `ImageSaver.save()` のログ出力でグレースケール画像の幅/高さが正しく取得されるよう `image.shape[:2]` に修正. ([#293](https://github.com/kurorosu/pochivision/pull/293))
 
 ### Removed
-- 無し
+- `feature_extractors/__init__.py` から未使用の Params クラス 9 件のエクスポートを削除. (NA.)
 
 ## [0.3.0] - 2026-04-04
 

--- a/pochivision/feature_extractors/__init__.py
+++ b/pochivision/feature_extractors/__init__.py
@@ -18,17 +18,6 @@ from .registry import (
     register_feature_extractor,
 )
 from .rgb_statistics import RGBStatisticsExtractor
-from .schema import (
-    BrightnessStatisticsParams,
-    CircleCounterParams,
-    FFTFrequencyParams,
-    GLCMTextureParams,
-    HLACTextureParams,
-    HSVStatisticsParams,
-    LBPTextureParams,
-    RGBStatisticsParams,
-    SWTFrequencyParams,
-)
 from .swt_frequency import SWTFrequencyExtractor
 
 __all__ = [
@@ -45,13 +34,4 @@ __all__ = [
     "FEATURE_EXTRACTOR_REGISTRY",
     "get_feature_extractor",
     "register_feature_extractor",
-    "BrightnessStatisticsParams",
-    "CircleCounterParams",
-    "FFTFrequencyParams",
-    "GLCMTextureParams",
-    "HLACTextureParams",
-    "HSVStatisticsParams",
-    "LBPTextureParams",
-    "RGBStatisticsParams",
-    "SWTFrequencyParams",
 ]


### PR DESCRIPTION

## Summary
- `feature_extractors/__init__.py` から外部未使用の Params クラス 9 件のエクスポートを削除

## Related Issue

Closes #288

## Changes
- `pochivision/feature_extractors/__init__.py`: `schema` モジュールからの Params クラスインポートと `__all__` エントリを削除

```python
# 削除された Params クラス (9 件)
# BrightnessStatisticsParams, CircleCounterParams, FFTFrequencyParams,
# GLCMTextureParams, HLACTextureParams, HSVStatisticsParams,
# LBPTextureParams, RGBStatisticsParams, SWTFrequencyParams
```

## Test Plan
- [x] `uv run pre-commit run --all-files` で全チェックが通る

## Checklist
- [x] Params クラスのエクスポートが削除されている
- [x] 外部からの参照がないことを Grep で確認済み
- [x] 既存テストが通る
