### PR TITLE
test: SimpleFFTVisualizer のロジックテスト追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
 ### Added
 - ライブプレビューに `h` キーでトグルするヘルプオーバーレイ表示機能を追加. 黒文字 + 白縁で表示し, 保存画像には影響しない. ([#295](https://github.com/kurorosu/pochivision/pull/295))
 - `FeatureExtractionRunner` の統合テスト 7 件を追加. ([#314](https://github.com/kurorosu/pochivision/pull/314))
-- `ProfileProcessor` のテスト 7 件を追加. (NA.)
+- `ProfileProcessor` のテスト 7 件を追加. ([#315](https://github.com/kurorosu/pochivision/pull/315))
+- `SimpleFFTVisualizer` のロジックテスト 10 件を追加. (NA.)
 
 ### Changed
 - 設定ファイル (`config.json`, `extractor_config.json`) を `config/` ディレクトリに移動し, CLI のデフォルトパスを更新. ([#294](https://github.com/kurorosu/pochivision/pull/294))

--- a/tests/core/test_fft_visualization.py
+++ b/tests/core/test_fft_visualization.py
@@ -1,0 +1,128 @@
+"""SimpleFFTVisualizer のロジックテスト."""
+
+import cv2
+import numpy as np
+import pytest
+
+from pochivision.core.fft_visualization import SimpleFFTVisualizer
+
+
+def _create_test_image(path, width=64, height=64):
+    """テスト用グレースケール画像を作成して保存する."""
+    image = np.random.randint(0, 256, (height, width), dtype=np.uint8)
+    cv2.imwrite(str(path), image)
+    return path
+
+
+def _create_color_image(path, width=64, height=64):
+    """テスト用カラー画像を作成して保存する."""
+    image = np.random.randint(0, 256, (height, width, 3), dtype=np.uint8)
+    cv2.imwrite(str(path), image)
+    return path
+
+
+class TestSimpleFFTVisualizer:
+    """SimpleFFTVisualizer のテストクラス."""
+
+    def test_load_grayscale_image(self, tmp_path):
+        """グレースケール画像を読み込める."""
+        img_path = _create_test_image(tmp_path / "gray.png")
+        viz = SimpleFFTVisualizer(str(img_path))
+        assert viz.load_image() is True
+        assert viz.img is not None
+        assert len(viz.img.shape) == 2
+
+    def test_load_color_image_converts_to_gray(self, tmp_path):
+        """カラー画像を読み込むとグレースケールに変換される."""
+        img_path = _create_color_image(tmp_path / "color.png")
+        viz = SimpleFFTVisualizer(str(img_path))
+        assert viz.load_image() is True
+        assert viz.img is not None
+        assert len(viz.img.shape) == 2
+
+    def test_load_nonexistent_image(self, tmp_path):
+        """存在しない画像で False を返す."""
+        viz = SimpleFFTVisualizer(str(tmp_path / "nonexistent.png"))
+        assert viz.load_image() is False
+
+    def test_compute_fft(self, tmp_path):
+        """FFT 計算後にスペクトラムが生成される."""
+        img_path = _create_test_image(tmp_path / "img.png")
+        viz = SimpleFFTVisualizer(str(img_path))
+        viz.load_image()
+        viz.compute_fft()
+
+        assert viz.fshift is not None
+        assert viz.spectrum_display is not None
+        assert viz.spectrum_display.dtype == np.uint8
+
+    def test_compute_fft_without_image_raises(self):
+        """画像未読み込みで compute_fft を呼ぶと ValueError."""
+        viz = SimpleFFTVisualizer("dummy.png")
+        with pytest.raises(ValueError):
+            viz.compute_fft()
+
+    def test_apply_filter_original(self, tmp_path):
+        """original モードでは元画像がそのまま返る."""
+        img_path = _create_test_image(tmp_path / "img.png")
+        viz = SimpleFFTVisualizer(str(img_path))
+        viz.load_image()
+        viz.compute_fft()
+
+        viz.filter_mode = "original"
+        result = viz.apply_filter()
+        np.testing.assert_array_equal(result, viz.img)
+
+    def test_apply_filter_lowpass(self, tmp_path):
+        """lowpass フィルタで画像が返る."""
+        img_path = _create_test_image(tmp_path / "img.png")
+        viz = SimpleFFTVisualizer(str(img_path))
+        viz.load_image()
+        viz.compute_fft()
+
+        viz.filter_mode = "lowpass"
+        viz.filter_radius = 20
+        result = viz.apply_filter()
+
+        assert result.shape == viz.img.shape
+        assert result.dtype == np.uint8
+
+    def test_apply_filter_highpass(self, tmp_path):
+        """highpass フィルタで画像が返る."""
+        img_path = _create_test_image(tmp_path / "img.png")
+        viz = SimpleFFTVisualizer(str(img_path))
+        viz.load_image()
+        viz.compute_fft()
+
+        viz.filter_mode = "highpass"
+        viz.filter_radius = 20
+        result = viz.apply_filter()
+
+        assert result.shape == viz.img.shape
+        assert result.dtype == np.uint8
+
+    def test_apply_filter_without_fft_raises(self, tmp_path):
+        """FFT 未計算で apply_filter を呼ぶと ValueError."""
+        img_path = _create_test_image(tmp_path / "img.png")
+        viz = SimpleFFTVisualizer(str(img_path))
+        viz.load_image()
+
+        with pytest.raises(ValueError):
+            viz.apply_filter()
+
+    def test_filter_radius_change(self, tmp_path):
+        """フィルタ半径を変更すると結果が変わる."""
+        img_path = _create_test_image(tmp_path / "img.png")
+        viz = SimpleFFTVisualizer(str(img_path))
+        viz.load_image()
+        viz.compute_fft()
+        viz.filter_mode = "lowpass"
+
+        viz.filter_radius = 5
+        result_small = viz.apply_filter()
+
+        viz.filter_radius = 30
+        result_large = viz.apply_filter()
+
+        # 半径が異なれば結果も異なる
+        assert not np.array_equal(result_small, result_large)


### PR DESCRIPTION

## Summary
- `SimpleFFTVisualizer` のロジックテスト 10 件を追加. GUI 部分はスキップし, 計算ロジックのみカバー

## Related Issue

Closes #308

## Changes
- `tests/core/test_fft_visualization.py`: 新規作成. 以下のテストケースを追加
  - `test_load_grayscale_image`: グレースケール画像の読み込み
  - `test_load_color_image_converts_to_gray`: カラー画像のグレースケール変換
  - `test_load_nonexistent_image`: ��在しない画像で False
  - `test_compute_fft`: FFT 計算後のスペクトラム生成
  - `test_compute_fft_without_image_raises`: 画像未読み込みで ValueError
  - `test_apply_filter_original`: original モードで元画像が返る
  - `test_apply_filter_lowpass`: lowpass フィルタの結果検証
  - `test_apply_filter_highpass`: highpass フィルタの結果検証
  - `test_apply_filter_without_fft_raises`: FFT 未計算で ValueError
  - `test_filter_radius_change`: 半径変更で結果が変わる

## Test Plan
- [x] `uv run pytest tests/core/test_fft_visualization.py -v` で 10 件全通過
- [x] `uv run pre-commit run --all-files` で全チェックが通る

## Checklist
- [x] 古典派テスト (モックなし, 実オブジェクト使用)
- [x] GUI 部分 (`run()`, `update_display()`) はスキップ
- [x] load, compute_fft, apply_filter の3メソッドをカバー
- [x] 既存テストが通る
