### PR TITLE
fix: _inferring フラグの check-then-act を threading.Lock で保護

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
   - 推論例外クラス (`InferenceError`, `InferenceConnectionError`)
   - テスト 25 件
 - 推論実行時にリサイズ+パディング後のフレーム画像を保存する機能を追加. `infer_config.json` の `save_frame` で有効/無効を制御. ([#355](https://github.com/kurorosu/pochivision/pull/355))
-- 推論結果を CSV ファイルに蓄積する機能を追加. `infer_config.json` の `save_csv` で有効/無効を制御. (NA.)
+- 推論結果を CSV ファイルに蓄積する機能を追加. `infer_config.json` の `save_csv` で有効/無効を制御. ([#356](https://github.com/kurorosu/pochivision/pull/356))
 
 ### Changed
 - 推論オーバーレイにクライアント側ネットワーク往復時間 (RTT) の表示を追加. ([#350](https://github.com/kurorosu/pochivision/pull/350))
@@ -20,6 +20,7 @@
 
 ### Fixed
 - 推論実行時にプレビューがブロックされる問題を修正. `_run_inference` をバックグラウンドスレッドで実行するよう変更し, 推論中の二重送信防止と "Inferring..." 表示を追加. ([#348](https://github.com/kurorosu/pochivision/pull/348))
+- `_inferring` フラグの check-then-act を `threading.Lock` で保護し, 推論の二重起動を確実に防止. (NA.)
 
 ### Removed
 - 無し

--- a/pochivision/capture_runner/viewer.py
+++ b/pochivision/capture_runner/viewer.py
@@ -61,6 +61,7 @@ class LivePreviewRunner:
         self.help_overlay = HelpOverlay()
         self.inference_overlay = InferenceOverlay()
         self._inferring = False
+        self._inferring_lock = threading.Lock()
         self._inference_thread: threading.Thread | None = None
 
     def _resize_for_preview(self, frame: np.ndarray) -> np.ndarray:
@@ -210,11 +211,13 @@ class LivePreviewRunner:
             )
             return
 
-        if self._inferring:
-            self.logger.info("Inference already in progress, skipping")
-            return
+        # Lock で check-then-act を保護し, 二重起動を確実に防止する.
+        with self._inferring_lock:
+            if self._inferring:
+                self.logger.info("Inference already in progress, skipping")
+                return
+            self._inferring = True
 
-        self._inferring = True
         self.inference_overlay.set_inferring(True)
         snapshot = frame.copy()
         self._inference_thread = threading.Thread(
@@ -249,7 +252,8 @@ class LivePreviewRunner:
             self.logger.error(f"Unexpected inference error: {e}")
         finally:
             self.inference_overlay.set_inferring(False)
-            self._inferring = False
+            with self._inferring_lock:
+                self._inferring = False
 
     def _save_inference_frame(self, frame: np.ndarray) -> str | None:
         """推論フレームをリサイズ+パディング後に画像ファイルとして保存する.

--- a/tests/capture_runner/test_run_inference.py
+++ b/tests/capture_runner/test_run_inference.py
@@ -1,0 +1,149 @@
+"""_run_inference のスレッドセーフ性テスト."""
+
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+
+from pochivision.capture_runner.viewer import LivePreviewRunner
+from pochivision.request.api.inference.client import InferenceClient
+from pochivision.request.api.inference.models import PredictResponse
+
+
+def _make_frame() -> np.ndarray:
+    """テスト用フレームを生成する."""
+    return np.zeros((100, 100, 3), dtype=np.uint8)
+
+
+def _make_result() -> PredictResponse:
+    """テスト用の PredictResponse を生成する."""
+    return PredictResponse(
+        class_id=0,
+        class_name="cat",
+        confidence=0.95,
+        probabilities=[0.95, 0.05],
+        e2e_time_ms=12.3,
+        backend="onnx",
+        rtt_ms=50.0,
+    )
+
+
+def _make_runner(tmp_path) -> LivePreviewRunner:
+    """テスト用の LivePreviewRunner を生成する."""
+    cap = MagicMock()
+    pipeline = MagicMock()
+    pipeline.output_dir = tmp_path
+
+    client = InferenceClient(base_url="http://localhost:8000")
+
+    return LivePreviewRunner(cap, pipeline, inference_client=client)
+
+
+class TestRunInferenceThreadSafety:
+    """_run_inference のスレッドセーフ性テスト."""
+
+    def test_concurrent_calls_only_one_executes(self, tmp_path):
+        """並行呼び出しで推論が 1 回だけ実行される."""
+        runner = _make_runner(tmp_path)
+        call_count = 0
+        barrier = threading.Barrier(2, timeout=5)
+
+        original_predict = runner.inference_client.predict  # type: ignore[union-attr]
+
+        def slow_predict(frame: np.ndarray) -> PredictResponse:
+            nonlocal call_count
+            call_count += 1
+            barrier.wait()
+            return _make_result()
+
+        with patch.object(runner.inference_client, "predict", side_effect=slow_predict):
+            frame = _make_frame()
+
+            # 2 スレッドから同時に _run_inference を呼び出す
+            t1 = threading.Thread(target=runner._run_inference, args=(frame,))
+            t2 = threading.Thread(target=runner._run_inference, args=(frame,))
+            t1.start()
+            t2.start()
+
+            # barrier で 1 スレッドしか来ないケースに備えてタイムアウト
+            t1.join(timeout=5)
+            t2.join(timeout=5)
+
+        # predict は 1 回のみ呼ばれるべき
+        assert call_count == 1
+
+        runner.inference_client.close()  # type: ignore[union-attr]
+
+    def test_inferring_flag_reset_after_completion(self, tmp_path):
+        """推論完了後に _inferring フラグがリセットされる."""
+        runner = _make_runner(tmp_path)
+
+        with patch.object(
+            runner.inference_client, "predict", return_value=_make_result()
+        ):
+            runner._run_inference(_make_frame())
+
+            # ワーカースレッド完了を待つ
+            if runner._inference_thread:
+                runner._inference_thread.join(timeout=5)
+
+        assert runner._inferring is False
+
+        runner.inference_client.close()  # type: ignore[union-attr]
+
+    def test_inferring_flag_reset_on_error(self, tmp_path):
+        """推論失敗時にも _inferring フラグがリセットされる."""
+        runner = _make_runner(tmp_path)
+
+        with patch.object(
+            runner.inference_client,
+            "predict",
+            side_effect=Exception("test error"),
+        ):
+            runner._run_inference(_make_frame())
+
+            if runner._inference_thread:
+                runner._inference_thread.join(timeout=5)
+
+        assert runner._inferring is False
+
+        runner.inference_client.close()  # type: ignore[union-attr]
+
+    def test_can_run_again_after_completion(self, tmp_path):
+        """推論完了後に再度推論を実行できる."""
+        runner = _make_runner(tmp_path)
+        call_count = 0
+
+        def counting_predict(frame: np.ndarray) -> PredictResponse:
+            nonlocal call_count
+            call_count += 1
+            return _make_result()
+
+        with patch.object(
+            runner.inference_client, "predict", side_effect=counting_predict
+        ):
+            # 1 回目
+            runner._run_inference(_make_frame())
+            if runner._inference_thread:
+                runner._inference_thread.join(timeout=5)
+
+            # 2 回目
+            runner._run_inference(_make_frame())
+            if runner._inference_thread:
+                runner._inference_thread.join(timeout=5)
+
+        assert call_count == 2
+
+        runner.inference_client.close()  # type: ignore[union-attr]
+
+    def test_no_client_returns_immediately(self, tmp_path):
+        """inference_client=None のとき即座に return する."""
+        cap = MagicMock()
+        pipeline = MagicMock()
+        pipeline.output_dir = tmp_path
+
+        runner = LivePreviewRunner(cap, pipeline)
+        runner._run_inference(_make_frame())
+
+        assert runner._inferring is False


### PR DESCRIPTION
## Summary

- `_inferring` フラグの check-then-act を `threading.Lock` で保護し, 推論の二重起動を確実に防止.

## Related Issue

Closes #354

## Changes

### 変更
- `viewer.py`: `_inferring_lock = threading.Lock()` を追加し, `_run_inference()` の check-then-act と `_inference_worker()` のフラグリセットを `with self._inferring_lock:` で保護

### 新規
- `test_run_inference.py`: スレッドセーフ性テスト 5 件 (並行呼び出し二重起動防止, 完了後フラグリセット, エラー時フラグリセット, 再実行可能, client=None)

## Test Plan

- [x] `uv run pytest tests/capture_runner/test_run_inference.py -v` で 5 件パス
- [x] `uv run pytest` で全テストパス
- [x] `uv run pre-commit run --all-files` 全件パス
- [x] 推論トリガーキー連打で二重起動されないこと

## Checklist

- [x] `uv run pre-commit run --all-files` 全件パス
- [x] CHANGELOG.md 更新 (`(NA.)` → `#356` 置換, 新エントリ追加)
