### PR TITLE
test: 例外クラスのテスト 21 件を追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 ## [Unreleased]
 
 ### Added
-- 無し
+- 例外クラスのテスト 21 件を追加. (NA.)
 
 ### Changed
 - 無し

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,124 @@
+"""例外クラスのテスト."""
+
+import pytest
+
+from pochivision.exceptions import (
+    CameraConfigError,
+    ConfigLoadError,
+    ConfigValidationError,
+    ExtractorValidationError,
+    ProcessorRuntimeError,
+    ProcessorValidationError,
+    VisionCaptureError,
+)
+
+
+class TestVisionCaptureError:
+    """VisionCaptureError のテスト."""
+
+    def test_message(self):
+        err = VisionCaptureError("base error")
+        assert str(err) == "base error"
+
+    def test_inheritance(self):
+        assert issubclass(VisionCaptureError, Exception)
+
+    def test_raise_and_catch(self):
+        with pytest.raises(VisionCaptureError, match="base"):
+            raise VisionCaptureError("base")
+
+
+class TestConfigValidationError:
+    """ConfigValidationError のテスト."""
+
+    def test_message(self):
+        err = ConfigValidationError("invalid config")
+        assert str(err) == "invalid config"
+
+    def test_inheritance(self):
+        assert issubclass(ConfigValidationError, VisionCaptureError)
+        assert issubclass(ConfigValidationError, ValueError)
+
+    def test_raise_and_catch(self):
+        with pytest.raises(ValueError, match="invalid"):
+            raise ConfigValidationError("invalid")
+
+
+class TestConfigLoadError:
+    """ConfigLoadError のテスト."""
+
+    def test_message(self):
+        err = ConfigLoadError("file not found")
+        assert str(err) == "file not found"
+
+    def test_inheritance(self):
+        assert issubclass(ConfigLoadError, VisionCaptureError)
+        assert issubclass(ConfigLoadError, OSError)
+
+    def test_raise_and_catch(self):
+        with pytest.raises(OSError, match="file not found"):
+            raise ConfigLoadError("file not found")
+
+
+class TestCameraConfigError:
+    """CameraConfigError のテスト."""
+
+    def test_message(self):
+        err = CameraConfigError("bad camera")
+        assert str(err) == "bad camera"
+
+    def test_inheritance(self):
+        assert issubclass(CameraConfigError, VisionCaptureError)
+        assert issubclass(CameraConfigError, ValueError)
+
+    def test_raise_and_catch(self):
+        with pytest.raises(VisionCaptureError, match="bad camera"):
+            raise CameraConfigError("bad camera")
+
+
+class TestProcessorValidationError:
+    """ProcessorValidationError のテスト."""
+
+    def test_message(self):
+        err = ProcessorValidationError("invalid input")
+        assert str(err) == "invalid input"
+
+    def test_inheritance(self):
+        assert issubclass(ProcessorValidationError, VisionCaptureError)
+        assert issubclass(ProcessorValidationError, ValueError)
+
+    def test_raise_and_catch(self):
+        with pytest.raises(ValueError, match="invalid input"):
+            raise ProcessorValidationError("invalid input")
+
+
+class TestProcessorRuntimeError:
+    """ProcessorRuntimeError のテスト."""
+
+    def test_message(self):
+        err = ProcessorRuntimeError("processing failed")
+        assert str(err) == "processing failed"
+
+    def test_inheritance(self):
+        assert issubclass(ProcessorRuntimeError, VisionCaptureError)
+        assert issubclass(ProcessorRuntimeError, RuntimeError)
+
+    def test_raise_and_catch(self):
+        with pytest.raises(RuntimeError, match="processing failed"):
+            raise ProcessorRuntimeError("processing failed")
+
+
+class TestExtractorValidationError:
+    """ExtractorValidationError のテスト."""
+
+    def test_message(self):
+        err = ExtractorValidationError("bad image")
+        assert str(err) == "bad image"
+
+    def test_inheritance(self):
+        assert issubclass(ExtractorValidationError, VisionCaptureError)
+        assert issubclass(ExtractorValidationError, ValueError)
+
+    def test_raise_and_catch(self):
+        with pytest.raises(VisionCaptureError, match="bad image"):
+            raise ExtractorValidationError("bad image")


### PR DESCRIPTION
## Summary

- `pochivision/exceptions/` 配下の全 7 例外クラスに対するテスト 21 件を追加した.

## Related Issue

Closes #328

## Changes

- `tests/test_exceptions.py` を新規作成
- 各例外クラスに対して以下の 3 テストを実装:
  - インスタンス化とメッセージの確認
  - 継承関係の検証
  - `raise` / `pytest.raises()` での捕捉テスト

## Test Plan

- `uv run pre-commit run --all-files` が通過する
- `uv run pytest tests/test_exceptions.py` が通過する (21テスト)

## Checklist

- [x] 全 7 例外クラスのテストがある
- [x] 継承関係が検証されている
- [x] pre-commit チェック通過
