### PR TITLE
refactor: 型アノテーションを Python 3.12+ 新スタイルに統一

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@
 ### Changed
 - `SimpleFFTVisualizer` の `print()` を `LogManager` 経由のログ出力に統一. ([#318](https://github.com/kurorosu/pochivision/pull/318))
 - `processors/registry.py` と `feature_extractors/registry.py` のロガーを `LogManager` に統一. ([#319](https://github.com/kurorosu/pochivision/pull/319))
-- プロセッサ (`binarization.py`, `clahe.py`, `equalize.py`) の `logging.getLogger` を `LogManager` に統一. (NA.)
+- プロセッサ (`binarization.py`, `clahe.py`, `equalize.py`) の `logging.getLogger` を `LogManager` に統一. ([#332](https://github.com/kurorosu/pochivision/pull/332))
+- 型アノテーションを Python 3.12+ 新スタイル (`dict`, `list`, `tuple`, `X | None`) に統一. (NA.)
 
 ### Fixed
 - 無し

--- a/pochivision/capture_runner/viewer.py
+++ b/pochivision/capture_runner/viewer.py
@@ -2,7 +2,6 @@
 
 import platform
 import time
-from typing import Optional
 
 import cv2
 import numpy as np
@@ -24,14 +23,14 @@ class LivePreviewRunner:
     Attributes:
         cap (cv2.VideoCapture): カメラオブジェクト.
         pipeline: キャプチャ後に処理を行うパイプラインインスタンス.
-        recording_manager (Optional[RecordingManager]): 録画機能を管理するマネージャー.
+        recording_manager (RecordingManager | None): 録画機能を管理するマネージャー.
     """
 
     def __init__(
         self,
         cap: cv2.VideoCapture,
         pipeline: PipelineExecutor,
-        recording_manager: Optional[RecordingManager] = None,
+        recording_manager: RecordingManager | None = None,
         preview_size: tuple[int, int] = (DEFAULT_PREVIEW_WIDTH, DEFAULT_PREVIEW_HEIGHT),
     ) -> None:
         """

--- a/pochivision/capturelib/camera_setup.py
+++ b/pochivision/capturelib/camera_setup.py
@@ -1,6 +1,6 @@
 """カメラの設定・初期化を行うためのユーティリティモジュール."""
 
-from typing import Any, Dict
+from typing import Any
 
 import cv2
 
@@ -18,7 +18,7 @@ class CameraSetup:
 
     def __init__(
         self,
-        config: Dict[str, Any],
+        config: dict[str, Any],
         log_manager: LogManager,
         camera_index: int,
         profile_name: str,
@@ -27,7 +27,7 @@ class CameraSetup:
         CameraSetupクラスのコンストラクタ.
 
         Args:
-            config (Dict[str, Any]): アプリケーション設定.
+            config (dict[str, Any]): アプリケーション設定.
             log_manager (LogManager): ロギングマネージャー.
             camera_index (Optional[int]): 使用するカメラのインデックス. None の場合は設定ファイルの値を使用.
             profile_name (Optional[str]): 使用するカメラプロファイル名. None の場合はカメラインデックスに対応する設定を使用.

--- a/pochivision/capturelib/config_handler.py
+++ b/pochivision/capturelib/config_handler.py
@@ -7,7 +7,7 @@
 import json
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, Tuple
+from typing import Any
 
 from pydantic import ValidationError
 
@@ -31,7 +31,7 @@ class ConfigHandler:
     _logger = LogManager().get_logger()
 
     @staticmethod
-    def load(path: str) -> Dict[str, Any]:
+    def load(path: str) -> dict[str, Any]:
         """
         設定ファイルを読み込む.
 
@@ -48,7 +48,7 @@ class ConfigHandler:
             logger = LogManager().get_logger()
             logger.debug(f"Loading configuration file: {path}")
             with open(path, "r", encoding="utf-8") as f:
-                config: Dict[str, Any] = json.load(f)
+                config: dict[str, Any] = json.load(f)
             logger.info(f"Configuration file loaded successfully: {path}")
             # バリデーション追加
             try:
@@ -65,7 +65,7 @@ class ConfigHandler:
             raise ConfigLoadError(f"Failed to decode JSON configuration: {e}")
 
     @staticmethod
-    def load_json(path: str) -> Dict[str, Any]:
+    def load_json(path: str) -> dict[str, Any]:
         """
         JSON 設定ファイルをバリデーションなしで読み込む.
 
@@ -80,7 +80,7 @@ class ConfigHandler:
         """
         try:
             with open(path, "r", encoding="utf-8") as f:
-                result: Dict[str, Any] = json.load(f)
+                result: dict[str, Any] = json.load(f)
             return result
         except FileNotFoundError:
             raise ConfigLoadError(f"Configuration file not found: {path}")
@@ -88,7 +88,7 @@ class ConfigHandler:
             raise ConfigLoadError(f"Failed to decode JSON configuration: {e}")
 
     @staticmethod
-    def save(config: Dict[str, Any], output_dir: Path) -> None:
+    def save(config: dict[str, Any], output_dir: Path) -> None:
         """
         設定をファイルに保存する.
 
@@ -118,7 +118,7 @@ class CameraConfigHandler:
     _logger = LogManager().get_logger()
 
     @staticmethod
-    def get_camera_processors(config: Dict[str, Any], profile_name: str) -> Tuple:
+    def get_camera_processors(config: dict[str, Any], profile_name: str) -> tuple:
         """
         指定されたカメラプロファイルのプロセッサ設定を取得する.
 

--- a/pochivision/capturelib/log_manager.py
+++ b/pochivision/capturelib/log_manager.py
@@ -4,7 +4,6 @@ import logging
 import platform
 import sys
 from pathlib import Path
-from typing import Optional
 
 import cv2
 
@@ -40,7 +39,7 @@ class LogManager:
     シングルトンパターンを採用し、複数箇所から同じインスタンスにアクセスできるようにする.
     """
 
-    _instance: Optional["LogManager"] = None
+    _instance: "LogManager | None" = None
 
     def __new__(cls, *args, **kwargs):
         """LogManagerのシングルトンインスタンスを生成・返却する."""
@@ -121,7 +120,7 @@ class LogManager:
         camera_id: int,
         requested_width: int,
         requested_height: int,
-        profile_name: Optional[str] = None,
+        profile_name: str | None = None,
     ) -> None:
         """
         カメラの情報をログに記録する.
@@ -131,7 +130,7 @@ class LogManager:
             camera_id (int): カメラID
             requested_width (int): 要求した幅
             requested_height (int): 要求した高さ
-            profile_name (Optional[str]): 使用しているカメラプロファイル名
+            profile_name (str | None): 使用しているカメラプロファイル名
         """
         profile_info = f", Profile: {profile_name}" if profile_name else ""
         self._logger.info(

--- a/pochivision/capturelib/recording_manager.py
+++ b/pochivision/capturelib/recording_manager.py
@@ -9,7 +9,6 @@ import threading
 import time
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, Optional, Tuple
 
 import cv2
 import numpy as np
@@ -31,7 +30,7 @@ class VideoFormat:
     """
 
     # 形式名: (fourcc, 拡張子, 説明)
-    FORMATS: Dict[str, Tuple[str, str, str]] = {
+    FORMATS: dict[str, tuple[str, str, str]] = {
         "mp4v": ("mp4v", ".mp4", "MP4 - Standard compression"),
         "xvid": ("XVID", ".avi", "XVID - Balanced compression"),
         "mjpg": ("MJPG", ".avi", "Motion JPEG - Low compression, high quality"),
@@ -41,12 +40,12 @@ class VideoFormat:
     }
 
     @classmethod
-    def get_available_formats(cls) -> Dict[str, str]:
+    def get_available_formats(cls) -> dict[str, str]:
         """利用可能な形式の一覧を取得."""
         return {name: info[2] for name, info in cls.FORMATS.items()}
 
     @classmethod
-    def get_format_info(cls, format_name: str) -> Optional[Tuple[str, str, str]]:
+    def get_format_info(cls, format_name: str) -> tuple[str, str, str] | None:
         """指定された形式の情報を取得."""
         return cls.FORMATS.get(format_name.lower())
 
@@ -61,11 +60,11 @@ class RecordingManager:
 
     Attributes:
         is_recording (bool): 録画中かどうかのフラグ
-        video_writer (Optional[cv2.VideoWriter]): 動画書き込みオブジェクト
+        video_writer (cv2.VideoWriter | None): 動画書き込みオブジェクト
         lock (threading.Lock): スレッドセーフ用のロック
         video_format (str): 使用する動画形式
         frame_count (int): 録画中のフレーム数
-        recording_start_time (Optional[float]): 録画開始時間
+        recording_start_time (float | None): 録画開始時間
     """
 
     def __init__(self, default_format: str = "mjpg") -> None:
@@ -76,13 +75,13 @@ class RecordingManager:
             default_format (str): 使用する動画形式
         """
         self.is_recording = False
-        self.video_writer: Optional[cv2.VideoWriter] = None
+        self.video_writer: cv2.VideoWriter | None = None
         self.lock = threading.Lock()
         self.logger = LogManager().get_logger()
 
         # フレーム数カウント用
         self.frame_count = 0
-        self.recording_start_time: Optional[float] = None
+        self.recording_start_time: float | None = None
 
         # 動画形式を設定
         format_info = VideoFormat.get_format_info(default_format)

--- a/pochivision/capturelib/schema.py
+++ b/pochivision/capturelib/schema.py
@@ -5,8 +5,6 @@
 プロセッサパラメータは processors/schema.py を参照.
 """
 
-from typing import Dict, List, Optional
-
 from pydantic import BaseModel, Field, StrictInt, StrictStr
 
 from pochivision.processors.schema import (
@@ -35,25 +33,25 @@ class CameraProfile(BaseModel):
     height: StrictInt
     fps: StrictInt
     backend: StrictStr
-    processors: List[StrictStr]
+    processors: list[StrictStr]
     mode: StrictStr
-    id_interval: Optional[StrictInt] = Field(default=None)
+    id_interval: StrictInt | None = Field(default=None)
 
-    gaussian_blur: Optional[GaussianBlurParams] = None
-    average_blur: Optional[AverageBlurParams] = None
-    median_blur: Optional[MedianBlurParams] = None
-    grayscale: Optional[GrayscaleParams] = None
-    std_bin: Optional[StandardBinarizationParams] = None
-    otsu_bin: Optional[OtsuBinarizationParams] = None
-    gauss_adapt_bin: Optional[GaussianAdaptiveBinarizationParams] = None
-    mean_adapt_bin: Optional[MeanAdaptiveBinarizationParams] = None
-    bilateral_filter: Optional[BilateralFilterParams] = None
-    motion_blur: Optional[MotionBlurParams] = None
-    resize: Optional[ResizeParams] = None
-    equalize: Optional[EqualizeParams] = None
-    clahe: Optional[CLAHEParams] = None
-    canny_edge: Optional[CannyEdgeParams] = None
-    contour: Optional[ContourParams] = None
+    gaussian_blur: GaussianBlurParams | None = None
+    average_blur: AverageBlurParams | None = None
+    median_blur: MedianBlurParams | None = None
+    grayscale: GrayscaleParams | None = None
+    std_bin: StandardBinarizationParams | None = None
+    otsu_bin: OtsuBinarizationParams | None = None
+    gauss_adapt_bin: GaussianAdaptiveBinarizationParams | None = None
+    mean_adapt_bin: MeanAdaptiveBinarizationParams | None = None
+    bilateral_filter: BilateralFilterParams | None = None
+    motion_blur: MotionBlurParams | None = None
+    resize: ResizeParams | None = None
+    equalize: EqualizeParams | None = None
+    clahe: CLAHEParams | None = None
+    canny_edge: CannyEdgeParams | None = None
+    contour: ContourParams | None = None
 
 
 class PreviewConfig(BaseModel):
@@ -66,7 +64,7 @@ class PreviewConfig(BaseModel):
 class ConfigModel(BaseModel):
     """全体設定 (カメラ一覧・選択インデックス) のスキーマ."""
 
-    cameras: Dict[str, CameraProfile]
+    cameras: dict[str, CameraProfile]
     selected_camera_index: StrictInt
-    id_interval: Optional[StrictInt] = Field(default=None)
-    preview: Optional[PreviewConfig] = Field(default=None)
+    id_interval: StrictInt | None = Field(default=None)
+    preview: PreviewConfig | None = Field(default=None)

--- a/pochivision/core/fft_visualization.py
+++ b/pochivision/core/fft_visualization.py
@@ -1,7 +1,6 @@
 """FFT ビジュアライザーのビジネスロジッククラス."""
 
 from pathlib import Path
-from typing import Optional
 
 import cv2
 import numpy as np
@@ -28,9 +27,9 @@ class SimpleFFTVisualizer:
         """
         self.image_path = Path(image_path)
         self.logger = LogManager().get_logger()
-        self.img: Optional[np.ndarray] = None
-        self.fshift: Optional[np.ndarray] = None
-        self.spectrum_display: Optional[np.ndarray] = None
+        self.img: np.ndarray | None = None
+        self.fshift: np.ndarray | None = None
+        self.spectrum_display: np.ndarray | None = None
         self.window_name = "FFT Visualizer - Spectrum (left) and Filtered Image (right)"
         self.filter_mode = "original"
         self.filter_radius = 50

--- a/pochivision/core/pipeline_executor.py
+++ b/pochivision/core/pipeline_executor.py
@@ -2,7 +2,7 @@
 
 import time
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any
 
 import numpy as np
 
@@ -29,7 +29,7 @@ class PipelineExecutor:
 
     def __init__(
         self,
-        processors: List[BaseProcessor],
+        processors: list[BaseProcessor],
         output_dir: Path,
         mode: str = "parallel",
         camera_index: int = 0,
@@ -82,7 +82,7 @@ class PipelineExecutor:
     @classmethod
     def from_config(
         cls,
-        config: Dict[str, Any],
+        config: dict[str, Any],
         output_dir: Path,
         camera_index: int = 0,
         profile_name: str = "0",
@@ -111,7 +111,7 @@ class PipelineExecutor:
             file_naming_manager = get_file_naming_manager()
             file_naming_manager.set_label(camera_index, label)
 
-            processors: List[BaseProcessor] = []
+            processors: list[BaseProcessor] = []
             for name in processor_names:
                 if name not in PROCESSOR_REGISTRY:
                     raise ValueError(f"Processor '{name}' is not registered")

--- a/pochivision/core/profile_processing.py
+++ b/pochivision/core/profile_processing.py
@@ -4,7 +4,7 @@ import json
 import shutil
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 import cv2
 import numpy as np
@@ -51,7 +51,7 @@ class ProfileProcessor:
         self.profile_config = self._get_profile_config(profile_name)
         self.processors = self._initialize_processors()
 
-    def _get_profile_config(self, profile_name: str) -> Dict[str, Any]:
+    def _get_profile_config(self, profile_name: str) -> dict[str, Any]:
         """指定されたプロファイルの設定を取得する.
 
         Args:
@@ -71,10 +71,10 @@ class ProfileProcessor:
                 f"利用可能なプロファイル: {available_profiles}"
             )
 
-        result: Dict[str, Any] = cameras[profile_name]
+        result: dict[str, Any] = cameras[profile_name]
         return result
 
-    def _initialize_processors(self) -> List[Any]:
+    def _initialize_processors(self) -> list[Any]:
         """プロファイル設定に基づいてプロセッサを初期化する.
 
         Returns:
@@ -99,7 +99,7 @@ class ProfileProcessor:
 
         return processors
 
-    def _get_image_files(self, input_dir: Path) -> List[Path]:
+    def _get_image_files(self, input_dir: Path) -> list[Path]:
         """入力ディレクトリから画像ファイルを取得する.
 
         Args:
@@ -132,7 +132,7 @@ class ProfileProcessor:
         """
         return self.output_manager.create_output_dir("processed")
 
-    def _process_image(self, image_path: Path) -> Optional[np.ndarray]:
+    def _process_image(self, image_path: Path) -> np.ndarray | None:
         """単一画像を処理する.
 
         Args:

--- a/pochivision/feature_extractors/base.py
+++ b/pochivision/feature_extractors/base.py
@@ -1,7 +1,7 @@
 """画像特徴量抽出の基底クラスを定義するモジュール."""
 
 import abc
-from typing import Any, Dict, Union
+from typing import Any
 
 import numpy as np
 
@@ -15,7 +15,7 @@ class BaseFeatureExtractor(abc.ABC):
         config (dict): 特徴量抽出器固有の設定.
     """
 
-    def __init__(self, name: str, config: Dict[str, Any]) -> None:
+    def __init__(self, name: str, config: dict[str, Any]) -> None:
         """
         BaseFeatureExtractorのコンストラクタ.
 
@@ -31,7 +31,7 @@ class BaseFeatureExtractor(abc.ABC):
         self.config = {**default_config, **user_config}
 
     @abc.abstractmethod
-    def extract(self, image: np.ndarray) -> Dict[str, Union[float, int]]:
+    def extract(self, image: np.ndarray) -> dict[str, float | int]:
         """
         画像から特徴量を抽出する.各特徴量抽出器でオーバーライドして実装する.
 
@@ -39,19 +39,19 @@ class BaseFeatureExtractor(abc.ABC):
             image (np.ndarray): 入力画像.
 
         Returns:
-            Dict[str, Union[float, int]]: 抽出された特徴量の辞書.
+            dict[str, float | int]: 抽出された特徴量の辞書.
                 キーは特徴量名、値は特徴量の値.
         """
         pass
 
     @staticmethod
     @abc.abstractmethod
-    def get_default_config() -> Dict[str, Any]:
+    def get_default_config() -> dict[str, Any]:
         """
         特徴量抽出器のデフォルト設定を返す.
 
         Returns:
-            Dict[str, Any]: デフォルト設定.
+            dict[str, Any]: デフォルト設定.
         """
         pass
 

--- a/pochivision/feature_extractors/brightness_statistics.py
+++ b/pochivision/feature_extractors/brightness_statistics.py
@@ -1,6 +1,6 @@
 """輝度統計特徴量抽出を行うモジュール."""
 
-from typing import Any, Dict, Optional, Union
+from typing import Any
 
 import cv2
 import numpy as np
@@ -45,7 +45,7 @@ class BrightnessStatisticsExtractor(BaseFeatureExtractor):
     def __init__(
         self,
         name: str = "brightness_statistics",
-        config: Optional[Dict[str, Any]] = None,
+        config: dict[str, Any] | None = None,
     ) -> None:
         """
         BrightnessStatisticsExtractorのコンストラクタ.
@@ -60,7 +60,7 @@ class BrightnessStatisticsExtractor(BaseFeatureExtractor):
         self.color_mode = self.config["color_mode"]
         self.exclude_zero_pixels = self.config["exclude_zero_pixels"]
 
-    def extract(self, image: np.ndarray) -> Dict[str, Union[float, int]]:
+    def extract(self, image: np.ndarray) -> dict[str, float | int]:
         """
         画像から輝度統計特徴量を抽出する.
 
@@ -68,7 +68,7 @@ class BrightnessStatisticsExtractor(BaseFeatureExtractor):
             image (np.ndarray): 入力画像.
 
         Returns:
-            Dict[str, Union[float, int]]: 抽出された特徴量の辞書.
+            dict[str, float | int]: 抽出された特徴量の辞書.
                 - mean: 輝度平均値
                 - median: 輝度中央値
                 - variance: 輝度分散
@@ -158,12 +158,12 @@ class BrightnessStatisticsExtractor(BaseFeatureExtractor):
             raise ExtractorValidationError(f"Unsupported image shape: {image.shape}")
 
     @staticmethod
-    def get_default_config() -> Dict[str, Any]:
+    def get_default_config() -> dict[str, Any]:
         """
         BrightnessStatisticsExtractorのデフォルト設定を返す.
 
         Returns:
-            Dict[str, Any]: デフォルト設定.
+            dict[str, Any]: デフォルト設定.
                 - color_mode: 輝度計算モード ("gray", "lab_l", "hsv_v")
                 - exclude_zero_pixels: 輝度値が0のピクセルを除外するかどうか
         """
@@ -197,11 +197,11 @@ class BrightnessStatisticsExtractor(BaseFeatureExtractor):
         return ["mean", "median", "variance", "std_dev", "cv"]
 
     @staticmethod
-    def get_feature_units() -> Dict[str, str]:
+    def get_feature_units() -> dict[str, str]:
         """
         特徴量の単位辞書を返す.
 
         Returns:
-            Dict[str, str]: 特徴量名と単位の対応辞書.
+            dict[str, str]: 特徴量名と単位の対応辞書.
         """
         return BrightnessStatisticsExtractor._FEATURE_UNITS.copy()

--- a/pochivision/feature_extractors/circle_counter.py
+++ b/pochivision/feature_extractors/circle_counter.py
@@ -1,6 +1,6 @@
 """画像内の丸をカウントする特徴量抽出を行うモジュール."""
 
-from typing import Any, Dict, Optional, Union
+from typing import Any
 
 import cv2
 import numpy as np
@@ -56,7 +56,7 @@ class CircleCounterExtractor(BaseFeatureExtractor):
     def __init__(
         self,
         name: str = "circle_counter",
-        config: Optional[Dict[str, Any]] = None,
+        config: dict[str, Any] | None = None,
     ) -> None:
         """
         CircleCounterExtractorのコンストラクタ.
@@ -81,7 +81,7 @@ class CircleCounterExtractor(BaseFeatureExtractor):
             )
         self.enable_circularity_filter = self.config["enable_circularity_filter"]
 
-    def extract(self, image: np.ndarray) -> Dict[str, Union[float, int]]:
+    def extract(self, image: np.ndarray) -> dict[str, float | int]:
         """
         画像から円形オブジェクトをカウントして特徴量を抽出する.
 
@@ -89,7 +89,7 @@ class CircleCounterExtractor(BaseFeatureExtractor):
             image (np.ndarray): 入力画像（BGR形式）.
 
         Returns:
-            Dict[str, Union[float, int]]: 抽出された特徴量の辞書.
+            dict[str, float | int]: 抽出された特徴量の辞書.
 
         Raises:
             ValueError: 画像が空の場合や無効な形状の場合.
@@ -212,7 +212,7 @@ class CircleCounterExtractor(BaseFeatureExtractor):
 
     def _calculate_features(
         self, circles: np.ndarray, image_area: int, max_radius: int
-    ) -> Dict[str, Union[float, int]]:
+    ) -> dict[str, float | int]:
         """
         検出された円から特徴量を計算する.
 
@@ -222,9 +222,9 @@ class CircleCounterExtractor(BaseFeatureExtractor):
             max_radius (int): 使用された最大半径.
 
         Returns:
-            Dict[str, Union[float, int]]: 計算された特徴量.
+            dict[str, float | int]: 計算された特徴量.
         """
-        results: Dict[str, Union[float, int]] = {}
+        results: dict[str, float | int] = {}
 
         # 基本カウント
         total_count = len(circles)
@@ -266,12 +266,12 @@ class CircleCounterExtractor(BaseFeatureExtractor):
         return results
 
     @staticmethod
-    def get_default_config() -> Dict[str, Any]:
+    def get_default_config() -> dict[str, Any]:
         """
         CircleCounterExtractorのデフォルト設定を返す.
 
         Returns:
-            Dict[str, Any]: デフォルト設定.
+            dict[str, Any]: デフォルト設定.
         """
         return {
             "min_radius": 5,  # 最小半径（ピクセル）
@@ -317,12 +317,12 @@ class CircleCounterExtractor(BaseFeatureExtractor):
         ]
 
     @staticmethod
-    def get_feature_units() -> Dict[str, str]:
+    def get_feature_units() -> dict[str, str]:
         """
         特徴量の単位辞書を返す.
 
         Returns:
-            Dict[str, str]: 特徴量名と単位の対応辞書.
+            dict[str, str]: 特徴量名と単位の対応辞書.
         """
         base_names = CircleCounterExtractor.get_base_feature_names()
         return {

--- a/pochivision/feature_extractors/fft_frequency.py
+++ b/pochivision/feature_extractors/fft_frequency.py
@@ -1,6 +1,6 @@
 """FFT（高速フーリエ変換）周波数領域特徴量抽出を行うモジュール."""
 
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any
 
 import cv2
 import numpy as np
@@ -75,7 +75,7 @@ class FFTFrequencyExtractor(BaseFeatureExtractor):
     def __init__(
         self,
         name: str = "fft_frequency",
-        config: Optional[Dict[str, Any]] = None,
+        config: dict[str, Any] | None = None,
     ) -> None:
         """
         FFTFrequencyExtractorのコンストラクタ.
@@ -118,7 +118,7 @@ class FFTFrequencyExtractor(BaseFeatureExtractor):
 
     def _compute_fft_data(
         self, image: np.ndarray
-    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
         """
         FFT を1回計算し, 各ヘルパーで共有するデータを返す.
 
@@ -161,18 +161,18 @@ class FFTFrequencyExtractor(BaseFeatureExtractor):
         self,
         power_spectrum: np.ndarray,
         freq_norm: np.ndarray,
-        bands: List[Tuple[float, float]],
-    ) -> Dict[str, float]:
+        bands: list[tuple[float, float]],
+    ) -> dict[str, float]:
         """
         周波数帯域ごとのエネルギーを計算する.
 
         Args:
             power_spectrum (np.ndarray): パワースペクトル
             freq_norm (np.ndarray): 正規化周波数マップ
-            bands (List[Tuple[float, float]]): 周波数帯域のリスト
+            bands (list[tuple[float, float]]): 周波数帯域のリスト
 
         Returns:
-            Dict[str, float]: 帯域別エネルギーの辞書
+            dict[str, float]: 帯域別エネルギーの辞書
         """
         total_energy = np.sum(power_spectrum)
         energies = {}
@@ -282,7 +282,7 @@ class FFTFrequencyExtractor(BaseFeatureExtractor):
 
     def _compute_spectral_peaks(
         self, magnitude: np.ndarray, threshold_ratio: float
-    ) -> Tuple[int, float]:
+    ) -> tuple[int, float]:
         """
         スペクトルピーク数と最大値を計算する.
 
@@ -291,7 +291,7 @@ class FFTFrequencyExtractor(BaseFeatureExtractor):
             threshold_ratio (float): ピーク検出の閾値比
 
         Returns:
-            Tuple[int, float]: (ピーク数, 最大ピーク振幅)
+            tuple[int, float]: (ピーク数, 最大ピーク振幅)
         """
         max_local = maximum_filter(magnitude, size=3)
         peaks = (magnitude == max_local) & (
@@ -360,18 +360,18 @@ class FFTFrequencyExtractor(BaseFeatureExtractor):
         self,
         magnitude: np.ndarray,
         freq_norm: np.ndarray,
-        bands: List[Tuple[float, float]],
-    ) -> Dict[str, float]:
+        bands: list[tuple[float, float]],
+    ) -> dict[str, float]:
         """
         周波数帯域ごとのエントロピーを計算する.
 
         Args:
             magnitude (np.ndarray): 振幅スペクトル
             freq_norm (np.ndarray): 正規化周波数マップ
-            bands (List[Tuple[float, float]]): 周波数帯域のリスト
+            bands (list[tuple[float, float]]): 周波数帯域のリスト
 
         Returns:
-            Dict[str, float]: 帯域別エントロピーの辞書
+            dict[str, float]: 帯域別エントロピーの辞書
         """
         entropies = {}
 
@@ -393,7 +393,7 @@ class FFTFrequencyExtractor(BaseFeatureExtractor):
 
         return entropies
 
-    def extract(self, image: np.ndarray) -> Dict[str, Union[float, int]]:
+    def extract(self, image: np.ndarray) -> dict[str, float | int]:
         """
         画像からFFT周波数領域特徴量を抽出する.
 
@@ -401,7 +401,7 @@ class FFTFrequencyExtractor(BaseFeatureExtractor):
             image (np.ndarray): 入力画像（BGR形式）.
 
         Returns:
-            Dict[str, Union[float, int]]: 抽出された特徴量の辞書.
+            dict[str, float | int]: 抽出された特徴量の辞書.
 
         Raises:
             ValueError: 画像が空の場合や無効な形状の場合.
@@ -509,12 +509,12 @@ class FFTFrequencyExtractor(BaseFeatureExtractor):
         return results
 
     @staticmethod
-    def get_default_config() -> Dict[str, Any]:
+    def get_default_config() -> dict[str, Any]:
         """
         FFTFrequencyExtractorのデフォルト設定を返す.
 
         Returns:
-            Dict[str, Any]: デフォルト設定.
+            dict[str, Any]: デフォルト設定.
                 - frequency_bands: 周波数帯域のリスト
                 - high_low_threshold: 高周波/低周波の境界閾値
                 - directional_tolerance: 方向性エネルギー計算の許容角度
@@ -537,12 +537,12 @@ class FFTFrequencyExtractor(BaseFeatureExtractor):
         }
 
     @staticmethod
-    def get_feature_names() -> List[str]:
+    def get_feature_names() -> list[str]:
         """
         この特徴量抽出器が出力する特徴量名のリストを返す（単位付き）.
 
         Returns:
-            List[str]: 特徴量名のリスト（単位付き）.
+            list[str]: 特徴量名のリスト（単位付き）.
         """
         base_names = FFTFrequencyExtractor.get_base_feature_names()
         return [
@@ -551,12 +551,12 @@ class FFTFrequencyExtractor(BaseFeatureExtractor):
         ]
 
     @staticmethod
-    def get_base_feature_names() -> List[str]:
+    def get_base_feature_names() -> list[str]:
         """
         この特徴量抽出器が出力する基本特徴量名のリストを返す（単位なし）.
 
         Returns:
-            List[str]: 基本特徴量名のリスト.
+            list[str]: 基本特徴量名のリスト.
         """
         return [
             "high_low_ratio",
@@ -578,12 +578,12 @@ class FFTFrequencyExtractor(BaseFeatureExtractor):
         ]
 
     @staticmethod
-    def get_feature_units() -> Dict[str, str]:
+    def get_feature_units() -> dict[str, str]:
         """
         特徴量の単位辞書を返す.
 
         Returns:
-            Dict[str, str]: 特徴量名と単位の対応辞書.
+            dict[str, str]: 特徴量名と単位の対応辞書.
         """
         return FFTFrequencyExtractor._FEATURE_UNITS.copy()
 

--- a/pochivision/feature_extractors/glcm_texture.py
+++ b/pochivision/feature_extractors/glcm_texture.py
@@ -1,6 +1,6 @@
 """GLCM（Gray-Level Co-occurrence Matrix）テクスチャ特徴量抽出を行うモジュール."""
 
-from typing import Any, Dict, List, Optional, Union
+from typing import Any
 
 import cv2
 import numpy as np
@@ -53,7 +53,7 @@ class GLCMTextureExtractor(BaseFeatureExtractor):
     def __init__(
         self,
         name: str = "glcm_texture",
-        config: Optional[Dict[str, Any]] = None,
+        config: dict[str, Any] | None = None,
     ) -> None:
         """
         GLCMTextureExtractorのコンストラクタ.
@@ -91,7 +91,7 @@ class GLCMTextureExtractor(BaseFeatureExtractor):
                 name="resize_for_glcm", config=resize_config
             )
 
-    def _parse_angles(self, angles_config: List[Union[int, float]]) -> List[float]:
+    def _parse_angles(self, angles_config: list[int | float]) -> list[float]:
         """
         角度設定を解析してラジアン値のリストに変換する.
 
@@ -99,7 +99,7 @@ class GLCMTextureExtractor(BaseFeatureExtractor):
             angles_config: 角度設定（度数のリスト）
 
         Returns:
-            List[float]: ラジアン値のリスト
+            list[float]: ラジアン値のリスト
 
         Raises:
             ValueError: 無効な角度設定の場合
@@ -118,7 +118,7 @@ class GLCMTextureExtractor(BaseFeatureExtractor):
         # 度数をラジアンに変換
         return [np.radians(float(angle)) for angle in angles_config]
 
-    def extract(self, image: np.ndarray) -> Dict[str, Union[float, int]]:
+    def extract(self, image: np.ndarray) -> dict[str, float | int]:
         """
         画像からGLCMテクスチャ特徴量を抽出する.
 
@@ -126,7 +126,7 @@ class GLCMTextureExtractor(BaseFeatureExtractor):
             image (np.ndarray): 入力画像（BGR形式）.
 
         Returns:
-            Dict[str, Union[float, int]]: 抽出された特徴量の辞書.
+            dict[str, float | int]: 抽出された特徴量の辞書.
                 各プロパティ、距離、角度の組み合わせについて:
                 - {property}_{distance}_{angle_deg}: 特徴量値
 
@@ -226,12 +226,12 @@ class GLCMTextureExtractor(BaseFeatureExtractor):
         return results
 
     @staticmethod
-    def get_default_config() -> Dict[str, Any]:
+    def get_default_config() -> dict[str, Any]:
         """
         GLCMTextureExtractorのデフォルト設定を返す.
 
         Returns:
-            Dict[str, Any]: デフォルト設定.
+            dict[str, Any]: デフォルト設定.
                 - distances: ピクセル間距離のリスト
                 - angles: 角度のリスト（度数）
                 - levels: グレーレベル数
@@ -259,12 +259,12 @@ class GLCMTextureExtractor(BaseFeatureExtractor):
         }
 
     @staticmethod
-    def get_feature_names() -> List[str]:
+    def get_feature_names() -> list[str]:
         """
         この特徴量抽出器が出力する特徴量名のリストを返す（単位付き）.
 
         Returns:
-            List[str]: 特徴量名のリスト（単位付き）.
+            list[str]: 特徴量名のリスト（単位付き）.
         """
         base_names = GLCMTextureExtractor.get_base_feature_names()
         return [
@@ -273,12 +273,12 @@ class GLCMTextureExtractor(BaseFeatureExtractor):
         ]
 
     @staticmethod
-    def get_base_feature_names() -> List[str]:
+    def get_base_feature_names() -> list[str]:
         """
         この特徴量抽出器が出力する基本特徴量名のリストを返す（単位なし）.
 
         Returns:
-            List[str]: 基本特徴量名のリスト.
+            list[str]: 基本特徴量名のリスト.
         """
         # デフォルト設定を使用して特徴量名を生成
         default_config = GLCMTextureExtractor.get_default_config()
@@ -297,12 +297,12 @@ class GLCMTextureExtractor(BaseFeatureExtractor):
         return feature_names
 
     @staticmethod
-    def get_feature_units() -> Dict[str, str]:
+    def get_feature_units() -> dict[str, str]:
         """
         特徴量の単位辞書を返す.
 
         Returns:
-            Dict[str, str]: 特徴量名と単位の対応辞書.
+            dict[str, str]: 特徴量名と単位の対応辞書.
         """
         # 基本特徴量名を取得
         base_names = GLCMTextureExtractor.get_base_feature_names()

--- a/pochivision/feature_extractors/hlac_texture.py
+++ b/pochivision/feature_extractors/hlac_texture.py
@@ -1,6 +1,6 @@
 """HLAC（Higher-order Local Auto-Correlation）テクスチャ特徴量抽出を行うモジュール."""
 
-from typing import Any, Dict, List, Optional, Union
+from typing import Any
 
 import cv2
 import numpy as np
@@ -53,7 +53,7 @@ class HLACTextureExtractor(BaseFeatureExtractor):
     def __init__(
         self,
         name: str = "hlac_texture",
-        config: Optional[Dict[str, Any]] = None,
+        config: dict[str, Any] | None = None,
     ) -> None:
         """
         HLACTextureExtractorのコンストラクタ.
@@ -105,12 +105,12 @@ class HLACTextureExtractor(BaseFeatureExtractor):
             self.binarizer = OtsuBinarizationProcessor(name="otsu_for_hlac", config={})
 
         # スケールリサイザーのキャッシュ (初回呼び出し時に生成)
-        self._scale_resizers: Dict[tuple, ResizeProcessor] = {}
+        self._scale_resizers: dict[tuple, ResizeProcessor] = {}
 
         # HLACカーネルの事前生成
         self.kernels = self._generate_hlac_kernels()
 
-    def extract(self, image: np.ndarray) -> Dict[str, Union[float, int]]:
+    def extract(self, image: np.ndarray) -> dict[str, float | int]:
         """
         画像からHLACテクスチャ特徴量を抽出する.
 
@@ -118,7 +118,7 @@ class HLACTextureExtractor(BaseFeatureExtractor):
             image (np.ndarray): 入力画像（BGR形式）.
 
         Returns:
-            Dict[str, Union[float, int]]: 抽出された特徴量の辞書.
+            dict[str, float | int]: 抽出された特徴量の辞書.
                 - hlac_feature_{i}: 各HLAC特徴量（i=0,1,2,...）
 
         Raises:
@@ -169,12 +169,12 @@ class HLACTextureExtractor(BaseFeatureExtractor):
             LogManager().get_logger().exception("HLAC feature extraction failed")
             raise
 
-    def _generate_hlac_kernels(self) -> List[np.ndarray]:
+    def _generate_hlac_kernels(self) -> list[np.ndarray]:
         """
         HLACのパターンカーネルを生成する.
 
         Returns:
-            List[np.ndarray]: HLACカーネルのリスト.
+            list[np.ndarray]: HLACカーネルのリスト.
         """
         patterns = []
 
@@ -204,7 +204,7 @@ class HLACTextureExtractor(BaseFeatureExtractor):
 
         # 回転不変性の処理
         if self.rotate_invariant:
-            unique_patterns: List[np.ndarray] = []
+            unique_patterns: list[np.ndarray] = []
             for pattern in patterns:
                 # 4方向の回転を生成
                 rotations = [np.rot90(pattern, k) for k in range(4)]
@@ -280,12 +280,12 @@ class HLACTextureExtractor(BaseFeatureExtractor):
 
         return total_features
 
-    def _get_default_results(self) -> Dict[str, float]:
+    def _get_default_results(self) -> dict[str, float]:
         """
         エラー時のデフォルト結果を返す.
 
         Returns:
-            Dict[str, float]: デフォルト特徴量の辞書.
+            dict[str, float]: デフォルト特徴量の辞書.
         """
         num_features = (
             len(self.kernels)
@@ -295,12 +295,12 @@ class HLACTextureExtractor(BaseFeatureExtractor):
         return {f"hlac_feature_{i:02d}": 0.0 for i in range(num_features)}
 
     @staticmethod
-    def get_default_config() -> Dict[str, Any]:
+    def get_default_config() -> dict[str, Any]:
         """
         HLACTextureExtractorのデフォルト設定を返す.
 
         Returns:
-            Dict[str, Any]: デフォルト設定.
+            dict[str, Any]: デフォルト設定.
                 - order: 自己相関の次数（1または2）
                 - rotate_invariant: 回転不変性の有効/無効
                 - normalize: 特徴量の正規化の有効/無効
@@ -321,12 +321,12 @@ class HLACTextureExtractor(BaseFeatureExtractor):
         }
 
     @staticmethod
-    def get_feature_names() -> List[str]:
+    def get_feature_names() -> list[str]:
         """
         この特徴量抽出器が出力する特徴量名のリストを返す（単位付き）.
 
         Returns:
-            List[str]: 特徴量名のリスト（単位付き）.
+            list[str]: 特徴量名のリスト（単位付き）.
         """
         base_names = HLACTextureExtractor.get_base_feature_names()
         return [
@@ -335,12 +335,12 @@ class HLACTextureExtractor(BaseFeatureExtractor):
         ]
 
     @staticmethod
-    def get_base_feature_names() -> List[str]:
+    def get_base_feature_names() -> list[str]:
         """
         この特徴量抽出器が出力する基本特徴量名のリストを返す（単位なし）.
 
         Returns:
-            List[str]: 基本特徴量名のリスト.
+            list[str]: 基本特徴量名のリスト.
         """
         # デフォルト設定での特徴量名を返す
         default_config = HLACTextureExtractor.get_default_config()
@@ -357,12 +357,12 @@ class HLACTextureExtractor(BaseFeatureExtractor):
         return [f"hlac_feature_{i:02d}" for i in range(num_features)]
 
     @staticmethod
-    def get_feature_units() -> Dict[str, str]:
+    def get_feature_units() -> dict[str, str]:
         """
         特徴量の単位辞書を返す.
 
         Returns:
-            Dict[str, str]: 特徴量名と単位の対応辞書.
+            dict[str, str]: 特徴量名と単位の対応辞書.
         """
         # 基本特徴量名を取得
         base_names = HLACTextureExtractor.get_base_feature_names()

--- a/pochivision/feature_extractors/hsv_statistics.py
+++ b/pochivision/feature_extractors/hsv_statistics.py
@@ -1,6 +1,6 @@
 """HSV統計特徴量抽出を行うモジュール."""
 
-from typing import Any, Dict, List, Optional, Union
+from typing import Any
 
 import cv2
 import numpy as np
@@ -61,7 +61,7 @@ class HSVStatisticsExtractor(BaseFeatureExtractor):
     def __init__(
         self,
         name: str = "hsv_statistics",
-        config: Optional[Dict[str, Any]] = None,
+        config: dict[str, Any] | None = None,
     ) -> None:
         """
         HSVStatisticsExtractorのコンストラクタ.
@@ -75,7 +75,7 @@ class HSVStatisticsExtractor(BaseFeatureExtractor):
         # 設定パラメータの取得（デフォルト設定が既にマージされているため直接アクセス）
         self.exclude_black_pixels = self.config["exclude_black_pixels"]
 
-    def extract(self, image: np.ndarray) -> Dict[str, Union[float, int]]:
+    def extract(self, image: np.ndarray) -> dict[str, float | int]:
         """
         画像からHSV統計特徴量を抽出する.
 
@@ -83,7 +83,7 @@ class HSVStatisticsExtractor(BaseFeatureExtractor):
             image (np.ndarray): 入力画像（BGR形式）.
 
         Returns:
-            Dict[str, Union[float, int]]: 抽出された特徴量の辞書.
+            dict[str, float | int]: 抽出された特徴量の辞書.
                 H、S、Vチャンネルそれぞれについて:
                 - {channel}_mean: 平均値
                 - {channel}_median: 中央値
@@ -192,23 +192,23 @@ class HSVStatisticsExtractor(BaseFeatureExtractor):
         return mean_val, median_val, variance_val, std_dev_val, cv_val
 
     @staticmethod
-    def get_default_config() -> Dict[str, Any]:
+    def get_default_config() -> dict[str, Any]:
         """
         HSVStatisticsExtractorのデフォルト設定を返す.
 
         Returns:
-            Dict[str, Any]: デフォルト設定.
+            dict[str, Any]: デフォルト設定.
                 - exclude_black_pixels: RGB値がすべて0のピクセルを除外するかどうか
         """
         return {"exclude_black_pixels": True}
 
     @staticmethod
-    def get_feature_names() -> List[str]:
+    def get_feature_names() -> list[str]:
         """
         この特徴量抽出器が出力する特徴量名のリストを返す（単位付き）.
 
         Returns:
-            List[str]: 特徴量名のリスト（単位付き）.
+            list[str]: 特徴量名のリスト（単位付き）.
         """
         base_names = HSVStatisticsExtractor.get_base_feature_names()
         return [
@@ -217,12 +217,12 @@ class HSVStatisticsExtractor(BaseFeatureExtractor):
         ]
 
     @staticmethod
-    def get_base_feature_names() -> List[str]:
+    def get_base_feature_names() -> list[str]:
         """
         この特徴量抽出器が出力する基本特徴量名のリストを返す（単位なし）.
 
         Returns:
-            List[str]: 基本特徴量名のリスト.
+            list[str]: 基本特徴量名のリスト.
         """
         feature_names = []
         channels = ["hue", "saturation", "value"]
@@ -235,12 +235,12 @@ class HSVStatisticsExtractor(BaseFeatureExtractor):
         return feature_names
 
     @staticmethod
-    def get_feature_units() -> Dict[str, str]:
+    def get_feature_units() -> dict[str, str]:
         """
         特徴量の単位辞書を返す.
 
         Returns:
-            Dict[str, str]: 特徴量名と単位の対応辞書.
+            dict[str, str]: 特徴量名と単位の対応辞書.
         """
         # 基本特徴量名を取得
         base_names = HSVStatisticsExtractor.get_base_feature_names()

--- a/pochivision/feature_extractors/lbp_texture.py
+++ b/pochivision/feature_extractors/lbp_texture.py
@@ -1,6 +1,6 @@
 """LBP（Local Binary Pattern）テクスチャ特徴量抽出を行うモジュール."""
 
-from typing import Any, Dict, List, Optional, Union
+from typing import Any
 
 import cv2
 import numpy as np
@@ -48,7 +48,7 @@ class LBPTextureExtractor(BaseFeatureExtractor):
     def __init__(
         self,
         name: str = "lbp_texture",
-        config: Optional[Dict[str, Any]] = None,
+        config: dict[str, Any] | None = None,
     ) -> None:
         """
         LBPTextureExtractorのコンストラクタ.
@@ -86,7 +86,7 @@ class LBPTextureExtractor(BaseFeatureExtractor):
                 name="resize_for_lbp", config=resize_config
             )
 
-    def extract(self, image: np.ndarray) -> Dict[str, Union[float, int]]:
+    def extract(self, image: np.ndarray) -> dict[str, float | int]:
         """
         画像からLBPテクスチャ特徴量を抽出する.
 
@@ -94,7 +94,7 @@ class LBPTextureExtractor(BaseFeatureExtractor):
             image (np.ndarray): 入力画像（BGR形式）.
 
         Returns:
-            Dict[str, Union[float, int]]: 抽出された特徴量の辞書.
+            dict[str, float | int]: 抽出された特徴量の辞書.
                 - lbp_mean: LBPヒストグラムの平均
                 - lbp_std: LBPヒストグラムの標準偏差
                 - lbp_skewness: LBPヒストグラムの歪度
@@ -179,7 +179,7 @@ class LBPTextureExtractor(BaseFeatureExtractor):
 
     def _calculate_statistics(
         self, hist: np.ndarray, lbp: np.ndarray
-    ) -> Dict[str, float]:
+    ) -> dict[str, float]:
         """
         LBP 画像とヒストグラムから統計量を計算する.
 
@@ -191,7 +191,7 @@ class LBPTextureExtractor(BaseFeatureExtractor):
             lbp (np.ndarray): LBP画像
 
         Returns:
-            Dict[str, float]: 統計量の辞書
+            dict[str, float]: 統計量の辞書
         """
         results = {}
 
@@ -237,12 +237,12 @@ class LBPTextureExtractor(BaseFeatureExtractor):
 
         return results
 
-    def _get_default_results(self) -> Dict[str, float]:
+    def _get_default_results(self) -> dict[str, float]:
         """
         エラー時のデフォルト結果を返す.
 
         Returns:
-            Dict[str, float]: デフォルト値の辞書
+            dict[str, float]: デフォルト値の辞書
         """
         results = {
             "lbp_mean": 0.0,
@@ -267,12 +267,12 @@ class LBPTextureExtractor(BaseFeatureExtractor):
         return results
 
     @staticmethod
-    def get_default_config() -> Dict[str, Any]:
+    def get_default_config() -> dict[str, Any]:
         """
         LBPTextureExtractorのデフォルト設定を返す.
 
         Returns:
-            Dict[str, Any]: デフォルト設定.
+            dict[str, Any]: デフォルト設定.
                 - P: 近傍点数
                 - R: 半径
                 - method: LBP手法
@@ -290,12 +290,12 @@ class LBPTextureExtractor(BaseFeatureExtractor):
         }
 
     @staticmethod
