### PR TITLE
fix: CircleCounterExtractor の circle_density 計算で除算ゼロを防止

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@
 
 ### Fixed
 - `RecordingManager.stop_recording()` の `is_recording` チェックをロック内に移動し race condition を修正. ([#334](https://github.com/kurorosu/pochivision/pull/334))
-- `_resize_for_preview()` でフレームサイズが 0 の場合に元フレームを返す防御コードを追加. (NA.)
+- `_resize_for_preview()` でフレームサイズが 0 の場合に元フレームを返す防御コードを追加. ([#335](https://github.com/kurorosu/pochivision/pull/335))
+- `CircleCounterExtractor` の `circle_density` 計算で画像面積が 0 の場合に除算ゼロを防止. (NA.)
 
 ### Removed
 - `RecordingManager` の未使用属性 `frame_queue`, `recording_thread` を削除. ([#320](https://github.com/kurorosu/pochivision/pull/320))

--- a/pochivision/feature_extractors/circle_counter.py
+++ b/pochivision/feature_extractors/circle_counter.py
@@ -257,7 +257,9 @@ class CircleCounterExtractor(BaseFeatureExtractor):
             results["large_circle_count"] = large_count
 
             # 密度計算
-            results["circle_density"] = float(total_count / image_area)
+            results["circle_density"] = (
+                float(total_count / image_area) if image_area > 0 else 0.0
+            )
 
             # 半径統計
             results["avg_circle_radius"] = float(np.mean(radii))


### PR DESCRIPTION

## Summary

- `CircleCounterExtractor` の `circle_density` 計算で画像面積が 0 の場合に除算ゼロエラーが発生する問題を修正した.

## Related Issue

Closes #324

## Changes

- `image_area > 0` のガード条件を追加し, 面積 0 の場合は `0.0` を返すよう修正

## Test Plan

- `uv run pre-commit run --all-files` が通過する
- `uv run pytest` が通過する

## Checklist

- [x] `image_area` が 0 の場合に `ZeroDivisionError` が発生しない
- [x] pre-commit チェック通過
