### PR TITLE
fix: FPS 測定の除算ゼロリスク対策

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@
 - `RecordingManager.add_frame()` のロック外チェックを削除しスレッド安全性を改善. `start_recording()` にフレームサイズ検証を追加. ([#292](https://github.com/kurorosu/pochivision/pull/292))
 - `ImageSaver.save()` のログ出力でグレースケール画像の幅/高さが正しく取得されるよう `image.shape[:2]` に修正. ([#293](https://github.com/kurorosu/pochivision/pull/293))
 - `run.py` の `SystemExit(1)` を `click.ClickException` に統一, `logger` パラメータ型と `_setup_camera()` 戻り値型を修正. ([#309](https://github.com/kurorosu/pochivision/pull/309))
-- `FeatureExtractionRunner` の特徴量ユニット名取得失敗時に警告ログを出力するよう修正. (NA.)
+- `FeatureExtractionRunner` の特徴量ユニット名取得失敗時に警告ログを出力するよう修正. ([#310](https://github.com/kurorosu/pochivision/pull/310))
+- `_measure_actual_fps()` の除算ゼロリスクに防御コードを追加. (NA.)
 
 ### Removed
 - `feature_extractors/__init__.py` から未使用の Params クラス 9 件のエクスポートを削除. ([#296](https://github.com/kurorosu/pochivision/pull/296))

--- a/pochivision/capture_runner/viewer.py
+++ b/pochivision/capture_runner/viewer.py
@@ -93,7 +93,7 @@ class LivePreviewRunner:
                 cv2.waitKey(1)
 
         actual_duration = time.time() - start_time
-        measured_fps = frame_count / actual_duration
+        measured_fps = frame_count / actual_duration if actual_duration > 0 else 0.0
 
         self.logger.info(
             f"Measured FPS: {measured_fps:.2f} "


### PR DESCRIPTION

## Summary
- `_measure_actual_fps()` で `actual_duration` がゼロの場合の除算ゼロリスクに防御コードを追加

## Related Issue

Closes #304

## Changes
- `pochivision/capture_runner/viewer.py`: `measured_fps` の算出にゼロ除算防御を追加

```python
# Before
measured_fps = frame_count / actual_duration

# After
measured_fps = frame_count / actual_duration if actual_duration > 0 else 0.0
```

## Test Plan
- [x] `uv run pre-commit run --all-files` で全チェックが通る

## Checklist
- [x] `actual_duration` がゼロの場合に `ZeroDivisionError` が発生しない
- [x] 既存テストが通る