-    def get_feature_names() -> List[str]:
+    def get_feature_names() -> list[str]:
         """
         この特徴量抽出器が出力する特徴量名のリストを返す（単位付き）.
 
         Returns:
-            List[str]: 特徴量名のリスト（単位付き）.
+            list[str]: 特徴量名のリスト（単位付き）.
         """
         base_names = LBPTextureExtractor.get_base_feature_names()
         return [
@@ -304,12 +304,12 @@ class LBPTextureExtractor(BaseFeatureExtractor):
         ]
 
     @staticmethod
-    def get_base_feature_names() -> List[str]:
+    def get_base_feature_names() -> list[str]:
         """
         この特徴量抽出器が出力する基本特徴量名のリストを返す（単位なし）.
 
         Returns:
-            List[str]: 基本特徴量名のリスト.
+            list[str]: 基本特徴量名のリスト.
         """
         # 基本統計量
         feature_names = [
@@ -342,12 +342,12 @@ class LBPTextureExtractor(BaseFeatureExtractor):
         return feature_names
 
     @staticmethod
-    def get_feature_units() -> Dict[str, str]:
+    def get_feature_units() -> dict[str, str]:
         """
         特徴量の単位辞書を返す.
 
         Returns:
-            Dict[str, str]: 特徴量名と単位の対応辞書.
+            dict[str, str]: 特徴量名と単位の対応辞書.
         """
         # 基本特徴量名を取得
         base_names = LBPTextureExtractor.get_base_feature_names()
@@ -378,12 +378,12 @@ class LBPTextureExtractor(BaseFeatureExtractor):
         return LBPTextureExtractor._FEATURE_UNITS.get(feature_name, "unknown")
 
     # インスタンスメソッド版（後方互換性のため残す）
-    def get_feature_names_instance(self) -> List[str]:
+    def get_feature_names_instance(self) -> list[str]:
         """
         この特徴量抽出器が出力する特徴量名のリストを返す（単位付き、インスタンス設定反映）.
 
         Returns:
-            List[str]: 特徴量名のリスト（単位付き）.
+            list[str]: 特徴量名のリスト（単位付き）.
         """
         # 基本統計量（単位付き）
         feature_names = []
@@ -420,12 +420,12 @@ class LBPTextureExtractor(BaseFeatureExtractor):
 
         return feature_names
 
-    def get_base_feature_names_instance(self) -> List[str]:
+    def get_base_feature_names_instance(self) -> list[str]:
         """
         この特徴量抽出器が出力する基本特徴量名のリストを返す（単位なし、インスタンス設定反映）.
 
         Returns:
-            List[str]: 基本特徴量名のリスト.
+            list[str]: 基本特徴量名のリスト.
         """
         # 基本統計量
         feature_names = [
@@ -456,12 +456,12 @@ class LBPTextureExtractor(BaseFeatureExtractor):
 
         return feature_names
 
-    def get_feature_units_instance(self) -> Dict[str, str]:
+    def get_feature_units_instance(self) -> dict[str, str]:
         """
         この特徴量抽出器が出力する特徴量の単位を返す（インスタンス設定反映）.
 
         Returns:
-            Dict[str, str]: 特徴量名と単位の辞書.
+            dict[str, str]: 特徴量名と単位の辞書.
         """
         units = self._FEATURE_UNITS.copy()
 

--- a/pochivision/feature_extractors/registry.py
+++ b/pochivision/feature_extractors/registry.py
@@ -10,7 +10,7 @@
         ...
 """
 
-from typing import Any, Callable, Dict, Optional, Type
+from typing import Any, Callable
 
 from pochivision.capturelib.log_manager import LogManager
 
@@ -20,12 +20,12 @@ from .schema import EXTRACTOR_SCHEMA_MAP
 logger = LogManager().get_logger()
 
 # 名前とクラスのマッピングを保持する辞書
-FEATURE_EXTRACTOR_REGISTRY: Dict[str, Type[BaseFeatureExtractor]] = {}
+FEATURE_EXTRACTOR_REGISTRY: dict[str, type[BaseFeatureExtractor]] = {}
 
 
 def register_feature_extractor(
     name: str,
-) -> Callable[[Type[BaseFeatureExtractor]], Type[BaseFeatureExtractor]]:
+) -> Callable[[type[BaseFeatureExtractor]], type[BaseFeatureExtractor]]:
     """
     特徴量抽出器クラスを名前付きで登録するためのデコレータ.
 
@@ -36,7 +36,7 @@ def register_feature_extractor(
         Callable: デコレートされたクラスをそのまま返す.
     """
 
-    def decorator(cls: Type[BaseFeatureExtractor]) -> Type[BaseFeatureExtractor]:
+    def decorator(cls: type[BaseFeatureExtractor]) -> type[BaseFeatureExtractor]:
         if name in FEATURE_EXTRACTOR_REGISTRY:
             logger.warning(
                 f"Feature extractor '{name}' is already registered "
@@ -50,7 +50,7 @@ def register_feature_extractor(
 
 
 def get_feature_extractor(
-    name: str, config: Optional[Dict[str, Any]] = None
+    name: str, config: dict[str, Any] | None = None
 ) -> BaseFeatureExtractor:
     """
     指定された名前の特徴量抽出器クラスを取得し、設定を使用してインスタンス化します.
@@ -59,7 +59,7 @@ def get_feature_extractor(
 
     Args:
         name (str): 取得する特徴量抽出器の名前.
-        config (Optional[Dict[str, Any]]): 特徴量抽出器の初期化に使用する設定.
+        config (dict[str, Any] | None): 特徴量抽出器の初期化に使用する設定.
             指定されない場合はデフォルト設定のみを使用.
 
     Returns:

--- a/pochivision/feature_extractors/rgb_statistics.py
+++ b/pochivision/feature_extractors/rgb_statistics.py
@@ -1,6 +1,6 @@
 """RGB統計特徴量抽出を行うモジュール."""
 
-from typing import Any, Dict, Optional, Union
+from typing import Any
 
 import numpy as np
 
@@ -46,7 +46,7 @@ class RGBStatisticsExtractor(BaseFeatureExtractor):
     def __init__(
         self,
         name: str = "rgb_statistics",
-        config: Optional[Dict[str, Any]] = None,
+        config: dict[str, Any] | None = None,
     ) -> None:
         """
         RGBStatisticsExtractorのコンストラクタ.
@@ -60,7 +60,7 @@ class RGBStatisticsExtractor(BaseFeatureExtractor):
         # 設定パラメータの取得（デフォルト設定が既にマージされているため直接アクセス）
         self.exclude_black_pixels = self.config["exclude_black_pixels"]
 
-    def extract(self, image: np.ndarray) -> Dict[str, Union[float, int]]:
+    def extract(self, image: np.ndarray) -> dict[str, float | int]:
         """
         画像からRGB統計特徴量を抽出する.
 
@@ -68,7 +68,7 @@ class RGBStatisticsExtractor(BaseFeatureExtractor):
             image (np.ndarray): 入力画像（BGR形式）.
 
         Returns:
-            Dict[str, Union[float, int]]: 抽出された特徴量の辞書.
+            dict[str, float | int]: 抽出された特徴量の辞書.
                 R、G、Bチャンネルそれぞれについて:
                 - {channel}_mean: 平均値
                 - {channel}_median: 中央値
@@ -134,12 +134,12 @@ class RGBStatisticsExtractor(BaseFeatureExtractor):
             raise
 
     @staticmethod
-    def get_default_config() -> Dict[str, Any]:
+    def get_default_config() -> dict[str, Any]:
         """
         RGBStatisticsExtractorのデフォルト設定を返す.
 
         Returns:
-            Dict[str, Any]: デフォルト設定.
+            dict[str, Any]: デフォルト設定.
                 - exclude_black_pixels: RGB値がすべて0のピクセルを除外するかどうか
         """
         return {"exclude_black_pixels": True}
@@ -177,12 +177,12 @@ class RGBStatisticsExtractor(BaseFeatureExtractor):
         return feature_names
 
     @staticmethod
-    def get_feature_units() -> Dict[str, str]:
+    def get_feature_units() -> dict[str, str]:
         """
         特徴量の単位辞書を返す.
 
         Returns:
-            Dict[str, str]: 特徴量名と単位の対応辞書.
+            dict[str, str]: 特徴量名と単位の対応辞書.
         """
         # 基本特徴量名を取得
         base_names = RGBStatisticsExtractor.get_base_feature_names()

--- a/pochivision/feature_extractors/schema.py
+++ b/pochivision/feature_extractors/schema.py
@@ -4,18 +4,14 @@
 各特徴量抽出器のパラメータ構造を型安全に管理します。
 """
 
-from typing import List, Optional, Union
-
 from pydantic import BaseModel, Field, StrictBool, StrictFloat, StrictInt, StrictStr
 
 
 class BrightnessStatisticsParams(BaseModel):
     """輝度統計特徴量抽出のパラメータスキーマ."""
 
-    color_mode: Optional[StrictStr] = Field(
-        default="gray", pattern="^(gray|lab_l|hsv_v)$"
-    )
-    exclude_zero_pixels: Optional[StrictBool] = Field(
+    color_mode: StrictStr | None = Field(default="gray", pattern="^(gray|lab_l|hsv_v)$")
+    exclude_zero_pixels: StrictBool | None = Field(
         default=True, description="輝度値0のピクセルを計算から除外するかどうか"
     )
 
@@ -23,7 +19,7 @@ class BrightnessStatisticsParams(BaseModel):
 class RGBStatisticsParams(BaseModel):
     """RGB統計特徴量抽出のパラメータスキーマ."""
 
-    exclude_black_pixels: Optional[StrictBool] = Field(
+    exclude_black_pixels: StrictBool | None = Field(
         default=True, description="RGB値がすべて0のピクセルを計算から除外するかどうか"
     )
 
@@ -31,7 +27,7 @@ class RGBStatisticsParams(BaseModel):
 class HSVStatisticsParams(BaseModel):
     """HSV統計特徴量抽出のパラメータスキーマ."""
 
-    exclude_black_pixels: Optional[StrictBool] = Field(
+    exclude_black_pixels: StrictBool | None = Field(
         default=True, description="HSV値がすべて0のピクセルを計算から除外するかどうか"
     )
 
@@ -39,24 +35,24 @@ class HSVStatisticsParams(BaseModel):
 class GLCMTextureParams(BaseModel):
     """GLCMテクスチャ特徴量抽出のパラメータスキーマ."""
 
-    distances: Optional[List[StrictInt]] = Field(
+    distances: list[StrictInt] | None = Field(
         default=[1, 2, 3], description="ピクセル間距離のリスト"
     )
-    angles: Optional[Union[List[StrictFloat], StrictStr]] = Field(
+    angles: list[StrictFloat] | StrictStr | None = Field(
         default="standard",
         description=(
             "角度設定（度数リスト、ラジアンリスト、またはプリセット名: 'horizontal', "
             "'vertical', 'diagonal', 'standard', 'all_8', 'fine_16'）"
         ),
     )
-    levels: Optional[StrictInt] = Field(
+    levels: StrictInt | None = Field(
         default=256, ge=2, le=256, description="グレーレベル数（2-256）"
     )
-    symmetric: Optional[StrictBool] = Field(
+    symmetric: StrictBool | None = Field(
         default=True, description="対称性を考慮するかどうか"
     )
-    normed: Optional[StrictBool] = Field(default=True, description="正規化するかどうか")
-    properties: Optional[List[StrictStr]] = Field(
+    normed: StrictBool | None = Field(default=True, description="正規化するかどうか")
+    properties: list[StrictStr] | None = Field(
         default=[
             "contrast",
             "dissimilarity",
@@ -67,13 +63,13 @@ class GLCMTextureParams(BaseModel):
         ],
         description="計算するプロパティのリスト",
     )
-    resize_shape: Optional[List[StrictInt]] = Field(
+    resize_shape: list[StrictInt] | None = Field(
         default=None, description="リサイズ形状 [高さ, 幅]"
     )
-    preserve_aspect_ratio: Optional[StrictBool] = Field(
+    preserve_aspect_ratio: StrictBool | None = Field(
         default=True, description="アスペクト比を保持するか"
     )
-    aspect_ratio_mode: Optional[StrictStr] = Field(
+    aspect_ratio_mode: StrictStr | None = Field(
         default="width", pattern="^(width|height)$", description="基準軸"
     )
 
@@ -81,34 +77,34 @@ class GLCMTextureParams(BaseModel):
 class FFTFrequencyParams(BaseModel):
     """FFT周波数領域特徴量抽出のパラメータスキーマ."""
 
-    frequency_bands: Optional[List[List[StrictFloat]]] = Field(
+    frequency_bands: list[list[StrictFloat]] | None = Field(
         default=[[0.0, 0.1], [0.1, 0.3], [0.3, 0.5]],
         description="周波数帯域のリスト（各帯域は[最小周波数, 最大周波数]の形式）",
     )
-    high_low_threshold: Optional[StrictFloat] = Field(
+    high_low_threshold: StrictFloat | None = Field(
         default=0.2, ge=0.0, le=0.5, description="高周波/低周波の境界閾値（0.0-0.5）"
     )
-    directional_tolerance: Optional[StrictFloat] = Field(
+    directional_tolerance: StrictFloat | None = Field(
         default=10.0,
         ge=0.0,
         le=90.0,
         description="方向性エネルギー計算の許容角度（度）",
     )
-    peak_threshold_ratio: Optional[StrictFloat] = Field(
+    peak_threshold_ratio: StrictFloat | None = Field(
         default=0.1, ge=0.0, le=1.0, description="ピーク検出の閾値比（0.0-1.0）"
     )
-    mm_per_pixel: Optional[StrictFloat] = Field(
+    mm_per_pixel: StrictFloat | None = Field(
         default=None,
         gt=0.0,
         description="ピクセルあたりのmm（Noneの場合はピクセル単位）",
     )
-    resize_shape: Optional[List[StrictInt]] = Field(
+    resize_shape: list[StrictInt] | None = Field(
         default=None, description="リサイズ形状 [高さ, 幅]"
     )
-    preserve_aspect_ratio: Optional[StrictBool] = Field(
+    preserve_aspect_ratio: StrictBool | None = Field(
         default=True, description="アスペクト比を保持するか"
     )
-    aspect_ratio_mode: Optional[StrictStr] = Field(
+    aspect_ratio_mode: StrictStr | None = Field(
         default="width", pattern="^(width|height)$", description="基準軸"
     )
 
@@ -116,14 +112,14 @@ class FFTFrequencyParams(BaseModel):
 class SWTFrequencyParams(BaseModel):
     """SWT周波数変換特徴量抽出のパラメータスキーマ."""
 
-    wavelet: Optional[StrictStr] = Field(
+    wavelet: StrictStr | None = Field(
         default="db1",
         description="ウェーブレット種類（例: 'db1', 'db4', 'haar', 'bior2.2'）",
     )
-    max_level: Optional[StrictInt] = Field(
+    max_level: StrictInt | None = Field(
         default=1, ge=1, le=6, description="最大分解レベル（1-6）"
     )
-    multiscale: Optional[StrictBool] = Field(
+    multiscale: StrictBool | None = Field(
         default=True,
         description=(
             "マルチスケール解析を行うかどうか. "
@@ -131,13 +127,13 @@ class SWTFrequencyParams(BaseModel):
             "False: level 1 (高周波) のみ抽出"
         ),
     )
-    resize_shape: Optional[List[StrictInt]] = Field(
+    resize_shape: list[StrictInt] | None = Field(
         default=None, description="リサイズ形状 [高さ, 幅]"
     )
-    preserve_aspect_ratio: Optional[StrictBool] = Field(
+    preserve_aspect_ratio: StrictBool | None = Field(
         default=True, description="アスペクト比を保持するか"
     )
-    aspect_ratio_mode: Optional[StrictStr] = Field(
+    aspect_ratio_mode: StrictStr | None = Field(
         default="width", pattern="^(width|height)$", description="基準軸"
     )
 
@@ -145,29 +141,27 @@ class SWTFrequencyParams(BaseModel):
 class LBPTextureParams(BaseModel):
     """LBPテクスチャ特徴量抽出のパラメータスキーマ."""
 
-    P: Optional[StrictInt] = Field(
-        default=8, ge=4, le=24, description="近傍点数（4-24）"
-    )
-    R: Optional[Union[StrictInt, StrictFloat]] = Field(
+    P: StrictInt | None = Field(default=8, ge=4, le=24, description="近傍点数（4-24）")
+    R: StrictInt | StrictFloat | None = Field(
         default=1, gt=0.0, description="半径（正の数値）"
     )
-    method: Optional[StrictStr] = Field(
+    method: StrictStr | None = Field(
         default="uniform",
         pattern="^(default|ror|uniform|nri_uniform|var)$",
         description="LBP手法（default, ror, uniform, nri_uniform, var）",
     )
-    resize_shape: Optional[List[StrictInt]] = Field(
+    resize_shape: list[StrictInt] | None = Field(
         default=[128, 128],
         description="リサイズ形状 [高さ, 幅]（Noneの場合はリサイズしない）",
     )
-    include_histogram: Optional[StrictBool] = Field(
+    include_histogram: StrictBool | None = Field(
         default=False,
         description="ヒストグラムの各ビンを特徴量として含むかどうか",
     )
-    preserve_aspect_ratio: Optional[StrictBool] = Field(
+    preserve_aspect_ratio: StrictBool | None = Field(
         default=True, description="アスペクト比を保持するか"
     )
-    aspect_ratio_mode: Optional[StrictStr] = Field(
+    aspect_ratio_mode: StrictStr | None = Field(
         default="width", pattern="^(width|height)$", description="基準軸"
     )
 
@@ -175,38 +169,38 @@ class LBPTextureParams(BaseModel):
 class HLACTextureParams(BaseModel):
     """HLACテクスチャ特徴量抽出のパラメータスキーマ."""
 
-    order: Optional[StrictInt] = Field(
+    order: StrictInt | None = Field(
         default=2, ge=1, le=2, description="自己相関の次数（1または2）"
     )
-    rotate_invariant: Optional[StrictBool] = Field(
+    rotate_invariant: StrictBool | None = Field(
         default=False, description="回転不変性を有効にするかどうか"
     )
-    normalize: Optional[StrictBool] = Field(
+    normalize: StrictBool | None = Field(
         default=True, description="特徴量を正規化するかどうか"
     )
-    scales: Optional[List[StrictFloat]] = Field(
+    scales: list[StrictFloat] | None = Field(
         default=[1.0, 0.75, 0.5],
         description="マルチスケール処理のスケール係数リスト",
     )
-    resize_shape: Optional[List[StrictInt]] = Field(
+    resize_shape: list[StrictInt] | None = Field(
         default=None,
         description="リサイズ形状 [高さ, 幅]（Noneの場合はリサイズしない）",
     )
-    preserve_aspect_ratio: Optional[StrictBool] = Field(
+    preserve_aspect_ratio: StrictBool | None = Field(
         default=True, description="アスペクト比を保持するか"
     )
-    aspect_ratio_mode: Optional[StrictStr] = Field(
+    aspect_ratio_mode: StrictStr | None = Field(
         default="width", pattern="^(width|height)$", description="基準軸"
     )
-    binarization_method: Optional[StrictStr] = Field(
+    binarization_method: StrictStr | None = Field(
         default="adaptive",
         pattern="^(otsu|adaptive)$",
         description="二値化方式 (otsu or adaptive)",
     )
-    adaptive_block_size: Optional[StrictInt] = Field(
+    adaptive_block_size: StrictInt | None = Field(
         default=11, ge=3, description="adaptive 二値化のブロックサイズ (奇数)"
     )
-    adaptive_c: Optional[Union[StrictInt, StrictFloat]] = Field(
+    adaptive_c: StrictInt | StrictFloat | None = Field(
         default=2, description="adaptive 二値化の定数 C"
     )
 
@@ -214,21 +208,21 @@ class HLACTextureParams(BaseModel):
 class CircleCounterParams(BaseModel):
     """円カウント特徴量抽出のパラメータスキーマ."""
 
-    min_radius: Optional[StrictInt] = Field(
+    min_radius: StrictInt | None = Field(
         default=5, ge=1, description="検出する円の最小半径（ピクセル）"
     )
-    max_radius: Optional[StrictInt] = Field(
+    max_radius: StrictInt | None = Field(
         default=0,
         ge=0,
         description="検出する円の最大半径（0の場合は画像サイズの1/4を使用）",
     )
-    min_dist_ratio: Optional[StrictFloat] = Field(
+    min_dist_ratio: StrictFloat | None = Field(
         default=0.8,
         ge=0.1,
         le=2.0,
         description="円の中心間の最小距離の係数（max_radius * ratio）",
     )
-    param1: Optional[StrictInt] = Field(
+    param1: StrictInt | None = Field(
         default=50,
         ge=10,
         le=200,
@@ -238,7 +232,7 @@ class CircleCounterParams(BaseModel):
             "低い値（30-50）:細かいエッジも検出、ノイズの影響を受けやすい（偽検出あり）"
         ),
     )
-    param2: Optional[StrictInt] = Field(
+    param2: StrictInt | None = Field(
         default=30,
         ge=10,
         le=100,
@@ -248,18 +242,18 @@ class CircleCounterParams(BaseModel):
             "高い値（40-60）:厳格な円のみ検出、検出漏れが増加"
         ),
     )
-    circularity_threshold: Optional[StrictFloat] = Field(
+    circularity_threshold: StrictFloat | None = Field(
         default=0.7,
         ge=0.0,
         le=1.0,
         description="真円度の閾値（0.0-1.0、1.0が完全な円）",
     )
-    blur_kernel_size: Optional[StrictInt] = Field(
+    blur_kernel_size: StrictInt | None = Field(
         default=5,
         ge=0,
         description="ガウシアンブラーのカーネルサイズ（0で無効化、奇数のみ有効）",
     )
-    enable_circularity_filter: Optional[StrictBool] = Field(
+    enable_circularity_filter: StrictBool | None = Field(
         default=True, description="真円度フィルタリングを有効にするかどうか"
     )
 

--- a/pochivision/feature_extractors/swt_frequency.py
+++ b/pochivision/feature_extractors/swt_frequency.py
@@ -1,6 +1,6 @@
 """SWT（Stationary Wavelet Transform）周波数変換特徴量抽出を行うモジュール."""
 
-from typing import Any, Dict, List, Optional, Union
+from typing import Any
 
 import numpy as np
 import pywt
@@ -52,7 +52,7 @@ class SWTFrequencyExtractor(BaseFeatureExtractor):
     def __init__(
         self,
         name: str = "swt_frequency",
-        config: Optional[Dict[str, Any]] = None,
+        config: dict[str, Any] | None = None,
     ) -> None:
         """
         SWTFrequencyExtractorのコンストラクタ.
@@ -162,7 +162,7 @@ class SWTFrequencyExtractor(BaseFeatureExtractor):
 
     def _extract_single_level_features(
         self, coeffs: tuple, level: int = 0
-    ) -> Dict[str, float]:
+    ) -> dict[str, float]:
         """
         単一レベルのSWT特徴量を抽出する.
 
@@ -171,7 +171,7 @@ class SWTFrequencyExtractor(BaseFeatureExtractor):
             level (int): 分解レベル（マルチスケール時のプレフィックス用）
 
         Returns:
-            Dict[str, float]: 抽出された特徴量の辞書
+            dict[str, float]: 抽出された特徴量の辞書
         """
         features = {}
 
@@ -295,7 +295,7 @@ class SWTFrequencyExtractor(BaseFeatureExtractor):
 
         return adjusted_image
 
-    def extract(self, image: np.ndarray) -> Dict[str, Union[float, int]]:
+    def extract(self, image: np.ndarray) -> dict[str, float | int]:
         """
         画像からSWT周波数変換特徴量を抽出する.
 
@@ -303,7 +303,7 @@ class SWTFrequencyExtractor(BaseFeatureExtractor):
             image (np.ndarray): 入力画像（グレースケールまたはRGB）
 
         Returns:
-            Dict[str, Union[float, int]]: 抽出された特徴量の辞書
+            dict[str, float | int]: 抽出された特徴量の辞書
 
         Raises:
             ValueError: 画像の次元が不正な場合
@@ -368,12 +368,12 @@ class SWTFrequencyExtractor(BaseFeatureExtractor):
             raise
 
     @staticmethod
-    def get_default_config() -> Dict[str, Any]:
+    def get_default_config() -> dict[str, Any]:
         """
         デフォルト設定を取得する.
 
         Returns:
-            Dict[str, Any]: デフォルト設定の辞書
+            dict[str, Any]: デフォルト設定の辞書
         """
         return {
             "wavelet": "db1",
@@ -385,7 +385,7 @@ class SWTFrequencyExtractor(BaseFeatureExtractor):
         }
 
     @staticmethod
-    def get_feature_names(config: Optional[Dict[str, Any]] = None) -> List[str]:
+    def get_feature_names(config: dict[str, Any] | None = None) -> list[str]:
         """
         抽出される特徴量名のリストを取得する (単位付き).
 
@@ -394,10 +394,10 @@ class SWTFrequencyExtractor(BaseFeatureExtractor):
         config=None の場合はデフォルト設定 (multiscale=True, max_level=1) を使用.
 
         Args:
-            config (Optional[Dict[str, Any]]): 設定辞書.
+            config (dict[str, Any] | None): 設定辞書.
 
         Returns:
-            List[str]: 特徴量名のリスト (単位付き).
+            list[str]: 特徴量名のリスト (単位付き).
         """
         base_names = SWTFrequencyExtractor.get_base_feature_names(config)
         return [
@@ -406,15 +406,15 @@ class SWTFrequencyExtractor(BaseFeatureExtractor):
         ]
 
     @staticmethod
-    def get_base_feature_names(config: Optional[Dict[str, Any]] = None) -> List[str]:
+    def get_base_feature_names(config: dict[str, Any] | None = None) -> list[str]:
         """
         抽出される基本特徴量名のリストを取得する（単位なし）.
 
         Args:
-            config (Optional[Dict[str, Any]]): 設定辞書。Noneの場合はデフォルト設定を使用。
+            config (dict[str, Any] | None): 設定辞書。Noneの場合はデフォルト設定を使用。
 
         Returns:
-            List[str]: 基本特徴量名のリスト.
+            list[str]: 基本特徴量名のリスト.
         """
         # 設定を取得（引数で指定されない場合はデフォルト設定を使用）
         if config is None:
@@ -454,15 +454,15 @@ class SWTFrequencyExtractor(BaseFeatureExtractor):
             return base_features
 
     @staticmethod
-    def get_feature_units(config: Optional[Dict[str, Any]] = None) -> Dict[str, str]:
+    def get_feature_units(config: dict[str, Any] | None = None) -> dict[str, str]:
         """
         特徴量の単位辞書を返す.
 
         Args:
-            config (Optional[Dict[str, Any]]): 設定辞書。Noneの場合はデフォルト設定を使用。
+            config (dict[str, Any] | None): 設定辞書。Noneの場合はデフォルト設定を使用。
 
         Returns:
-            Dict[str, str]: 特徴量名と単位の対応辞書.
+            dict[str, str]: 特徴量名と単位の対応辞書.
         """
         # 基本特徴量名を取得（設定を渡す）
         base_names = SWTFrequencyExtractor.get_base_feature_names(config)

--- a/pochivision/processors/base.py
+++ b/pochivision/processors/base.py
@@ -1,7 +1,7 @@
 """画像処理プロセッサの基底クラスを定義するモジュール."""
 
 import abc
-from typing import Any, Dict
+from typing import Any
 
 import numpy as np
 
@@ -15,7 +15,7 @@ class BaseProcessor(abc.ABC):
         config (dict): プロセッサ固有の設定.
     """
 
-    def __init__(self, name: str, config: Dict[str, Any]) -> None:
+    def __init__(self, name: str, config: dict[str, Any]) -> None:
         """
         BaseProcessorのコンストラクタ.
 
@@ -41,11 +41,11 @@ class BaseProcessor(abc.ABC):
 
     @staticmethod
     @abc.abstractmethod
-    def get_default_config() -> Dict[str, Any]:
+    def get_default_config() -> dict[str, Any]:
         """
         プロセッサのデフォルト設定を返す.
 
         Returns:
-            Dict[str, Any]: デフォルト設定.
+            dict[str, Any]: デフォルト設定.
         """
         pass

--- a/pochivision/processors/binarization.py
+++ b/pochivision/processors/binarization.py
@@ -1,6 +1,6 @@
 """2値化処理プロセッサの実装を提供するモジュール."""
 
-from typing import Any, Dict
+from typing import Any
 
 import cv2
 import numpy as np
@@ -42,7 +42,7 @@ class StandardBinarizationProcessor(BaseProcessor):
         threshold (int): 2値化の閾値（0-255, デフォルト128）
     """
 
-    def __init__(self, name: str, config: Dict[str, int]) -> None:
+    def __init__(self, name: str, config: dict[str, int]) -> None:
         """
         StandardBinarizationProcessorのコンストラクタ.
 
@@ -88,12 +88,12 @@ class StandardBinarizationProcessor(BaseProcessor):
         return binary
 
     @staticmethod
-    def get_default_config() -> Dict[str, Any]:
+    def get_default_config() -> dict[str, Any]:
         """
         標準2値化プロセッサのデフォルト設定を返す.
 
         Returns:
-            Dict[str, Any]: デフォルト設定.
+            dict[str, Any]: デフォルト設定.
         """
         return {"threshold": 128}
 
@@ -115,7 +115,7 @@ class OtsuBinarizationProcessor(BaseProcessor):
         }
     """
 
-    def __init__(self, name: str, config: Dict[str, Any]) -> None:
+    def __init__(self, name: str, config: dict[str, Any]) -> None:
         """
         OtsuBinarizationProcessorのコンストラクタ.
 
@@ -160,12 +160,12 @@ class OtsuBinarizationProcessor(BaseProcessor):
         return binary
 
     @staticmethod
-    def get_default_config() -> Dict[str, Any]:
+    def get_default_config() -> dict[str, Any]:
         """
         大津の2値化プロセッサのデフォルト設定を返す.
 
         Returns:
-            Dict[str, Any]: デフォルト設定（空の辞書）.
+            dict[str, Any]: デフォルト設定（空の辞書）.
         """
         return {}
 
@@ -188,7 +188,7 @@ class GaussianAdaptiveBinarizationProcessor(BaseProcessor):
         }
     """
 
-    def __init__(self, name: str, config: Dict[str, Any]) -> None:
+    def __init__(self, name: str, config: dict[str, Any]) -> None:
         """
         GaussianAdaptiveBinarizationProcessorのコンストラクタ.
 
@@ -245,12 +245,12 @@ class GaussianAdaptiveBinarizationProcessor(BaseProcessor):
         return binary
 
     @staticmethod
-    def get_default_config() -> Dict[str, Any]:
+    def get_default_config() -> dict[str, Any]:
         """
         ガウシアン適応的2値化プロセッサのデフォルト設定を返す.
 
         Returns:
-            Dict[str, Any]: デフォルト設定.
+            dict[str, Any]: デフォルト設定.
         """
         return {"block_size": 11, "c": 2}
 
@@ -273,7 +273,7 @@ class MeanAdaptiveBinarizationProcessor(BaseProcessor):
         }
     """
 
-    def __init__(self, name: str, config: Dict[str, Any]) -> None:
+    def __init__(self, name: str, config: dict[str, Any]) -> None:
         """
         MeanAdaptiveBinarizationProcessorのコンストラクタ.
 
@@ -330,11 +330,11 @@ class MeanAdaptiveBinarizationProcessor(BaseProcessor):
         return binary
 
     @staticmethod
-    def get_default_config() -> Dict[str, Any]:
+    def get_default_config() -> dict[str, Any]:
         """
         平均値による適応的2値化プロセッサのデフォルト設定を返す.
 
         Returns:
-            Dict[str, Any]: デフォルト設定.
+            dict[str, Any]: デフォルト設定.
         """
         return {"block_size": 11, "c": 2}

--- a/pochivision/processors/blur.py
+++ b/pochivision/processors/blur.py
@@ -1,6 +1,6 @@
 """各種ブラー（ぼかし）処理プロセッサの実装を提供するモジュール."""
 
-from typing import Any, Dict
+from typing import Any
 
 import cv2
 import numpy as np
@@ -34,13 +34,13 @@ class GaussianBlurProcessor(BaseProcessor):
         }
     """
 
-    def __init__(self, name: str, config: Dict[str, Any]) -> None:
+    def __init__(self, name: str, config: dict[str, Any]) -> None:
         """
         GaussianBlurProcessorを初期化.
 
         Args:
             name (str): プロセッサ名.
-            config (Dict[str, Any]): 設定パラメータ.
+            config (dict[str, Any]): 設定パラメータ.
         """
         super().__init__(name, config)
         self.validator = GaussianBlurValidator(config)
@@ -81,12 +81,12 @@ class GaussianBlurProcessor(BaseProcessor):
             raise ProcessorRuntimeError(error_msg)
 
     @staticmethod
-    def get_default_config() -> Dict[str, Any]:
+    def get_default_config() -> dict[str, Any]:
         """
         ガウシアンブラープロセッサのデフォルト設定を返す.
 
         Returns:
-            Dict[str, Any]: デフォルト設定.
+            dict[str, Any]: デフォルト設定.
         """
         return {"kernel_size": [15, 15], "sigma": 0}
 
@@ -108,13 +108,13 @@ class AverageBlurProcessor(BaseProcessor):
         }
     """
 
-    def __init__(self, name: str, config: Dict[str, Any]) -> None:
+    def __init__(self, name: str, config: dict[str, Any]) -> None:
         """
         AverageBlurProcessorを初期化します.
 
         Args:
             name (str): プロセッサ名.
-            config (Dict[str, Any]): 設定パラメータ.
+            config (dict[str, Any]): 設定パラメータ.
         """
         super().__init__(name, config)
         self.validator = AverageBlurValidator(config)
@@ -150,12 +150,12 @@ class AverageBlurProcessor(BaseProcessor):
             raise ProcessorRuntimeError(error_msg)
 
     @staticmethod
-    def get_default_config() -> Dict[str, Any]:
+    def get_default_config() -> dict[str, Any]:
         """
         平均値ブラープロセッサのデフォルト設定を返す.
 
         Returns:
-            Dict[str, Any]: デフォルト設定.
+            dict[str, Any]: デフォルト設定.
         """
         return {"kernel_size": [5, 5]}
 
@@ -178,13 +178,13 @@ class MedianBlurProcessor(BaseProcessor):
         }
     """
 
-    def __init__(self, name: str, config: Dict[str, Any]) -> None:
+    def __init__(self, name: str, config: dict[str, Any]) -> None:
         """
         MedianBlurProcessorを初期化します.
 
         Args:
             name (str): プロセッサ名.
-            config (Dict[str, Any]): 設定パラメータ.
+            config (dict[str, Any]): 設定パラメータ.
         """
         super().__init__(name, config)
         self.validator = MedianBlurValidator(config)
@@ -219,12 +219,12 @@ class MedianBlurProcessor(BaseProcessor):
             raise ProcessorRuntimeError(error_msg)
 
     @staticmethod
-    def get_default_config() -> Dict[str, Any]:
+    def get_default_config() -> dict[str, Any]:
         """
         メディアンブラープロセッサのデフォルト設定を返す.
 
         Returns:
-            Dict[str, Any]: デフォルト設定.
+            dict[str, Any]: デフォルト設定.
         """
         return {"kernel_size": 5}
 
@@ -248,13 +248,13 @@ class BilateralFilterProcessor(BaseProcessor):
         }
     """
 
-    def __init__(self, name: str, config: Dict[str, Any]):
+    def __init__(self, name: str, config: dict[str, Any]):
         """
         BilateralFilterProcessorを初期化します.
 
         Args:
             name (str): プロセッサ名.
-            config (Dict[str, Any]): 設定パラメータ.
+            config (dict[str, Any]): 設定パラメータ.
         """
         super().__init__(name, config)
         self.validator = BilateralFilterValidator(config)
@@ -293,12 +293,12 @@ class BilateralFilterProcessor(BaseProcessor):
             raise ProcessorRuntimeError(error_msg)
 
     @staticmethod
-    def get_default_config() -> Dict[str, Any]:
+    def get_default_config() -> dict[str, Any]:
         """
         バイラテラルフィルタプロセッサのデフォルト設定を返す.
 
         Returns:
-            Dict[str, Any]: デフォルト設定.
+            dict[str, Any]: デフォルト設定.
         """
         return {"d": 9, "sigmaColor": 75, "sigmaSpace": 75}
 
@@ -320,13 +320,13 @@ class MotionBlurProcessor(BaseProcessor):
         }
     """
 
-    def __init__(self, name: str, config: Dict[str, Any]):
+    def __init__(self, name: str, config: dict[str, Any]):
         """
         MotionBlurProcessorを初期化します.
 
         Args:
             name (str): プロセッサ名.
-            config (Dict[str, Any]): 設定パラメータ.
+            config (dict[str, Any]): 設定パラメータ.
         """
         super().__init__(name, config)
         self.validator = MotionBlurValidator(config)
@@ -374,11 +374,11 @@ class MotionBlurProcessor(BaseProcessor):
             raise ProcessorRuntimeError(error_msg)
 
     @staticmethod
-    def get_default_config() -> Dict[str, Any]:
+    def get_default_config() -> dict[str, Any]:
         """
         モーションブラープロセッサのデフォルト設定を返す.
 
         Returns:
-            Dict[str, Any]: デフォルト設定.
+            dict[str, Any]: デフォルト設定.
         """
         return {"kernel_size": 15, "angle": 0}

--- a/pochivision/processors/clahe.py
+++ b/pochivision/processors/clahe.py
@@ -1,6 +1,6 @@
 """CLAHE（適応的ヒストグラム平坦化）プロセッサーを提供するモジュール."""
 
-from typing import Any, Dict, Optional
+from typing import Any
 
 import cv2
 import numpy as np
@@ -37,13 +37,13 @@ class CLAHEProcessor(BaseProcessor):
         }
     """
 
-    def __init__(self, name: str, config: Optional[Dict[str, Any]] = None) -> None:
+    def __init__(self, name: str, config: dict[str, Any] | None = None) -> None:
         """
         CLAHEProcessorの初期化.
 
         Args:
             name (str): プロセッサ名.
