### PR TITLE
fix: ResizeProcessor の aspect_ratio 計算で除算ゼロを防止

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@
 ### Fixed
 - `RecordingManager.stop_recording()` の `is_recording` チェックをロック内に移動し race condition を修正. ([#334](https://github.com/kurorosu/pochivision/pull/334))
 - `_resize_for_preview()` でフレームサイズが 0 の場合に元フレームを返す防御コードを追加. ([#335](https://github.com/kurorosu/pochivision/pull/335))
-- `CircleCounterExtractor` の `circle_density` 計算で画像面積が 0 の場合に除算ゼロを防止. (NA.)
+- `CircleCounterExtractor` の `circle_density` 計算で画像面積が 0 の場合に除算ゼロを防止. ([#336](https://github.com/kurorosu/pochivision/pull/336))
+- `ResizeProcessor` の `aspect_ratio` 計算で元画像の高さが 0 の場合に除算ゼロを防止. (NA.)
 
 ### Removed
 - `RecordingManager` の未使用属性 `frame_queue`, `recording_thread` を削除. ([#320](https://github.com/kurorosu/pochivision/pull/320))

--- a/pochivision/processors/resize.py
+++ b/pochivision/processors/resize.py
@@ -85,6 +85,9 @@ class ResizeProcessor(BaseProcessor):
                 self.height if self.height is not None else orig_height,
             )
 
+        if orig_height == 0:
+            return orig_width, orig_height
+
         aspect_ratio = orig_width / orig_height
 
         if self.aspect_ratio_mode == "width" and self.width is not None:


### PR DESCRIPTION

## Summary

- `ResizeProcessor` の `aspect_ratio` 計算で元画像の高さが 0 の場合に除算ゼロエラーが発生する問題を修正した.

## Related Issue

Closes #325

## Changes

- `orig_height == 0` の場合に元のサイズをそのまま返す早期リターンを追加

## Test Plan

- `uv run pre-commit run --all-files` が通過する
- `uv run pytest` が通過する

## Checklist

- [x] `orig_height` が 0 の場合に `ZeroDivisionError` が発生しない
- [x] pre-commit チェック通過
