### PR TITLE
fix: RecordingManager.start_recording() の race condition 修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@
 - `ImageSaver.save()` のログ出力でグレースケール画像の幅/高さが正しく取得されるよう `image.shape[:2]` に修正. ([#293](https://github.com/kurorosu/pochivision/pull/293))
 - `run.py` の `SystemExit(1)` を `click.ClickException` に統一, `logger` パラメータ型と `_setup_camera()` 戻り値型を修正. ([#309](https://github.com/kurorosu/pochivision/pull/309))
 - `FeatureExtractionRunner` の特徴量ユニット名取得失敗時に警告ログを出力するよう修正. ([#310](https://github.com/kurorosu/pochivision/pull/310))
-- `_measure_actual_fps()` の除算ゼロリスクに防御コードを追加. (NA.)
+- `_measure_actual_fps()` の除算ゼロリスクに防御コードを追加. ([#311](https://github.com/kurorosu/pochivision/pull/311))
+- `RecordingManager.start_recording()` の `is_recording` チェックをロック内に移動し race condition を修正. (NA.)
 
 ### Removed
 - `feature_extractors/__init__.py` から未使用の Params クラス 9 件のエクスポートを削除. ([#296](https://github.com/kurorosu/pochivision/pull/296))

--- a/pochivision/capturelib/recording_manager.py
+++ b/pochivision/capturelib/recording_manager.py
@@ -133,66 +133,67 @@ class RecordingManager:
         Returns:
             bool: 録画開始に成功した場合True、失敗した場合False
         """
-        if self.is_recording:
-            self.logger.warning("Recording is already in progress")
-            return False
-
-        # フレームサイズの検証
-        if len(frame_size) != 2 or frame_size[0] <= 0 or frame_size[1] <= 0:
-            self.logger.error(f"Invalid frame size: {frame_size}")
-            return False
-
-        # 設定された動画形式を使用
-        format_info = VideoFormat.get_format_info(self.video_format)
-        if format_info is None:
-            self.logger.error(f"Invalid video format: {self.video_format}")
-            return False
-
-        fourcc_str, extension, description = format_info
-
-        try:
-            # movieディレクトリを作成
-            movie_dir = output_dir / "movie"
-            movie_dir.mkdir(parents=True, exist_ok=True)
-
-            # 録画ファイル名を生成（タイムスタンプ付き）
-            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-            video_filename = (
-                movie_dir / f"recording_{timestamp}_{self.video_format}{extension}"
-            )
-
-            # VideoWriterを初期化
-            fourcc_code = cv2.VideoWriter.fourcc(*fourcc_str)
-            self.video_writer = cv2.VideoWriter(
-                str(video_filename), fourcc_code, fps, frame_size
-            )
-
-            if not self.video_writer.isOpened():
-                self.logger.error(
-                    f"Failed to initialize VideoWriter with format {self.video_format}"
-                )
-                self.video_writer.release()
-                self.video_writer = None
+        with self.lock:
+            if self.is_recording:
+                self.logger.warning("Recording is already in progress")
                 return False
 
-            # 録画フラグを設定
-            with self.lock:
+            # フレームサイズの検証
+            if len(frame_size) != 2 or frame_size[0] <= 0 or frame_size[1] <= 0:
+                self.logger.error(f"Invalid frame size: {frame_size}")
+                return False
+
+            # 設定された動画形式を使用
+            format_info = VideoFormat.get_format_info(self.video_format)
+            if format_info is None:
+                self.logger.error(f"Invalid video format: {self.video_format}")
+                return False
+
+            fourcc_str, extension, description = format_info
+
+            try:
+                # movieディレクトリを作成
+                movie_dir = output_dir / "movie"
+                movie_dir.mkdir(parents=True, exist_ok=True)
+
+                # 録画ファイル名を生成（タイムスタンプ付き）
+                timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+                video_filename = (
+                    movie_dir / f"recording_{timestamp}_{self.video_format}{extension}"
+                )
+
+                # VideoWriterを初期化
+                fourcc_code = cv2.VideoWriter.fourcc(*fourcc_str)
+                self.video_writer = cv2.VideoWriter(
+                    str(video_filename), fourcc_code, fps, frame_size
+                )
+
+                if not self.video_writer.isOpened():
+                    self.logger.error(
+                        f"Failed to initialize VideoWriter "
+                        f"with format {self.video_format}"
+                    )
+                    self.video_writer.release()
+                    self.video_writer = None
+                    return False
+
+                # 録画フラグを設定
                 self.is_recording = True
                 self.frame_queue.clear()
                 self.frame_count = 0
                 self.recording_start_time = time.time()
 
-            self.logger.info(
-                f"Recording started: {video_filename} (Format: {description})"
-            )
-            return True
+                self.logger.info(
+                    f"Recording started: {video_filename} " f"(Format: {description})"
+                )
+                return True
 
-        except Exception as e:
-            self.logger.error(f"Error occurred while starting recording: {e}")
-            if self.video_writer is not None:
-                self.video_writer.release()
-                self.video_writer = None
-            return False
+            except Exception as e:
+                self.logger.error(f"Error occurred while starting recording: {e}")
+                if self.video_writer is not None:
+                    self.video_writer.release()
+                    self.video_writer = None
+                return False
 
     def stop_recording(self) -> bool:
         """


### PR DESCRIPTION

## Summary
- `start_recording()` の `is_recording` チェックをロック内に移動し, 複数スレッドからの同時呼び出しによる race condition を修正

## Related Issue

Closes #305

## Changes
- `pochivision/capturelib/recording_manager.py`: `start_recording()` メソッド全体を `with self.lock:` ブロック内に移動. `is_recording` チェック, VideoWriter 初期化, フラグ設定がすべてアトミックに実行される

```python
# Before
def start_recording(self, ...):
    if self.is_recording:  # ロック外でチェック
        return False
    ...
    with self.lock:  # フラグ設定のみロック内
        self.is_recording = True

# After
def start_recording(self, ...):
    with self.lock:  # メソッド全体をロック内で実行
        if self.is_recording:
            return False
        ...
        self.is_recording = True
```

## Test Plan
- [x] `uv run pre-commit run --all-files` で全チェックが通る

## Checklist
- [x] `is_recording` チェックがロック内で実行される
- [x] VideoWriter 初期化とフラグ設定がアトミックに実行される
- [x] 既存テストが通る