-            config (Optional[Dict[str, Any]], optional): 設定パラメータ. デフォルトはNone.
+            config (dict[str, Any] | None, optional): 設定パラメータ. デフォルトはNone.
                 - color_mode (str): カラー画像の処理方式 ('gray', 'lab', 'bgr')
                 - clip_limit (float): コントラスト制限値
                 - tile_grid_size (List[int]): タイルグリッドのサイズ
@@ -121,11 +121,11 @@ class CLAHEProcessor(BaseProcessor):
             raise ProcessorRuntimeError(error_msg)
 
     @staticmethod
-    def get_default_config() -> Dict[str, Any]:
+    def get_default_config() -> dict[str, Any]:
         """
         CLAHEプロセッサのデフォルト設定を返す.
 
         Returns:
-            Dict[str, Any]: デフォルト設定.
+            dict[str, Any]: デフォルト設定.
         """
         return {"color_mode": "gray", "clip_limit": 2.0, "tile_grid_size": [8, 8]}

--- a/pochivision/processors/contour.py
+++ b/pochivision/processors/contour.py
@@ -1,6 +1,6 @@
 """輪郭抽出プロセッサーを定義するモジュール."""
 
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 import cv2
 import numpy as np
@@ -17,13 +17,13 @@ from .validators.contour import ContourValidator
 class ContourProcessor(BaseProcessor):
     """画像から輪郭を抽出するプロセッサー."""
 
