### PR TITLE
refactor: tests/conftest.py の未使用フィクスチャを削除

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Removed
 - `RecordingManager` の未使用属性 `frame_queue`, `recording_thread` を削除. ([#320](https://github.com/kurorosu/pochivision/pull/320))
+- `tests/conftest.py` の未使用フィクスチャ `dummy_color_image`, `dummy_grayscale_image` を削除. (NA.)
 
 ## [0.4.0] - 2026-04-04
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,18 +5,6 @@ import pytest
 
 
 @pytest.fixture
-def dummy_color_image() -> np.ndarray:
-    """100x100 のカラー画像 (BGR, uint8) を返す."""
-    return np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)
-
-
-@pytest.fixture
-def dummy_grayscale_image() -> np.ndarray:
-    """100x100 のグレースケール画像 (uint8) を返す."""
-    return np.random.randint(0, 256, (100, 100), dtype=np.uint8)
-
-
-@pytest.fixture
 def dummy_binary_image() -> np.ndarray:
     """100x100 の2値画像 (0/255, uint8) を返す."""
     image = np.zeros((100, 100), dtype=np.uint8)


### PR DESCRIPTION
## Summary

- `tests/conftest.py` の未使用フィクスチャ `dummy_color_image` と `dummy_grayscale_image` を削除した.

## Related Issue

Closes #303

## Changes

- `tests/conftest.py`: `dummy_color_image`, `dummy_grayscale_image` フィクスチャの定義を削除

## Test Plan

- `uv run pre-commit run --all-files` が通過する
- `uv run pytest` が通過する

## Checklist

- [x] `dummy_color_image` フィクスチャが削除されている
- [x] `dummy_grayscale_image` フィクスチャが削除されている
- [x] pre-commit チェック通過
