### PR TITLE
fix: _resize_for_preview() でフレームサイズ 0 の除算ゼロを防止

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@
 - 型アノテーションを Python 3.12+ 新スタイル (`dict`, `list`, `tuple`, `X | None`) に統一. ([#333](https://github.com/kurorosu/pochivision/pull/333))
 
 ### Fixed
-- `RecordingManager.stop_recording()` の `is_recording` チェックをロック内に移動し race condition を修正. (NA.)
+- `RecordingManager.stop_recording()` の `is_recording` チェックをロック内に移動し race condition を修正. ([#334](https://github.com/kurorosu/pochivision/pull/334))
+- `_resize_for_preview()` でフレームサイズが 0 の場合に元フレームを返す防御コードを追加. (NA.)
 
 ### Removed
 - `RecordingManager` の未使用属性 `frame_queue`, `recording_thread` を削除. ([#320](https://github.com/kurorosu/pochivision/pull/320))

--- a/pochivision/capture_runner/viewer.py
+++ b/pochivision/capture_runner/viewer.py
@@ -61,6 +61,9 @@ class LivePreviewRunner:
             np.ndarray: リサイズされたフレーム.
         """
         h, w = frame.shape[:2]
+        if w == 0 or h == 0:
+            self.logger.warning(f"Invalid frame size: ({w}, {h}), skipping resize")
+            return frame
         max_w, max_h = self.preview_size
         scale = min(max_w / w, max_h / h)
         new_w = int(w * scale)


### PR DESCRIPTION

## Summary

- `_resize_for_preview()` でフレームの幅または高さが 0 の場合に除算ゼロエラーが発生する問題を修正した.

## Related Issue

Closes #323

## Changes

- `w == 0 or h == 0` の場合に警告ログを出力し, 元フレームをそのまま返す防御コードを追加

## Test Plan

- `uv run pre-commit run --all-files` が通過する
- `uv run pytest` が通過する

## Checklist

- [x] `w` または `h` が 0 の場合に `ZeroDivisionError` が発生しない
- [x] pre-commit チェック通過