-    def __init__(self, name: str, config: Dict[str, Any]) -> None:
+    def __init__(self, name: str, config: dict[str, Any]) -> None:
         """
         ContourProcessorを初期化.
 
         Args:
             name (str): プロセッサの名前.
-            config (Dict[str, Any]): 輪郭抽出の設定辞書.
+            config (dict[str, Any]): 輪郭抽出の設定辞書.
         """
         super().__init__(name, config)
         self.validator = ContourValidator(self.config)
@@ -94,17 +94,15 @@ class ContourProcessor(BaseProcessor):
         }
         return int(method_map.get(method_str, cv2.CHAIN_APPROX_SIMPLE))
 
-    def _select_contour_by_rank(
-        self, contours: List[np.ndarray]
-    ) -> Optional[np.ndarray]:
+    def _select_contour_by_rank(self, contours: list[np.ndarray]) -> np.ndarray | None:
         """
         指定されたランクの輪郭を選択する.
 
         Args:
-            contours (List[np.ndarray]): 輪郭のリスト
+            contours (list[np.ndarray]): 輪郭のリスト
 
         Returns:
-            Optional[np.ndarray]: 指定されたランクの輪郭。該当する輪郭がない場合はNone
+            np.ndarray | None: 指定されたランクの輪郭。該当する輪郭がない場合はNone
         """
         if not contours:
             return None
