### PR TITLE
fix: feature_extraction.py の例外黙殺にログ追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@
 - `ImageSaver.save()` で `cv2.imwrite()` の戻り値を検証し, 保存失敗時に警告ログを出力するよう修正. ([#291](https://github.com/kurorosu/pochivision/pull/291))
 - `RecordingManager.add_frame()` のロック外チェックを削除しスレッド安全性を改善. `start_recording()` にフレームサイズ検証を追加. ([#292](https://github.com/kurorosu/pochivision/pull/292))
 - `ImageSaver.save()` のログ出力でグレースケール画像の幅/高さが正しく取得されるよう `image.shape[:2]` に修正. ([#293](https://github.com/kurorosu/pochivision/pull/293))
-- `run.py` の `SystemExit(1)` を `click.ClickException` に統一, `logger` パラメータ型と `_setup_camera()` 戻り値型を修正. (NA.)
+- `run.py` の `SystemExit(1)` を `click.ClickException` に統一, `logger` パラメータ型と `_setup_camera()` 戻り値型を修正. ([#309](https://github.com/kurorosu/pochivision/pull/309))
+- `FeatureExtractionRunner` の特徴量ユニット名取得失敗時に警告ログを出力するよう修正. (NA.)
 
 ### Removed
 - `feature_extractors/__init__.py` から未使用の Params クラス 9 件のエクスポートを削除. ([#296](https://github.com/kurorosu/pochivision/pull/296))

--- a/pochivision/core/feature_extraction.py
+++ b/pochivision/core/feature_extraction.py
@@ -174,7 +174,10 @@ class FeatureExtractionRunner:
                                     features[f"{extractor_name}_{unit_name}"] = value
                                 else:
                                     features[f"{extractor_name}_{base_name}"] = value
-                        except Exception:
+                        except Exception as e:
+                            self.logger.warning(
+                                f"ユニット名の取得に失敗しました ({extractor_name}): {e}"
+                            )
                             for feature_name, value in extracted.items():
                                 features[f"{extractor_name}_{feature_name}"] = value
                     else:


### PR DESCRIPTION

## Summary
- 特徴量ユニット名取得失敗時の `except Exception:` に警告ログを追加

## Related Issue

Closes #300

## Changes
- `pochivision/core/feature_extraction.py`: ユニット名取得の `except Exception:` を `except Exception as e:` に変更し, `self.logger.warning()` で原因を出力

```python
# Before
except Exception:
    for feature_name, value in extracted.items():
        features[f"{extractor_name}_{feature_name}"] = value

# After
except Exception as e:
    self.logger.warning(
        f"ユニット名の取得に失敗しました ({extractor_name}): {e}"
    )
    for feature_name, value in extracted.items():
        features[f"{extractor_name}_{feature_name}"] = value
```

## Test Plan
- [x] `uv run pre-commit run --all-files` で全チェックが通る

## Checklist
- [x] 例外が警告ログに出力される
- [x] フォールバック動作 (ユニット名なしで特徴量名を使用) は維持
- [x] 既存テストが通る
