### PR TITLE
refactor: プロセッサの logging.getLogger を LogManager に統一

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,14 @@
 ### Changed
 - `SimpleFFTVisualizer` の `print()` を `LogManager` 経由のログ出力に統一. ([#318](https://github.com/kurorosu/pochivision/pull/318))
 - `processors/registry.py` と `feature_extractors/registry.py` のロガーを `LogManager` に統一. ([#319](https://github.com/kurorosu/pochivision/pull/319))
+- プロセッサ (`binarization.py`, `clahe.py`, `equalize.py`) の `logging.getLogger` を `LogManager` に統一. (NA.)
 
 ### Fixed
 - 無し
 
 ### Removed
 - `RecordingManager` の未使用属性 `frame_queue`, `recording_thread` を削除. ([#320](https://github.com/kurorosu/pochivision/pull/320))
-- `tests/conftest.py` の未使用フィクスチャ `dummy_color_image`, `dummy_grayscale_image` を削除. (NA.)
+- `tests/conftest.py` の未使用フィクスチャ `dummy_color_image`, `dummy_grayscale_image` を削除. ([#321](https://github.com/kurorosu/pochivision/pull/321))
 
 ## [0.4.0] - 2026-04-04
 

--- a/pochivision/processors/binarization.py
+++ b/pochivision/processors/binarization.py
@@ -1,11 +1,11 @@
 """2値化処理プロセッサの実装を提供するモジュール."""
 
-import logging
 from typing import Any, Dict
 
 import cv2
 import numpy as np
 
+from pochivision.capturelib.log_manager import LogManager
 from pochivision.exceptions import ProcessorRuntimeError
 from pochivision.processors import BaseProcessor
 from pochivision.processors.registry import register_processor
@@ -51,7 +51,7 @@ class StandardBinarizationProcessor(BaseProcessor):
             config (dict, optional): 設定パラメータ. デフォルトはNone.
         """
         super().__init__(name, config)
-        self.logger = logging.getLogger(__name__)
+        self.logger = LogManager().get_logger()
         self.validator = StandardBinarizationValidator(self.config)
         self.threshold: int = self.config.get("threshold", 128)
 
@@ -124,7 +124,7 @@ class OtsuBinarizationProcessor(BaseProcessor):
             config (dict, optional): 設定パラメータ.
         """
         super().__init__(name, config)
-        self.logger = logging.getLogger(__name__)
+        self.logger = LogManager().get_logger()
         self.validator = OtsuBinarizationValidator(self.config)
 
     def process(self, image: np.ndarray) -> np.ndarray:
@@ -197,7 +197,7 @@ class GaussianAdaptiveBinarizationProcessor(BaseProcessor):
             config (dict, optional): 設定パラメータ.
         """
         super().__init__(name, config)
-        self.logger = logging.getLogger(__name__)
+        self.logger = LogManager().get_logger()
         self.validator = GaussianAdaptiveBinarizationValidator(self.config)
         self.block_size: int = self.config.get("block_size", 11)
         self.c_value: int | float = self.config.get("c", 2)
@@ -282,7 +282,7 @@ class MeanAdaptiveBinarizationProcessor(BaseProcessor):
             config (dict, optional): 設定パラメータ.
         """
         super().__init__(name, config)
-        self.logger = logging.getLogger(__name__)
+        self.logger = LogManager().get_logger()
         self.validator = MeanAdaptiveBinarizationValidator(self.config)
         self.block_size: int = self.config.get("block_size", 11)
         self.c_value: int | float = self.config.get("c", 2)

--- a/pochivision/processors/clahe.py
+++ b/pochivision/processors/clahe.py
@@ -1,11 +1,11 @@
 """CLAHE（適応的ヒストグラム平坦化）プロセッサーを提供するモジュール."""
 
-import logging
 from typing import Any, Dict, Optional
 
 import cv2
 import numpy as np
 
+from pochivision.capturelib.log_manager import LogManager
 from pochivision.exceptions import ProcessorRuntimeError
 from pochivision.processors import BaseProcessor
 from pochivision.processors.registry import register_processor
@@ -49,7 +49,7 @@ class CLAHEProcessor(BaseProcessor):
                 - tile_grid_size (List[int]): タイルグリッドのサイズ
         """
         super().__init__(name, config or {})
-        self.logger = logging.getLogger(__name__)
+        self.logger = LogManager().get_logger()
         self.validator = CLAHEInputValidator(self.config)
 
         self.color_mode = self.config.get("color_mode", "gray")

--- a/pochivision/processors/equalize.py
+++ b/pochivision/processors/equalize.py
@@ -1,11 +1,11 @@
 """ヒストグラム平坦化プロセッサーを提供するモジュール."""
 
-import logging
 from typing import Any, Dict, Optional
 
 import cv2
 import numpy as np
 
+from pochivision.capturelib.log_manager import LogManager
 from pochivision.exceptions import ProcessorRuntimeError
 from pochivision.processors import BaseProcessor
 from pochivision.processors.registry import register_processor
@@ -45,7 +45,7 @@ class EqualizeProcessor(BaseProcessor):
                 - color_mode (str): カラー画像の処理方式 ('gray', 'lab', 'bgr')
         """
         super().__init__(name, config or {})
-        self.logger = logging.getLogger(__name__)
+        self.logger = LogManager().get_logger()
         self.validator = EqualizeInputValidator(self.config)
 
         self.color_mode = self.config.get("color_mode", "gray")


### PR DESCRIPTION
## Summary

- プロセッサモジュールの `logging.getLogger(__name__)` を `LogManager` に統一した.

## Related Issue

Closes #326

## Changes

- `pochivision/processors/binarization.py`: 4クラスの `logging.getLogger(__name__)` → `LogManager().get_logger()`
- `pochivision/processors/clahe.py`: `logging.getLogger(__name__)` → `LogManager().get_logger()`
- `pochivision/processors/equalize.py`: `logging.getLogger(__name__)` → `LogManager().get_logger()`

## Test Plan

- `uv run pre-commit run --all-files` が通過する
- `uv run pytest` が通過する

## Checklist

- [x] 全プロセッサのロガーが `LogManager` 経由になっている
- [x] `logging.getLogger` がプロジェクト内で `LogManager` 内部以外に残っていない
- [x] pre-commit チェック通過