@@ -197,12 +195,12 @@ class ContourProcessor(BaseProcessor):
             raise ProcessorRuntimeError(f"Error occurred during contour detection: {e}")
 
     @staticmethod
-    def get_default_config() -> Dict[str, Any]:
+    def get_default_config() -> dict[str, Any]:
         """
         輪郭抽出プロセッサのデフォルト設定を返す.
 
         Returns:
-            Dict[str, Any]: デフォルト設定.
+            dict[str, Any]: デフォルト設定.
         """
         return {
             "retrieval_mode": "list",  # デフォルトはLISTモードで全ての輪郭を検出

--- a/pochivision/processors/edge_detection.py
+++ b/pochivision/processors/edge_detection.py
@@ -1,6 +1,6 @@
 """Cannyエッジ検出プロセッサーを定義します."""
 
-from typing import Any, Dict
+from typing import Any
 
 import cv2
 import numpy as np
@@ -17,13 +17,13 @@ from .validators.edge_detection.canny import CannyEdgeValidator
 class CannyEdgeProcessor(BaseProcessor):
     """画像にCannyエッジ検出を適用します."""
 
-    def __init__(self, name: str, config: Dict[str, Any]):
+    def __init__(self, name: str, config: dict[str, Any]):
         """
         CannyEdgeProcessorを初期化.
 
         Args:
             name (str): プロセッサの名前.
-            config (Dict[str, Any]): Cannyエッジ検出の設定辞書.
+            config (dict[str, Any]): Cannyエッジ検出の設定辞書.
         """
         super().__init__(name, config)
         self.validator = CannyEdgeValidator(self.config)
@@ -87,12 +87,12 @@ class CannyEdgeProcessor(BaseProcessor):
         return edges
 
     @staticmethod
-    def get_default_config() -> Dict[str, Any]:
+    def get_default_config() -> dict[str, Any]:
         """
         CannyEdgeProcessorのデフォルト設定を返します.
 
         Returns:
-            Dict[str, Any]: デフォルト設定.
+            dict[str, Any]: デフォルト設定.
         """
         return {
             "threshold1": 100.0,

--- a/pochivision/processors/equalize.py
+++ b/pochivision/processors/equalize.py
@@ -1,6 +1,6 @@
 """ヒストグラム平坦化プロセッサーを提供するモジュール."""
 
-from typing import Any, Dict, Optional
+from typing import Any
 
 import cv2
 import numpy as np
@@ -35,13 +35,13 @@ class EqualizeProcessor(BaseProcessor):
         }
     """
 
-    def __init__(self, name: str, config: Optional[Dict[str, Any]] = None) -> None:
+    def __init__(self, name: str, config: dict[str, Any] | None = None) -> None:
         """
         EqualizeProcessorの初期化.
 
         Args:
             name (str): プロセッサ名.
-            config (Optional[Dict[str, Any]], optional): 設定パラメータ. デフォルトはNone.
+            config (dict[str, Any] | None, optional): 設定パラメータ. デフォルトはNone.
                 - color_mode (str): カラー画像の処理方式 ('gray', 'lab', 'bgr')
         """
         super().__init__(name, config or {})
@@ -111,11 +111,11 @@ class EqualizeProcessor(BaseProcessor):
             raise ProcessorRuntimeError(error_msg)
 
     @staticmethod
-    def get_default_config() -> Dict[str, Any]:
+    def get_default_config() -> dict[str, Any]:
         """
         ヒストグラム平坦化プロセッサのデフォルト設定を返す.
 
         Returns:
-            Dict[str, Any]: デフォルト設定.
+            dict[str, Any]: デフォルト設定.
         """
         return {"color_mode": "gray"}

--- a/pochivision/processors/grayscale.py
+++ b/pochivision/processors/grayscale.py
@@ -1,6 +1,6 @@
 """グレースケール変換プロセッサの実装を提供するモジュール."""
 
-from typing import Any, Dict
+from typing import Any
 
 import numpy as np
 
@@ -28,13 +28,13 @@ class GrayscaleProcessor(BaseProcessor):
         }
     """
 
-    def __init__(self, name: str, config: Dict[str, Any]) -> None:
+    def __init__(self, name: str, config: dict[str, Any]) -> None:
         """
         GrayscaleProcessorを初期化.
 
         Args:
             name (str): プロセッサ名.
-            config (Dict[str, Any]): 設定パラメータ.
+            config (dict[str, Any]): 設定パラメータ.
         """
         super().__init__(name, config)
         self.validator = GrayscaleValidator(config)
@@ -63,11 +63,11 @@ class GrayscaleProcessor(BaseProcessor):
             raise ProcessorRuntimeError(error_msg)
 
     @staticmethod
-    def get_default_config() -> Dict[str, Any]:
+    def get_default_config() -> dict[str, Any]:
         """
         グレースケール変換プロセッサのデフォルト設定を返す.
 
         Returns:
-            Dict[str, Any]: デフォルト設定（空の辞書）.
+            dict[str, Any]: デフォルト設定（空の辞書）.
         """
         return {}

--- a/pochivision/processors/mask_composition.py
+++ b/pochivision/processors/mask_composition.py
@@ -1,6 +1,6 @@
 """マスク合成プロセッサを提供するモジュール."""
 
-from typing import Any, Dict, Optional, Tuple
+from typing import Any
 
 import cv2
 import numpy as np
@@ -41,13 +41,13 @@ class MaskCompositionProcessor(BaseProcessor):
         }
     """
 
-    def __init__(self, name: str, config: Dict[str, Any]) -> None:
+    def __init__(self, name: str, config: dict[str, Any]) -> None:
         """
         MaskCompositionProcessorを初期化.
 
         Args:
             name (str): プロセッサ名.
