### PR TITLE
fix: run.py のエラーハンドリング統一と型アノテーション修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,19 +6,20 @@
 ## [Unreleased]
 
 ### Added
-- ライブプレビューに `h` キーでトグルするヘルプオーバーレイ表示機能を追加. 黒文字 + 白縁で表示し, 保存画像には影響しない. (NA.)
+- ライブプレビューに `h` キーでトグルするヘルプオーバーレイ表示機能を追加. 黒文字 + 白縁で表示し, 保存画像には影響しない. ([#295](https://github.com/kurorosu/pochivision/pull/295))
 
 ### Changed
-- 設定ファイル (`config.json`, `extractor_config.json`) を `config/` ディレクトリに移動し, CLI のデフォルトパスを更新. (NA.)
-- `FeatureExtractionRunner` の CSV 出力を `FeatureCSVWriter` に, クラス名抽出を `extract_class_from_filename()` に分離. (NA.)
+- 設定ファイル (`config.json`, `extractor_config.json`) を `config/` ディレクトリに移動し, CLI のデフォルトパスを更新. ([#294](https://github.com/kurorosu/pochivision/pull/294))
+- `FeatureExtractionRunner` の CSV 出力を `FeatureCSVWriter` に, クラス名抽出を `extract_class_from_filename()` に分離. ([#297](https://github.com/kurorosu/pochivision/pull/297))
 
 ### Fixed
 - `ImageSaver.save()` で `cv2.imwrite()` の戻り値を検証し, 保存失敗時に警告ログを出力するよう修正. ([#291](https://github.com/kurorosu/pochivision/pull/291))
 - `RecordingManager.add_frame()` のロック外チェックを削除しスレッド安全性を改善. `start_recording()` にフレームサイズ検証を追加. ([#292](https://github.com/kurorosu/pochivision/pull/292))
 - `ImageSaver.save()` のログ出力でグレースケール画像の幅/高さが正しく取得されるよう `image.shape[:2]` に修正. ([#293](https://github.com/kurorosu/pochivision/pull/293))
+- `run.py` の `SystemExit(1)` を `click.ClickException` に統一, `logger` パラメータ型と `_setup_camera()` 戻り値型を修正. (NA.)
 
 ### Removed
-- `feature_extractors/__init__.py` から未使用の Params クラス 9 件のエクスポートを削除. (NA.)
+- `feature_extractors/__init__.py` から未使用の Params クラス 9 件のエクスポートを削除. ([#296](https://github.com/kurorosu/pochivision/pull/296))
 
 ## [0.3.0] - 2026-04-04
 

--- a/pochivision/cli/commands/run.py
+++ b/pochivision/cli/commands/run.py
@@ -1,6 +1,6 @@
 """run サブコマンド: ライブプレビュー起動."""
 
-from typing import cast
+import logging
 
 import click
 import cv2
@@ -12,7 +12,7 @@ from pochivision.capturelib.log_manager import LogManager
 from pochivision.capturelib.recording_manager import RecordingManager
 from pochivision.constants import DEFAULT_PREVIEW_HEIGHT, DEFAULT_PREVIEW_WIDTH
 from pochivision.core import PipelineExecutor
-from pochivision.exceptions.config import ConfigValidationError
+from pochivision.exceptions.config import ConfigLoadError, ConfigValidationError
 from pochivision.workspace import OutputManager
 
 
@@ -54,7 +54,7 @@ def run(
     )
 
 
-def _load_config(config_path: str, logger: object) -> dict:
+def _load_config(config_path: str, logger: logging.Logger) -> dict:
     """設定ファイルを読み込む.
 
     Args:
@@ -63,18 +63,22 @@ def _load_config(config_path: str, logger: object) -> dict:
 
     Returns:
         設定辞書.
+
+    Raises:
+        click.ClickException: 設定ファイルの読み込みに失敗した場合.
     """
     try:
         config_data = ConfigHandler.load(config_path)
-        logger.info("Configuration loaded successfully")  # type: ignore[attr-defined]
+        logger.info("Configuration loaded successfully")
         return config_data
     except ConfigValidationError as e:
-        logger.error(str(e))  # type: ignore[attr-defined]
-        click.echo("設定ファイルに誤りがあります. 詳細はログを確認してください.")
-        raise SystemExit(1)
-    except Exception as e:
-        logger.error(f"Failed to load configuration: {e}")  # type: ignore[attr-defined]
-        raise SystemExit(1)
+        logger.error(str(e))
+        raise click.ClickException(
+            "設定ファイルに誤りがあります. 詳細はログ��確認してください."
+        )
+    except (ConfigLoadError, Exception) as e:
+        logger.error(f"Failed to load configuration: {e}")
+        raise click.ClickException(str(e))
 
 
 def _print_profiles(config_data: dict) -> None:
@@ -98,7 +102,7 @@ def _setup_camera(
     log_manager: LogManager,
     camera: int,
     profile: str | None,
-) -> tuple:
+) -> tuple[cv2.VideoCapture, CameraSetup]:
     """カメラをセットアップする.
 
     Args:
@@ -109,6 +113,9 @@ def _setup_camera(
 
     Returns:
         (cap, camera_setup) のタプル.
+
+    Raises:
+        click.ClickException: カメラのセットアップに失敗した場合.
     """
     logger = log_manager.get_logger()
     try:
@@ -119,11 +126,13 @@ def _setup_camera(
             profile_name=profile or "0",
         )
         camera_setup.load_camera_config()
-        cap = cast(cv2.VideoCapture, camera_setup.initialize_camera())
+        cap = camera_setup.initialize_camera()
 
-        if not cap.isOpened():
+        if cap is None or not cap.isOpened():
             logger.error(f"Failed to open camera {camera_setup.camera_index}.")
-            raise SystemExit(1)
+            raise click.ClickException(
+                f"カメラ {camera_setup.camera_index} を開けませ���でした."
+            )
 
         log_manager.log_camera_info(
             cap,
@@ -134,17 +143,17 @@ def _setup_camera(
         )
         return cap, camera_setup
 
-    except SystemExit:
+    except click.ClickException:
         raise
     except Exception as e:
         logger.error(f"Error setting up camera: {e}")
-        raise SystemExit(1)
+        raise click.ClickException(str(e))
 
 
 def _run_preview(
     config_data: dict,
     log_manager: LogManager,
-    cap: object,
+    cap: cv2.VideoCapture,
     camera_setup: CameraSetup,
     no_recording: bool,
     output_manager: OutputManager,
@@ -154,7 +163,7 @@ def _run_preview(
     Args:
         config_data: 設定辞書.
         log_manager: ログマネージャ.
-        cap: カメラキャプチャオブジェクト.
+        cap: カメラキャプチャオブジェクト (cv2.VideoCapture).
         camera_setup: カメラセットアップ.
         no_recording: 録画無効フラグ.
         output_manager: 出力ディレクトリの統一管理クラス.
@@ -192,7 +201,7 @@ def _run_preview(
             preview_config.get("height", DEFAULT_PREVIEW_HEIGHT),
         )
 
-        app = LivePreviewRunner(cap, pipeline, recording_manager, preview_size)  # type: ignore[arg-type]
+        app = LivePreviewRunner(cap, pipeline, recording_manager, preview_size)
         app.run()
 
     except Exception as e:


### PR DESCRIPTION

## Summary
- `run.py` の `SystemExit(1)` を `click.ClickException` に統一し, 型アノテーションを修正

## Related Issue

Closes #298

## Changes
- `pochivision/cli/commands/run.py`:
  - `_load_config()`: `SystemExit(1)` → `click.ClickException`, `logger: object` → `logger: logging.Logger`, `type: ignore` 削除
  - `_setup_camera()`: `SystemExit(1)` → `click.ClickException`, `-> tuple` → `-> tuple[cv2.VideoCapture, CameraSetup]`, `cast()` 削除
  - `_run_preview()`: `cap: object` → `cap: cv2.VideoCapture`, `type: ignore[arg-type]` 削除
  - `from typing import cast` 削除, `import logging` と `ConfigLoadError` 追加

```python
# Before
def _load_config(config_path: str, logger: object) -> dict:
    ...
    raise SystemExit(1)

def _setup_camera(...) -> tuple:
    cap = cast(cv2.VideoCapture, camera_setup.initialize_camera())
    ...
    raise SystemExit(1)

# After
def _load_config(config_path: str, logger: logging.Logger) -> dict:
    ...
    raise click.ClickException(str(e))

def _setup_camera(...) -> tuple[cv2.VideoCapture, CameraSetup]:
    cap = camera_setup.initialize_camera()
    ...
    raise click.ClickException(str(e))
```

## Test Plan
- [x] `uv run pre-commit run --all-files` で全チェックが通る

## Checklist
- [x] `SystemExit(1)` が `click.ClickException` に統一されている
- [x] `type: ignore` コメントが削除されている
- [x] 型アノテーションが正確になっている
- [x] 既存テストが通る
