### PR TITLE
refactor: FeatureExtractionRunner の責務分割

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Changed
 - 設定ファイル (`config.json`, `extractor_config.json`) を `config/` ディレクトリに移動し, CLI のデフォルトパスを更新. (NA.)
+- `FeatureExtractionRunner` の CSV 出力を `FeatureCSVWriter` に, クラス名抽出を `extract_class_from_filename()` に分離. (NA.)
 
 ### Fixed
 - `ImageSaver.save()` で `cv2.imwrite()` の戻り値を検証し, 保存失敗時に警告ログを出力するよう修正. ([#291](https://github.com/kurorosu/pochivision/pull/291))

--- a/pochivision/core/feature_csv_writer.py
+++ b/pochivision/core/feature_csv_writer.py
@@ -1,0 +1,202 @@
+"""特徴量抽出結果の CSV 出力を担当するモジュール."""
+
+import csv
+from pathlib import Path
+from typing import Any
+
+from pochivision.capturelib.log_manager import LogManager
+
+
+class FeatureCSVWriter:
+    """特徴量抽出結果を CSV ファイルに出力するクラス.
+
+    Attributes:
+        output_dir: 出力先ディレクトリ.
+    """
+
+    def __init__(self, output_dir: Path, config: dict[str, Any]) -> None:
+        """FeatureCSVWriterのコンストラクタ.
+
+        Args:
+            output_dir: CSV ファイルの出力先ディレクトリ.
+            config: 出力設定を含む設定辞書.
+        """
+        self.output_dir = output_dir
+        self.config = config
+        self.logger = LogManager().get_logger()
+
+    def _get_output_settings(self) -> Any:
+        """出力設定を取得する.
+
+        Returns:
+            出力設定の辞書.
+        """
+        return self.config.get("output_settings", {})
+
+    def _get_class_config(self) -> Any:
+        """クラス抽出設定を取得する.
+
+        Returns:
+            クラス抽出設定の辞書.
+        """
+        return self._get_output_settings().get("class_extraction", {})
+
+    def save_wide_csv(self, results: list[dict[str, Any]]) -> None:
+        """抽出結果を横持ち CSV ファイルに保存する.
+
+        Args:
+            results: 特徴量抽出結果のリスト.
+        """
+        if not results:
+            self.logger.warning("保存する結果がありません")
+            return
+
+        output_settings = self._get_output_settings()
+        output_filename = output_settings.get("output_filename", "features.csv")
+        output_path = self.output_dir / output_filename
+        separator = output_settings.get("csv_separator", ",")
+
+        try:
+            headers = self._build_wide_headers(results)
+
+            with open(output_path, "w", newline="", encoding="utf-8") as f:
+                writer = csv.DictWriter(f, fieldnames=headers, delimiter=separator)
+                writer.writeheader()
+                writer.writerows(results)
+
+            self.logger.info(f"横持ちCSV結果を保存しました: {output_path}")
+            self.logger.info(f"処理された画像数: {len(results)}")
+
+        except Exception as e:
+            self.logger.error(f"CSV保存中にエラーが発生しました: {e}")
+
+    def _build_wide_headers(self, results: list[dict[str, Any]]) -> list[str]:
+        """横持ち CSV のヘッダーを構築する.
+
+        Args:
+            results: 特徴量抽出結果のリスト.
+
+        Returns:
+            ヘッダーのリスト.
+        """
+        all_feature_names: set[str] = set()
+        for result in results:
+            all_feature_names.update(result.keys())
+
+        headers: list[str] = []
+        if "filename" in all_feature_names:
+            headers.append("filename")
+            all_feature_names.remove("filename")
+
+        class_config = self._get_class_config()
+        if class_config.get("enabled", False):
+            column_name = class_config.get("column_name", "class")
+            if column_name in all_feature_names:
+                headers.append(column_name)
+                all_feature_names.remove(column_name)
+
+        if "timestamp" in all_feature_names:
+            headers.append("timestamp")
+            all_feature_names.remove("timestamp")
+        headers.extend(sorted(all_feature_names))
+
+        return headers
+
+    def save_long_csv(self, results: list[dict[str, Any]]) -> None:
+        """抽出結果を縦持ち CSV ファイルに保存する.
+
+        Args:
+            results: 特徴量抽出結果のリスト.
+        """
+        if not results:
+            self.logger.warning("保存する結果がありません")
+            return
+
+        output_settings = self._get_output_settings()
+        output_filename = output_settings.get(
+            "long_format_filename", "features_long.csv"
+        )
+        output_path = self.output_dir / output_filename
+        separator = output_settings.get("csv_separator", ",")
+
+        try:
+            long_data = self._build_long_data(results)
+            headers = self._build_long_headers(long_data)
+
+            with open(output_path, "w", newline="", encoding="utf-8") as f:
+                writer = csv.DictWriter(f, fieldnames=headers, delimiter=separator)
+                writer.writeheader()
+                writer.writerows(long_data)
+
+            self.logger.info(f"縦持ちCSV結果を保存しました: {output_path}")
+            self.logger.info(f"特徴量レコード数: {len(long_data)}")
+
+        except Exception as e:
+            self.logger.error(f"縦持ちCSV保存中にエラーが発生しました: {e}")
+
+    def _build_long_data(self, results: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """縦持ち形式のデータを構築する.
+
+        Args:
+            results: 特徴量抽出結果のリスト.
+
+        Returns:
+            縦持ち形式のデータリスト.
+        """
+        class_config = self._get_class_config()
+        long_data: list[dict[str, Any]] = []
+
+        for result in results:
+            filename = result.get("filename", "")
+            timestamp = result.get("timestamp", "")
+
+            class_name = ""
+            if class_config.get("enabled", False):
+                column_name = class_config.get("column_name", "class")
+                class_name = result.get(column_name, "")
+
+            excluded_columns = ["filename", "timestamp"]
+            if class_config.get("enabled", False):
+                excluded_columns.append(class_config.get("column_name", "class"))
+
+            for feature_name, feature_value in result.items():
+                if feature_name not in excluded_columns:
+                    row: dict[str, Any] = {
+                        "filename": filename,
+                        "feature_name": feature_name,
+                        "feature_value": feature_value,
+                    }
+
+                    if class_name:
+                        row[class_config.get("column_name", "class")] = class_name
+
+                    if timestamp:
+                        row["timestamp"] = timestamp
+
+                    long_data.append(row)
+
+        return long_data
+
+    def _build_long_headers(self, long_data: list[dict[str, Any]]) -> list[str]:
+        """縦持ち CSV のヘッダーを構築する.
+
+        Args:
+            long_data: 縦持ち形式のデータリスト.
+
+        Returns:
+            ヘッダーのリスト.
+        """
+        class_config = self._get_class_config()
+        headers: list[str] = ["filename"]
+
+        if class_config.get("enabled", False) and any(
+            row.get(class_config.get("column_name", "class")) for row in long_data
+        ):
+            headers.append(class_config.get("column_name", "class"))
+
+        headers.extend(["feature_name", "feature_value"])
+
+        if any(row.get("timestamp") for row in long_data):
+            headers.insert(-2, "timestamp")
+
+        return headers

--- a/pochivision/core/feature_extraction.py
+++ b/pochivision/core/feature_extraction.py
@@ -1,16 +1,16 @@
 """特徴量抽出のビジネスロジッククラス."""
 
-import csv
 import inspect
 import shutil
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any
 
 from pochivision.capturelib.config_handler import ConfigHandler
 from pochivision.capturelib.log_manager import LogManager
-from pochivision.exceptions.config import ConfigLoadError
+from pochivision.core.feature_csv_writer import FeatureCSVWriter
 from pochivision.feature_extractors.registry import get_feature_extractor
+from pochivision.utils.class_extraction import extract_class_from_filename
 from pochivision.utils.image import get_image_files, load_image
 from pochivision.workspace import OutputManager
 
@@ -31,7 +31,6 @@ class FeatureExtractionRunner:
                 None の場合はデフォルトの OutputManager を使用.
 
         Raises:
-            ConfigLoadError: 設定ファイルの読み込みに失敗した場合.
             ValueError: 使用可能な特徴量抽出器がない場合.
         """
         self.logger = LogManager().get_logger()
@@ -41,6 +40,7 @@ class FeatureExtractionRunner:
         self.output_manager = output_manager or OutputManager()
         self.output_dir = self.output_manager.create_output_dir("features")
         self.extractors = self._initialize_extractors()
+        self.csv_writer = FeatureCSVWriter(self.output_dir, self.config)
 
     def _copy_config_to_output(self) -> None:
         """使用した設定ファイルを出力ディレクトリにコピーする."""
@@ -52,7 +52,7 @@ class FeatureExtractionRunner:
         except Exception as e:
             self.logger.warning(f"設定ファイルのコピーに失敗しました: {e}")
 
-    def _initialize_extractors(self) -> Dict[str, Any]:
+    def _initialize_extractors(self) -> dict[str, Any]:
         """設定に基づいて特徴量抽出器を初期化する.
 
         Returns:
@@ -84,7 +84,7 @@ class FeatureExtractionRunner:
 
         return extractors
 
-    def _get_image_files(self) -> List[Path]:
+    def _get_image_files(self) -> list[Path]:
         """入力ディレクトリから対象画像ファイルを取得する.
 
         Returns:
@@ -113,44 +113,7 @@ class FeatureExtractionRunner:
 
         return image_files
 
-    def _extract_class_from_filename(self, filename: str) -> str:
-        """ファイル名からクラス名を抽出する.
-
-        Args:
-            filename: ファイル名 (拡張子なし).
-
-        Returns:
-            抽出されたクラス名. 抽出できない場合は空文字列.
-        """
-        class_config = self.config.get("output_settings", {}).get(
-            "class_extraction", {}
-        )
-
-        if not class_config.get("enabled", False):
-            return ""
-
-        delimiter = class_config.get("delimiter", "_")
-        position = class_config.get("position", 0)
-
-        try:
-            parts = filename.split(delimiter)
-
-            if 0 <= position < len(parts):
-                return str(parts[position])
-            elif position < 0 and abs(position) <= len(parts):
-                return str(parts[position])
-            else:
-                self.logger.warning(
-                    f"ファイル名 '{filename}' の位置 {position} にクラス名が見つかりません"
-                )
-                return ""
-        except Exception as e:
-            self.logger.warning(
-                f"ファイル名 '{filename}' からクラス名の抽出に失敗しました: {e}"
-            )
-            return ""
-
-    def _extract_features_from_image(self, image_path: Path) -> Dict[str, Any]:
+    def _extract_features_from_image(self, image_path: Path) -> dict[str, Any]:
         """1つの画像から特徴量を抽出する.
 
         Args:
@@ -165,14 +128,17 @@ class FeatureExtractionRunner:
                 self.logger.warning(f"画像の読み込みに失敗しました: {image_path}")
                 return {}
 
-            features: Dict[str, Any] = {"filename": image_path.name}
+            features: dict[str, Any] = {"filename": image_path.name}
 
             class_config = self.config.get("output_settings", {}).get(
                 "class_extraction", {}
             )
             if class_config.get("enabled", False):
-                filename_without_ext = image_path.stem
-                class_name = self._extract_class_from_filename(filename_without_ext)
+                class_name = extract_class_from_filename(
+                    image_path.stem,
+                    delimiter=class_config.get("delimiter", "_"),
+                    position=class_config.get("position", 0),
+                )
                 if class_name:
                     column_name = class_config.get("column_name", "class")
                     features[column_name] = class_name
@@ -226,136 +192,6 @@ class FeatureExtractionRunner:
             self.logger.error(f"画像処理中にエラーが発生しました ({image_path}): {e}")
             return {}
 
-    def _save_results_to_csv(self, results: List[Dict[str, Any]]) -> None:
-        """抽出結果をCSVファイルに保存する.
-
-        Args:
-            results: 特徴量抽出結果のリスト.
-        """
-        if not results:
-            self.logger.warning("保存する結果がありません")
-            return
-
-        output_filename = self.config.get("output_settings", {}).get(
-            "output_filename", "features.csv"
-        )
-        output_path = self.output_dir / output_filename
-
-        separator = self.config.get("output_settings", {}).get("csv_separator", ",")
-
-        try:
-            all_feature_names: set[str] = set()
-            for result in results:
-                all_feature_names.update(result.keys())
-
-            headers: list[str] = []
-            if "filename" in all_feature_names:
-                headers.append("filename")
-                all_feature_names.remove("filename")
-
-            class_config = self.config.get("output_settings", {}).get(
-                "class_extraction", {}
-            )
-            if class_config.get("enabled", False):
-                column_name = class_config.get("column_name", "class")
-                if column_name in all_feature_names:
-                    headers.append(column_name)
-                    all_feature_names.remove(column_name)
-
-            if "timestamp" in all_feature_names:
-                headers.append("timestamp")
-                all_feature_names.remove("timestamp")
-            headers.extend(sorted(all_feature_names))
-
-            with open(output_path, "w", newline="", encoding="utf-8") as f:
-                writer = csv.DictWriter(f, fieldnames=headers, delimiter=separator)
-                writer.writeheader()
-                writer.writerows(results)
-
-            self.logger.info(f"横持ちCSV結果を保存しました: {output_path}")
-            self.logger.info(f"処理された画像数: {len(results)}")
-
-        except Exception as e:
-            self.logger.error(f"CSV保存中にエラーが発生しました: {e}")
-
-    def _save_results_to_long_csv(self, results: List[Dict[str, Any]]) -> None:
-        """抽出結果を縦持ちCSVファイルに保存する.
-
-        Args:
-            results: 特徴量抽出結果のリスト.
-        """
-        if not results:
-            self.logger.warning("保存する結果がありません")
-            return
-
-        output_filename = self.config.get("output_settings", {}).get(
-            "long_format_filename", "features_long.csv"
-        )
-        output_path = self.output_dir / output_filename
-
-        separator = self.config.get("output_settings", {}).get("csv_separator", ",")
-
-        try:
-            long_data: list[dict[str, Any]] = []
-
-            for result in results:
-                filename = result.get("filename", "")
-                timestamp = result.get("timestamp", "")
-
-                class_config = self.config.get("output_settings", {}).get(
-                    "class_extraction", {}
-                )
-                class_name = ""
-                if class_config.get("enabled", False):
-                    column_name = class_config.get("column_name", "class")
-                    class_name = result.get(column_name, "")
-
-                excluded_columns = ["filename", "timestamp"]
-                if class_config.get("enabled", False):
-                    excluded_columns.append(class_config.get("column_name", "class"))
-
-                for feature_name, feature_value in result.items():
-                    if feature_name not in excluded_columns:
-                        row: dict[str, Any] = {
-                            "filename": filename,
-                            "feature_name": feature_name,
-                            "feature_value": feature_value,
-                        }
-
-                        if class_name:
-                            row[class_config.get("column_name", "class")] = class_name
-
-                        if timestamp:
-                            row["timestamp"] = timestamp
-
-                        long_data.append(row)
-
-            headers: list[str] = ["filename"]
-
-            class_config = self.config.get("output_settings", {}).get(
-                "class_extraction", {}
-            )
-            if class_config.get("enabled", False) and any(
-                row.get(class_config.get("column_name", "class")) for row in long_data
-            ):
-                headers.append(class_config.get("column_name", "class"))
-
-            headers.extend(["feature_name", "feature_value"])
-
-            if any(row.get("timestamp") for row in long_data):
-                headers.insert(-2, "timestamp")
-
-            with open(output_path, "w", newline="", encoding="utf-8") as f:
-                writer = csv.DictWriter(f, fieldnames=headers, delimiter=separator)
-                writer.writeheader()
-                writer.writerows(long_data)
-
-            self.logger.info(f"縦持ちCSV結果を保存しました: {output_path}")
-            self.logger.info(f"特徴量レコード数: {len(long_data)}")
-
-        except Exception as e:
-            self.logger.error(f"縦持ちCSV保存中にエラーが発生しました: {e}")
-
     def run(self) -> None:
         """特徴量抽出を実行する."""
         self.logger.info("=== 特徴量抽出を開始します ===")
@@ -378,11 +214,11 @@ class FeatureExtractionRunner:
                 results.append(features)
 
         if self.config.get("output_format", "csv") == "csv":
-            self._save_results_to_csv(results)
+            self.csv_writer.save_wide_csv(results)
 
             if self.config.get("output_settings", {}).get("enable_long_format", False):
-                self._save_results_to_long_csv(results)
+                self.csv_writer.save_long_csv(results)
         elif self.config.get("output_format", "csv") == "long_csv":
-            self._save_results_to_long_csv(results)
+            self.csv_writer.save_long_csv(results)
 
         self.logger.info("=== 特徴量抽出が完了しました ===")

--- a/pochivision/utils/class_extraction.py
+++ b/pochivision/utils/class_extraction.py
@@ -1,0 +1,37 @@
+"""ファイル名からクラス名を抽出するユーティリティ."""
+
+from pochivision.capturelib.log_manager import LogManager
+
+
+def extract_class_from_filename(
+    filename: str,
+    delimiter: str = "_",
+    position: int = 0,
+) -> str:
+    """ファイル名からクラス名を抽出する.
+
+    Args:
+        filename: ファイル名 (拡張子なし).
+        delimiter: 区切り文字.
+        position: クラス名の位置 (負のインデックスも可).
+
+    Returns:
+        抽出されたクラス名. 抽出できない場合は空文字列.
+    """
+    logger = LogManager().get_logger()
+
+    try:
+        parts = filename.split(delimiter)
+
+        if 0 <= position < len(parts):
+            return str(parts[position])
+        elif position < 0 and abs(position) <= len(parts):
+            return str(parts[position])
+        else:
+            logger.warning(
+                f"ファイル名 '{filename}' の位置 {position} にクラス名が見つかりません"
+            )
+            return ""
+    except Exception as e:
+        logger.warning(f"ファイル名 '{filename}' からクラス名の抽出に失敗しました: {e}")
+        return ""

--- a/tests/core/test_feature_csv_writer.py
+++ b/tests/core/test_feature_csv_writer.py
@@ -1,0 +1,116 @@
+"""FeatureCSVWriter のテスト."""
+
+import csv
+
+from pochivision.core.feature_csv_writer import FeatureCSVWriter
+
+
+class TestFeatureCSVWriter:
+    """FeatureCSVWriter のテストクラス."""
+
+    def _make_config(self, **overrides):
+        """テスト用の設定辞書を生成する."""
+        config = {"output_settings": {"output_filename": "features.csv"}}
+        config["output_settings"].update(overrides)
+        return config
+
+    def test_save_wide_csv_basic(self, tmp_path):
+        """基本的な横持ち CSV 出力."""
+        config = self._make_config()
+        writer = FeatureCSVWriter(tmp_path, config)
+
+        results = [
+            {"filename": "img1.png", "feat_a": 1.0, "feat_b": 2.0},
+            {"filename": "img2.png", "feat_a": 3.0, "feat_b": 4.0},
+        ]
+        writer.save_wide_csv(results)
+
+        csv_path = tmp_path / "features.csv"
+        assert csv_path.exists()
+
+        with open(csv_path, encoding="utf-8") as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+
+        assert len(rows) == 2
+        assert rows[0]["filename"] == "img1.png"
+        assert reader.fieldnames is not None
+        assert reader.fieldnames[0] == "filename"
+
+    def test_save_wide_csv_with_class_column(self, tmp_path):
+        """class カラム付きの横持ち CSV 出力."""
+        config = self._make_config(
+            class_extraction={"enabled": True, "column_name": "label"}
+        )
+        writer = FeatureCSVWriter(tmp_path, config)
+
+        results = [
+            {"filename": "img1.png", "label": "cat", "feat_a": 1.0},
+        ]
+        writer.save_wide_csv(results)
+
+        with open(tmp_path / "features.csv", encoding="utf-8") as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+
+        assert reader.fieldnames is not None
+        assert reader.fieldnames[0] == "filename"
+        assert reader.fieldnames[1] == "label"
+        assert rows[0]["label"] == "cat"
+
+    def test_save_wide_csv_empty_results(self, tmp_path):
+        """空の結果では CSV ファイルが作成されない."""
+        config = self._make_config()
+        writer = FeatureCSVWriter(tmp_path, config)
+        writer.save_wide_csv([])
+
+        assert not (tmp_path / "features.csv").exists()
+
+    def test_save_long_csv_basic(self, tmp_path):
+        """基本的な縦持ち CSV 出力."""
+        config = self._make_config(long_format_filename="features_long.csv")
+        writer = FeatureCSVWriter(tmp_path, config)
+
+        results = [
+            {"filename": "img1.png", "feat_a": 1.0, "feat_b": 2.0},
+        ]
+        writer.save_long_csv(results)
+
+        csv_path = tmp_path / "features_long.csv"
+        assert csv_path.exists()
+
+        with open(csv_path, encoding="utf-8") as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+
+        assert len(rows) == 2
+        feature_names = {row["feature_name"] for row in rows}
+        assert feature_names == {"feat_a", "feat_b"}
+
+    def test_save_wide_csv_custom_separator(self, tmp_path):
+        """カスタム区切り文字での CSV 出力."""
+        config = self._make_config(csv_separator="\t")
+        writer = FeatureCSVWriter(tmp_path, config)
+
+        results = [{"filename": "img1.png", "feat_a": 1.0}]
+        writer.save_wide_csv(results)
+
+        content = (tmp_path / "features.csv").read_text(encoding="utf-8")
+        assert "\t" in content
+
+    def test_header_order_filename_first(self, tmp_path):
+        """ヘッダー順序: filename が先頭."""
+        config = self._make_config()
+        writer = FeatureCSVWriter(tmp_path, config)
+
+        results = [{"z_feat": 1.0, "a_feat": 2.0, "filename": "img.png"}]
+        writer.save_wide_csv(results)
+
+        with open(tmp_path / "features.csv", encoding="utf-8") as f:
+            reader = csv.DictReader(f)
+            list(reader)
+
+        assert reader.fieldnames is not None
+        assert reader.fieldnames[0] == "filename"
+        assert reader.fieldnames[1] == "a_feat"
+        assert reader.fieldnames[2] == "z_feat"

--- a/tests/utils/test_class_extraction.py
+++ b/tests/utils/test_class_extraction.py
@@ -1,0 +1,42 @@
+"""extract_class_from_filename のテスト."""
+
+from pochivision.utils.class_extraction import extract_class_from_filename
+
+
+class TestExtractClassFromFilename:
+    """extract_class_from_filename のテストクラス."""
+
+    def test_default_delimiter_position_zero(self):
+        """デフォルト設定 (区切り文字 '_', 位置 0) でクラス名を抽出する."""
+        result = extract_class_from_filename("apple_001")
+        assert result == "apple"
+
+    def test_custom_delimiter(self):
+        """カスタム区切り文字でクラス名を抽出する."""
+        result = extract_class_from_filename("apple-001", delimiter="-")
+        assert result == "apple"
+
+    def test_position_one(self):
+        """位置 1 でクラス名を抽出する."""
+        result = extract_class_from_filename("prefix_classA_001", position=1)
+        assert result == "classA"
+
+    def test_negative_position(self):
+        """負のインデックスでクラス名を抽出する."""
+        result = extract_class_from_filename("apple_001_suffix", position=-1)
+        assert result == "suffix"
+
+    def test_out_of_bounds_returns_empty(self):
+        """範囲外インデックスで空文字列を返す."""
+        result = extract_class_from_filename("apple_001", position=5)
+        assert result == ""
+
+    def test_no_delimiter_in_filename(self):
+        """区切り文字がファイル名にない場合, 位置 0 で全体を返す."""
+        result = extract_class_from_filename("apple", delimiter="_", position=0)
+        assert result == "apple"
+
+    def test_no_delimiter_position_nonzero_returns_empty(self):
+        """区切り文字がなく位置 1 で空文字列を返す."""
+        result = extract_class_from_filename("apple", delimiter="_", position=1)
+        assert result == ""


### PR DESCRIPTION

## Summary
- `FeatureExtractionRunner` から CSV 出力とクラス名抽出の責務を分離し, SRP に準拠

## Related Issue

Closes #284

## Changes
- `pochivision/core/feature_csv_writer.py`: `FeatureCSVWriter` クラスを新規作成. 横持ち/縦持ち CSV の出力を担当
- `pochivision/utils/class_extraction.py`: `extract_class_from_filename()` を独立関数として切り出し
- `pochivision/core/feature_extraction.py`: 上記に委譲するようリファクタリング. 型アノテーションを Python 3.12+ スタイルに統一
- `tests/core/test_feature_csv_writer.py`: `FeatureCSVWriter` のユニットテスト 6 件を追加
- `tests/utils/test_class_extraction.py`: `extract_class_from_filename` のユニットテスト 7 件を追加

```python
# pochivision/core/feature_extraction.py (run メソッド内)
# CSV 出力を FeatureCSVWriter に委譲
self.csv_writer = FeatureCSVWriter(self.output_dir, self.config)
self.csv_writer.save_wide_csv(results)
self.csv_writer.save_long_csv(results)

# クラス名抽出を独立関数に委譲
from pochivision.utils.class_extraction import extract_class_from_filename
class_name = extract_class_from_filename(
    image_path.stem,
    delimiter=class_config.get("delimiter", "_"),
    position=class_config.get("position", 0),
)
```

## Test Plan
- [x] `uv run pre-commit run --all-files` で全チェックが通る
- [x] エージェント 3 名 (設計, コード品質, テストカバレッジ) でレビュー済み

## Checklist
- [x] CSV 出力責務が `FeatureCSVWriter` に分離されている
- [x] クラス名抽出が独立関数に分離されている
- [x] 型アノテーションが Python 3.12+ スタイルに統一されている
- [x] 新規クラス/関数のユニットテストが追加されている
- [x] 既存テストが通る