-            config (Dict[str, Any]): 設定パラメータ.
+            config (dict[str, Any]): 設定パラメータ.
 
         Raises:
             ProcessorRuntimeError: パラレルモードで実行しようとした場合.
@@ -69,7 +69,7 @@ class MaskCompositionProcessor(BaseProcessor):
         self.crop_margin = self.config.get("crop_margin", default_config["crop_margin"])
 
         # ターゲット画像（実行時に設定）
-        self.target_image: Optional[np.ndarray] = None
+        self.target_image: np.ndarray | None = None
 
         # リサイズプロセッサの準備（サイズはprocess内で動的設定）
         resize_config = ResizeProcessor.get_default_config()
@@ -103,9 +103,7 @@ class MaskCompositionProcessor(BaseProcessor):
                 "MaskCompositionProcessor can only be used in pipeline mode"
             )
 
-    def _find_crop_bounds(
-        self, mask: np.ndarray
-    ) -> Optional[Tuple[int, int, int, int]]:
+    def _find_crop_bounds(self, mask: np.ndarray) -> tuple[int, int, int, int] | None:
         """
         マスクの白ピクセル領域に基づいてトリミング範囲を計算.
 
@@ -113,7 +111,7 @@ class MaskCompositionProcessor(BaseProcessor):
             mask (np.ndarray): 2値化マスク画像（グレースケール）.
 
         Returns:
-            Optional[Tuple[int, int, int, int]]: トリミング範囲 (y_min, y_max, x_min, x_max)
+            tuple[int, int, int, int] | None: トリミング範囲 (y_min, y_max, x_min, x_max)
                                                 白ピクセルが見つからない場合はNone
         """
         # 白ピクセル（255）の座標を取得
@@ -141,14 +139,14 @@ class MaskCompositionProcessor(BaseProcessor):
         return (y_min, y_max, x_min, x_max)
 
     def _crop_image(
-        self, image: np.ndarray, bounds: Tuple[int, int, int, int]
+        self, image: np.ndarray, bounds: tuple[int, int, int, int]
     ) -> np.ndarray:
         """
         指定された範囲で画像をトリミング.
 
         Args:
             image (np.ndarray): トリミング対象の画像.
-            bounds (Tuple[int, int, int, int]): トリミング範囲 (y_min, y_max, x_min, x_max).
+            bounds (tuple[int, int, int, int]): トリミング範囲 (y_min, y_max, x_min, x_max).
 
         Returns:
             np.ndarray: トリミングされた画像.
@@ -233,12 +231,12 @@ class MaskCompositionProcessor(BaseProcessor):
             raise ProcessorRuntimeError(f"Unexpected error in {self.name}: {e}")
 
     @staticmethod
-    def get_default_config() -> Dict[str, Any]:
+    def get_default_config() -> dict[str, Any]:
         """
         マスク合成プロセッサのデフォルト設定を返す.
 
         Returns:
-            Dict[str, Any]: デフォルト設定.
+            dict[str, Any]: デフォルト設定.
         """
         return {
             "target_image": "original",  # デフォルトはオリジナル画像

--- a/pochivision/processors/registry.py
+++ b/pochivision/processors/registry.py
@@ -10,7 +10,7 @@
         ...
 """
 
-from typing import Any, Callable, Dict, Type
+from typing import Any, Callable
 
 from pochivision.capturelib.log_manager import LogManager
 
@@ -20,12 +20,12 @@ from .base import BaseProcessor
 from .schema import PROCESSOR_SCHEMA_MAP
 
 # 名前とクラスのマッピングを保持する辞書
-PROCESSOR_REGISTRY: Dict[str, Type[BaseProcessor]] = {}
+PROCESSOR_REGISTRY: dict[str, type[BaseProcessor]] = {}
 
 
 def register_processor(
     name: str,
-) -> Callable[[Type[BaseProcessor]], Type[BaseProcessor]]:
+) -> Callable[[type[BaseProcessor]], type[BaseProcessor]]:
     """
     画像処理プロセッサクラスを名前付きで登録するためのデコレータ.
 
@@ -36,7 +36,7 @@ def register_processor(
         Callable: デコレートされたクラスをそのまま返す.
     """
 
-    def decorator(cls: Type[BaseProcessor]) -> Type[BaseProcessor]:
+    def decorator(cls: type[BaseProcessor]) -> type[BaseProcessor]:
         if name in PROCESSOR_REGISTRY:
             logger.warning(
                 f"Processor '{name}' is already registered "
@@ -49,13 +49,13 @@ def register_processor(
     return decorator
 
 
-def get_processor(name: str, config: Dict[str, Any]) -> BaseProcessor:
+def get_processor(name: str, config: dict[str, Any]) -> BaseProcessor:
     """
     指定された名前のプロセッサクラスを取得し、設定を使用してインスタンス化します.
 
     Args:
         name (str): 取得するプロセッサの名前.
-        config (Dict[str, Any]): プロセッサの初期化に使用する設定.
+        config (dict[str, Any]): プロセッサの初期化に使用する設定.
 
     Returns:
         BaseProcessor: 指定されたプロセッサのインスタンス.

--- a/pochivision/processors/resize.py
+++ b/pochivision/processors/resize.py
@@ -1,6 +1,6 @@
 """リサイズプロセッサーを提供するモジュール."""
 
-from typing import Any, Dict
+from typing import Any
 
 import cv2
 import numpy as np
@@ -18,13 +18,13 @@ class ResizeProcessor(BaseProcessor):
     アスペクト比の保持オプションを提供します.
     """
 
-    def __init__(self, name: str, config: Dict[str, Any]) -> None:
+    def __init__(self, name: str, config: dict[str, Any]) -> None:
         """
         ResizeProcessorを初期化.
 
         Args:
             name (str): プロセッサー名
-            config (Dict[str, Any]): リサイズパラメータ
+            config (dict[str, Any]): リサイズパラメータ
                 - width (int): リサイズ後の幅
                 - height (int): リサイズ後の高さ
                 - preserve_aspect_ratio (bool, optional): アスペクト比を保持するかどうか
@@ -101,12 +101,12 @@ class ResizeProcessor(BaseProcessor):
         return target_w, target_h
 
     @staticmethod
-    def get_default_config() -> Dict[str, Any]:
+    def get_default_config() -> dict[str, Any]:
         """
         リサイズプロセッサのデフォルト設定を返す.
 
         Returns:
-            Dict[str, Any]: デフォルト設定.
+            dict[str, Any]: デフォルト設定.
         """
         return {
             "width": 1600,

--- a/pochivision/processors/schema.py
+++ b/pochivision/processors/schema.py
@@ -4,8 +4,6 @@
 各プロセッサのパラメータ構造を型安全に管理する.
 """
 
-from typing import List, Optional, Union
-
 from pydantic import (
     BaseModel,
     ConfigDict,
@@ -22,14 +20,14 @@ from pydantic import (
 class GaussianBlurParams(BaseModel):
     """ガウシアンブラーのパラメータスキーマ."""
 
-    kernel_size: List[StrictInt]
+    kernel_size: list[StrictInt]
     sigma: StrictFloat = Field(ge=0)
 
 
 class AverageBlurParams(BaseModel):
     """平均化ブラーのパラメータスキーマ."""
 
-    kernel_size: List[StrictInt]
+    kernel_size: list[StrictInt]
 
 
 class MedianBlurParams(BaseModel):
@@ -60,7 +58,7 @@ class GaussianAdaptiveBinarizationParams(BaseModel):
     """ガウシアン適応的2値化のパラメータスキーマ."""
 
     block_size: StrictInt = Field(ge=3)
-    c: Union[StrictInt, StrictFloat]
+    c: StrictInt | StrictFloat
 
     @field_validator("block_size")
     @classmethod
@@ -75,7 +73,7 @@ class MeanAdaptiveBinarizationParams(BaseModel):
     """平均適応的2値化のパラメータスキーマ."""
 
     block_size: StrictInt = Field(ge=3)
-    c: Union[StrictInt, StrictFloat]
+    c: StrictInt | StrictFloat
 
     @field_validator("block_size")
     @classmethod
@@ -106,10 +104,10 @@ class MotionBlurParams(BaseModel):
 class ResizeParams(BaseModel):
     """リサイズプロセッサーのパラメータスキーマ."""
 
-    width: Optional[StrictInt] = Field(default=None, gt=0)
-    height: Optional[StrictInt] = Field(default=None, gt=0)
-    preserve_aspect_ratio: Optional[StrictBool] = Field(default=False)
-    aspect_ratio_mode: Optional[StrictStr] = Field(
+    width: StrictInt | None = Field(default=None, gt=0)
+    height: StrictInt | None = Field(default=None, gt=0)
+    preserve_aspect_ratio: StrictBool | None = Field(default=False)
+    aspect_ratio_mode: StrictStr | None = Field(
         default="width", pattern="^(width|height)$"
     )
 
@@ -117,15 +115,15 @@ class ResizeParams(BaseModel):
 class EqualizeParams(BaseModel):
     """ヒストグラム平坦化のパラメータスキーマ."""
 
-    color_mode: Optional[StrictStr] = Field(default="gray", pattern="^(gray|lab|bgr)$")
+    color_mode: StrictStr | None = Field(default="gray", pattern="^(gray|lab|bgr)$")
 
 
 class CLAHEParams(BaseModel):
     """CLAHE のパラメータスキーマ."""
 
-    color_mode: Optional[StrictStr] = Field(default="gray", pattern="^(gray|lab|bgr)$")
-    clip_limit: Optional[StrictFloat] = Field(default=2.0, gt=0)
-    tile_grid_size: Optional[List[StrictInt]] = Field(
+    color_mode: StrictStr | None = Field(default="gray", pattern="^(gray|lab|bgr)$")
+    clip_limit: StrictFloat | None = Field(default=2.0, gt=0)
+    tile_grid_size: list[StrictInt] | None = Field(
         default=[8, 8], min_length=2, max_length=2
     )
 
@@ -135,8 +133,8 @@ class CannyEdgeParams(BaseModel):
 
     threshold1: StrictFloat = Field(ge=0)
     threshold2: StrictFloat = Field(ge=0)
-    aperture_size: Optional[StrictInt] = Field(default=3, ge=3, le=7)
-    l2_gradient: Optional[StrictBool] = Field(default=False)
+    aperture_size: StrictInt | None = Field(default=3, ge=3, le=7)
+    l2_gradient: StrictBool | None = Field(default=False)
 
     @field_validator("aperture_size")
     @classmethod
@@ -160,19 +158,19 @@ class CannyEdgeParams(BaseModel):
 class ContourParams(BaseModel):
     """輪郭抽出プロセッサのパラメータスキーマ."""
 
-    retrieval_mode: Optional[StrictStr] = Field(
+    retrieval_mode: StrictStr | None = Field(
         default="list", pattern="^(external|list|ccomp|tree|floodfill)$"
     )
-    approximation_method: Optional[StrictStr] = Field(
+    approximation_method: StrictStr | None = Field(
         default="simple", pattern="^(none|simple|tc89_l1|tc89_kcos)$"
     )
-    min_area: Optional[StrictInt] = Field(default=100, ge=0)
-    select_mode: Optional[StrictStr] = Field(default="rank", pattern="^(rank|all)$")
-    contour_rank: Optional[StrictInt] = Field(default=0, ge=0)
-    outside_color: Optional[List[StrictInt]] = Field(
+    min_area: StrictInt | None = Field(default=100, ge=0)
+    select_mode: StrictStr | None = Field(default="rank", pattern="^(rank|all)$")
+    contour_rank: StrictInt | None = Field(default=0, ge=0)
+    outside_color: list[StrictInt] | None = Field(
         default=[0, 0, 0], min_length=3, max_length=3
     )
-    inside_color: Optional[List[StrictInt]] = Field(
+    inside_color: list[StrictInt] | None = Field(
         default=[255, 255, 255], min_length=3, max_length=3
     )
 
@@ -180,10 +178,10 @@ class ContourParams(BaseModel):
 class MaskCompositionParams(BaseModel):
     """マスク合成プロセッサのパラメータスキーマ."""
 
-    target_image: Optional[StrictStr] = Field(default="original")
-    use_white_pixels: Optional[StrictBool] = Field(default=True)
-    enable_cropping: Optional[StrictBool] = Field(default=False)
-    crop_margin: Optional[StrictInt] = Field(default=0, ge=0)
+    target_image: StrictStr | None = Field(default="original")
+    use_white_pixels: StrictBool | None = Field(default=True)
+    enable_cropping: StrictBool | None = Field(default=False)
+    crop_margin: StrictInt | None = Field(default=0, ge=0)
 
 
 # プロセッサ名とスキーマクラスのマッピング

--- a/pochivision/processors/validators/binarization/adaptive.py
+++ b/pochivision/processors/validators/binarization/adaptive.py
@@ -1,6 +1,6 @@
 """適応的2値化バリデータの実装モジュール."""
 
-from typing import Any, Dict
+from typing import Any
 
 import numpy as np
 
@@ -13,18 +13,18 @@ class GaussianAdaptiveBinarizationValidator(BaseValidator):
     ガウシアン適応的2値化用のバリデータ.
 
     Args:
-        config (Dict[str, Any]): バリデーション対象の設定辞書.
+        config (dict[str, Any]): バリデーション対象の設定辞書.
 
     Raises:
         ProcessorValidationError: 不正なパラメータが検出された場合.
     """
 
-    def __init__(self, config: Dict[str, Any]) -> None:
+    def __init__(self, config: dict[str, Any]) -> None:
         """
         GaussianAdaptiveBinarizationValidatorのコンストラクタ.
 
         Args:
-            config (Dict[str, Any]): バリデーション対象の設定辞書.
+            config (dict[str, Any]): バリデーション対象の設定辞書.
         """
         self.config = config
 
@@ -52,18 +52,18 @@ class MeanAdaptiveBinarizationValidator(BaseValidator):
     平均適応的2値化用のバリデータ.
 
     Args:
-        config (Dict[str, Any]): バリデーション対象の設定辞書.
+        config (dict[str, Any]): バリデーション対象の設定辞書.
 
     Raises:
         ProcessorValidationError: 不正なパラメータが検出された場合.
     """
 
-    def __init__(self, config: Dict[str, Any]) -> None:
+    def __init__(self, config: dict[str, Any]) -> None:
         """
         MeanAdaptiveBinarizationValidatorのコンストラクタ.
 
         Args:
-            config (Dict[str, Any]): バリデーション対象の設定辞書.
+            config (dict[str, Any]): バリデーション対象の設定辞書.
         """
         self.config = config
 

--- a/pochivision/processors/validators/binarization/otsu.py
+++ b/pochivision/processors/validators/binarization/otsu.py
@@ -1,7 +1,5 @@
 """大津の2値化バリデータの実装モジュール."""
 
-from typing import Dict
-
 import numpy as np
 
 from pochivision.exceptions import ProcessorValidationError
@@ -13,18 +11,18 @@ class OtsuBinarizationValidator(BaseValidator):
     大津の2値化用のバリデータ.
 
     Args:
-        config (Dict[str, int]): バリデーション対象の設定辞書.
+        config (dict[str, int]): バリデーション対象の設定辞書.
 
     Raises:
         ProcessorValidationError: 不正なパラメータが検出された場合.
     """
 
-    def __init__(self, config: Dict[str, int]) -> None:
+    def __init__(self, config: dict[str, int]) -> None:
         """
         OtsuBinarizationValidatorのコンストラクタ.
 
         Args:
-            config (Dict[str, int]): バリデーション対象の設定辞書.
+            config (dict[str, int]): バリデーション対象の設定辞書.
         """
         self.config = config
 

--- a/pochivision/processors/validators/binarization/standard.py
+++ b/pochivision/processors/validators/binarization/standard.py
@@ -1,7 +1,5 @@
 """標準2値化バリデータの実装モジュール."""
 
-from typing import Dict
-
 import numpy as np
 
 from pochivision.exceptions import ProcessorValidationError
@@ -19,7 +17,7 @@ class StandardBinarizationValidator(BaseValidator):
         ProcessorValidationError: 不正なパラメータが検出された場合.
     """
 
-    def __init__(self, config: Dict[str, int]) -> None:
+    def __init__(self, config: dict[str, int]) -> None:
         """
         StandardBinarizationValidatorのコンストラクタ.
 

--- a/pochivision/processors/validators/blur/average.py
+++ b/pochivision/processors/validators/blur/average.py
@@ -1,6 +1,6 @@
 """平均ブラー用バリデータの実装モジュール."""
 
-from typing import Any, Dict
+from typing import Any
 
 import numpy as np
 
@@ -11,7 +11,7 @@ from pochivision.processors.validators.base import BaseValidator
 class AverageBlurValidator(BaseValidator):
     """平均ブラー用のバリデータ."""
 
-    def __init__(self, config: Dict[str, Any]) -> None:
+    def __init__(self, config: dict[str, Any]) -> None:
         """
         AverageBlurValidatorのコンストラクタ.
 

--- a/pochivision/processors/validators/blur/bilateral.py
+++ b/pochivision/processors/validators/blur/bilateral.py
@@ -1,6 +1,6 @@
 """バイラテラルフィルタ用バリデータの実装モジュール."""
 
-from typing import Any, Dict
+from typing import Any
 
 import numpy as np
 
@@ -11,7 +11,7 @@ from pochivision.processors.validators.base import BaseValidator
 class BilateralFilterValidator(BaseValidator):
     """バイラテラルフィルタ用のバリデータ."""
 
-    def __init__(self, config: Dict[str, Any]) -> None:
+    def __init__(self, config: dict[str, Any]) -> None:
         """
         BilateralFilterValidatorのコンストラクタ.
 

--- a/pochivision/processors/validators/blur/gaussian.py
+++ b/pochivision/processors/validators/blur/gaussian.py
@@ -1,6 +1,6 @@
 """ガウシアンブラー用バリデータの実装モジュール."""
 
-from typing import Any, Dict
+from typing import Any
 
 import numpy as np
 
@@ -11,7 +11,7 @@ from pochivision.processors.validators.base import BaseValidator
 class GaussianBlurValidator(BaseValidator):
     """ガウシアンブラー用のバリデータ."""
 
-    def __init__(self, config: Dict[str, Any]) -> None:
+    def __init__(self, config: dict[str, Any]) -> None:
         """
         GaussianBlurValidatorのコンストラクタ.
 

--- a/pochivision/processors/validators/blur/median.py
+++ b/pochivision/processors/validators/blur/median.py
@@ -1,6 +1,6 @@
 """メディアンブラー用バリデータの実装モジュール."""
 
-from typing import Any, Dict
+from typing import Any
 
 import numpy as np
 
@@ -11,7 +11,7 @@ from pochivision.processors.validators.base import BaseValidator
 class MedianBlurValidator(BaseValidator):
     """メディアンブラー用のバリデータ."""
 
-    def __init__(self, config: Dict[str, Any]) -> None:
+    def __init__(self, config: dict[str, Any]) -> None:
         """
         MedianBlurValidatorのコンストラクタ.
 

--- a/pochivision/processors/validators/blur/motion.py
+++ b/pochivision/processors/validators/blur/motion.py
@@ -1,6 +1,6 @@
 """モーションブラー用バリデータの実装モジュール."""
 
-from typing import Any, Dict
+from typing import Any
 
 import numpy as np
 
@@ -11,7 +11,7 @@ from pochivision.processors.validators.base import BaseValidator
 class MotionBlurValidator(BaseValidator):
     """モーションブラー用のバリデータ."""
 
-    def __init__(self, config: Dict[str, Any]) -> None:
+    def __init__(self, config: dict[str, Any]) -> None:
         """
         MotionBlurValidatorのコンストラクタ.
 

--- a/pochivision/processors/validators/clahe/clahe.py
+++ b/pochivision/processors/validators/clahe/clahe.py
@@ -1,6 +1,6 @@
 """CLAHE入力バリデータの実装モジュール."""
 
-from typing import Any, Dict, Optional
+from typing import Any
 
 import numpy as np
 
@@ -11,12 +11,12 @@ from pochivision.processors.validators.base import BaseValidator
 class CLAHEInputValidator(BaseValidator):
     """CLAHE入力用のバリデータ."""
 
-    def __init__(self, config: Optional[Dict[str, Any]] = None) -> None:
+    def __init__(self, config: dict[str, Any] | None = None) -> None:
         """
         CLAHEInputValidatorのコンストラクタ.
 
         Args:
-            config (Optional[Dict[str, Any]], optional): 設定パラメータ. デフォルトはNone.
+            config (dict[str, Any] | None, optional): 設定パラメータ. デフォルトはNone.
         """
         self.config = config or {}
 

--- a/pochivision/processors/validators/contour/contour.py
+++ b/pochivision/processors/validators/contour/contour.py
@@ -1,6 +1,6 @@
 """輪郭抽出プロセッサーのバリデータを定義するモジュール."""
 
-from typing import Any, Dict, Tuple
+from typing import Any
 
 import numpy as np
 
@@ -12,12 +12,12 @@ from pochivision.utils.image import to_grayscale
 class ContourValidator(BaseValidator):
     """輪郭抽出処理のためのバリデータ."""
 
-    def __init__(self, config: Dict[str, Any]) -> None:
+    def __init__(self, config: dict[str, Any]) -> None:
         """
         ContourValidatorのコンストラクタ.
 
         Args:
-            config (Dict[str, Any]): バリデーション対象の設定辞書.
+            config (dict[str, Any]): バリデーション対象の設定辞書.
         """
         self.config = config
 
@@ -69,7 +69,7 @@ class ContourValidator(BaseValidator):
             msg_part2 = "or 3/4 channel color image."
             raise ProcessorValidationError(msg_part1 + msg_part2)
 
-    def validate_image_for_contour(self, image: np.ndarray) -> Tuple[bool, str]:
+    def validate_image_for_contour(self, image: np.ndarray) -> tuple[bool, str]:
         """
         輪郭抽出処理のための画像検証を行い、二値化画像かどうかを返す.
 
@@ -77,7 +77,7 @@ class ContourValidator(BaseValidator):
             image (np.ndarray): 入力画像.
 
         Returns:
-            Tuple[bool, str]: 画像が適切かどうかのフラグとメッセージのタプル.
+            tuple[bool, str]: 画像が適切かどうかのフラグとメッセージのタプル.
                               (True, "") なら問題なし、(False, "エラーメッセージ") なら問題あり
         """
         try:

--- a/pochivision/processors/validators/edge_detection/canny.py
+++ b/pochivision/processors/validators/edge_detection/canny.py
@@ -1,6 +1,6 @@
 """Cannyエッジ検出プロセッサーの設定バリデーターを定義します."""
 
-from typing import Any, Dict
+from typing import Any
 
 import numpy as np  # numpy をインポート
 
@@ -15,14 +15,14 @@ from ..base import BaseValidator
 class CannyEdgeValidator(BaseValidator):  # クラス名を CannyEdgeValidator に変更
     """CannyEdgeProcessor設定および入力画像のバリデーター."""
 
-    def __init__(self, config: Dict[str, Any]):
+    def __init__(self, config: dict[str, Any]):
         """
         CannyEdgeValidatorを初期化します.
 
         Args:
-            config (Dict[str, Any]): 検証対象の設定.
+            config (dict[str, Any]): 検証対象の設定.
         """
-        self.config: Dict[str, Any] = config
+        self.config: dict[str, Any] = config
 
     def validate_image(self, image: np.ndarray) -> None:
         """

--- a/pochivision/processors/validators/equalize/equalize.py
+++ b/pochivision/processors/validators/equalize/equalize.py
@@ -1,6 +1,6 @@
 """ヒストグラム平坦化入力バリデータの実装モジュール."""
 
-from typing import Any, Dict, Optional
+from typing import Any
 
 import numpy as np
 
@@ -11,12 +11,12 @@ from pochivision.processors.validators.base import BaseValidator
 class EqualizeInputValidator(BaseValidator):
     """ヒストグラム平坦化入力用のバリデータ."""
 
-    def __init__(self, config: Optional[Dict[str, Any]] = None) -> None:
+    def __init__(self, config: dict[str, Any] | None = None) -> None:
         """
         EqualizeInputValidatorのコンストラクタ.
 
         Args:
-            config (Optional[Dict[str, Any]], optional): 設定パラメータ. デフォルトはNone.
+            config (dict[str, Any] | None, optional): 設定パラメータ. デフォルトはNone.
         """
         self.config = config or {}
 

--- a/pochivision/processors/validators/grayscale/grayscale.py
+++ b/pochivision/processors/validators/grayscale/grayscale.py
@@ -1,6 +1,6 @@
 """グレースケール変換バリデータの実装モジュール."""
 
-from typing import Any, Dict
+from typing import Any
 
 import numpy as np
 
@@ -11,12 +11,12 @@ from pochivision.processors.validators.base import BaseValidator
 class GrayscaleValidator(BaseValidator):
     """グレースケール変換用のバリデータ."""
 
-    def __init__(self, config: Dict[str, Any]) -> None:
+    def __init__(self, config: dict[str, Any]) -> None:
         """
         GrayscaleValidatorのコンストラクタ.
 
         Args:
-            config (Dict[str, Any]): バリデーション対象の設定辞書.
+            config (dict[str, Any]): バリデーション対象の設定辞書.
         """
         self.config = config
 

--- a/pochivision/processors/validators/mask_composition/mask_composition.py
+++ b/pochivision/processors/validators/mask_composition/mask_composition.py
@@ -1,6 +1,6 @@
 """マスク合成プロセッサのバリデータを定義."""
 
-from typing import Any, Dict
+from typing import Any
 
 import cv2
 import numpy as np
@@ -12,12 +12,12 @@ from pochivision.processors.validators.base import BaseValidator
 class MaskCompositionValidator(BaseValidator):
     """マスク合成プロセッサの設定と入力画像を検証するバリデータ."""
 
-    def __init__(self, config: Dict[str, Any]):
+    def __init__(self, config: dict[str, Any]):
         """
         MaskCompositionValidatorを初期化.
 
         Args:
-            config (Dict[str, Any]): 設定パラメータ.
+            config (dict[str, Any]): 設定パラメータ.
         """
         self.config = config
 

--- a/pochivision/processors/validators/resize/resize.py
+++ b/pochivision/processors/validators/resize/resize.py
@@ -1,6 +1,6 @@
 """リサイズプロセッサー用バリデータの実装モジュール."""
 
-from typing import Any, Dict
+from typing import Any
 
 import numpy as np
 
@@ -10,12 +10,12 @@ from pochivision.processors.validators.base import BaseValidator
 class ResizeConfigValidator(BaseValidator):
     """リサイズプロセッサー用のバリデータ."""
 
-    def __init__(self, config: Dict[str, Any]) -> None:
+    def __init__(self, config: dict[str, Any]) -> None:
         """
         ResizeConfigValidatorのコンストラクタ.
 
         Args:
-            config (Dict[str, Any]): バリデーション対象の設定辞書.
+            config (dict[str, Any]): バリデーション対象の設定辞書.
         """
         self.config = config
 

--- a/pochivision/utils/file_naming.py
+++ b/pochivision/utils/file_naming.py
@@ -1,7 +1,6 @@
 """ファイル命名規則を管理するユーティリティモジュール."""
 
 from datetime import datetime
-from typing import Dict, Tuple
 
 
 class FileNamingManager:
@@ -9,16 +8,16 @@ class FileNamingManager:
     画像ファイルの命名規則を管理するクラス.
 
     Attributes:
-        image_counters (Dict[Tuple[int, str], int]): カメラとプレフィックスごとの画像カウンタ
-        id_intervals (Dict[Tuple[int, str], int]): カメラとプレフィックスごとのID増加間隔
-        labels (Dict[int, str]): カメラごとのラベル
+        image_counters (dict[tuple[int, str], int]): カメラとプレフィックスごとの画像カウンタ
+        id_intervals (dict[tuple[int, str], int]): カメラとプレフィックスごとのID増加間隔
+        labels (dict[int, str]): カメラごとのラベル
     """
 
     def __init__(self) -> None:
         """FileNamingManagerのコンストラクタ."""
-        self.image_counters: Dict[Tuple[int, str], int] = {}
-        self.id_intervals: Dict[Tuple[int, str], int] = {}
-        self.labels: Dict[int, str] = {}  # カメラごとのラベル
+        self.image_counters: dict[tuple[int, str], int] = {}
+        self.id_intervals: dict[tuple[int, str], int] = {}
+        self.labels: dict[int, str] = {}  # カメラごとのラベル
 
     def set_id_interval(
         self, prefix: str, camera_index: int, interval: int = 1
@@ -46,7 +45,7 @@ class FileNamingManager:
 
     def get_filename(
         self, prefix: str, camera_index: int, extension: str = "bmp"
-    ) -> Tuple[str, int, int]:
+    ) -> tuple[str, int, int]:
         """
         指定されたプレフィックスと拡張子で新しいファイル名を生成します.
 
@@ -59,7 +58,7 @@ class FileNamingManager:
             extension (str): ファイルの拡張子（デフォルトは'bmp'）
 
         Returns:
-            Tuple[str, int, int]: 生成されたファイル名、ID値、画像カウンタ値のタプル
+            tuple[str, int, int]: 生成されたファイル名、ID値、画像カウンタ値のタプル
         """
         # カメラとプレフィックスのセットをキーとして使用
         key = (camera_index, prefix)

--- a/pochivision/utils/image.py
+++ b/pochivision/utils/image.py
@@ -1,7 +1,6 @@
 """画像処理に関する共通ユーティリティ関数を提供するモジュール."""
 
 from pathlib import Path
-from typing import List, Optional
 
 import cv2
 import numpy as np
@@ -9,7 +8,7 @@ import numpy as np
 DEFAULT_IMAGE_EXTENSIONS = [".jpg", ".jpeg", ".png", ".bmp", ".tiff", ".tif"]
 
 
-def load_image(image_path: Path) -> Optional[np.ndarray]:
+def load_image(image_path: Path) -> np.ndarray | None:
     """画像ファイルを読み込む.
 
     Args:
@@ -26,9 +25,9 @@ def load_image(image_path: Path) -> Optional[np.ndarray]:
 
 def get_image_files(
     directory: Path,
-    extensions: Optional[List[str]] = None,
+    extensions: list[str] | None = None,
     case_sensitive: bool = False,
-) -> List[Path]:
+) -> list[Path]:
     """ディレクトリから画像ファイルのパスリストを取得する.
 
     Args:
@@ -42,7 +41,7 @@ def get_image_files(
     if extensions is None:
         extensions = DEFAULT_IMAGE_EXTENSIONS
 
-    image_files: List[Path] = []
+    image_files: list[Path] = []
     for ext in extensions:
         if case_sensitive:
             image_files.extend(directory.glob(f"*{ext}"))

--- a/pochivision/utils/image_aggregation/aggregator.py
+++ b/pochivision/utils/image_aggregation/aggregator.py
@@ -2,7 +2,6 @@
 
 import shutil
 from pathlib import Path
-from typing import Dict, List, Tuple
 
 from tqdm import tqdm
 
@@ -42,8 +41,8 @@ class ImageAggregator:
         self.mode = mode
 
     def _collect_all_image_files(
-        self, processor_types: Dict[str, List[Path]]
-    ) -> Tuple[List[Tuple[Path, Path]], Path]:
+        self, processor_types: dict[str, list[Path]]
+    ) -> tuple[list[tuple[Path, Path]], Path]:
         """
         すべての画像ファイルとその出力先を収集する.
 

--- a/pochivision/utils/image_aggregation/folder_finder.py
+++ b/pochivision/utils/image_aggregation/folder_finder.py
@@ -1,7 +1,6 @@
 """処理フォルダの検索を行うモジュール."""
 
 from pathlib import Path
-from typing import Dict, List
 
 
 class ProcessorFolderFinder:
@@ -21,14 +20,14 @@ class ProcessorFolderFinder:
         """
         self.base_dir = base_dir
 
-    def find_processor_types(self) -> Dict[str, List[Path]]:
+    def find_processor_types(self) -> dict[str, list[Path]]:
         """
         カメラフォルダ内のすべての機能（プロセッサタイプ）フォルダを検出する.
 
         Returns:
             プロセッサタイプをキー、そのフォルダパスのリストを値とする辞書
         """
-        processor_types: Dict[str, List[Path]] = {}
+        processor_types: dict[str, list[Path]] = {}
 
         print(f"Scanning camera directory: {self.base_dir.name}")
 


### PR DESCRIPTION
## Summary

- 型アノテーションを Python 3.12+ 新スタイルに統一した.

## Related Issue

Closes #327

## Changes

- `Dict` → `dict`, `List` → `list`, `Tuple` → `tuple`, `Optional[X]` → `X | None`, `Union[X, Y]` → `X | Y`, `Type[X]` → `type[X]`
- 不要になった `from typing import ...` を削除
- 52ファイル, 427行追加 / 452行削除

## Test Plan

- `uv run pre-commit run --all-files` が通過する
- `uv run pytest` が通過する (489テスト)
- `uv run mypy .` が通過する

## Checklist

- [x] `Dict`, `List`, `Tuple`, `Optional`, `Union`, `Type` が pochivision/ 内で使用されていない
- [x] `Any`, `Callable` は引き続き typing からインポート
- [x] pre-commit チェック通過
