### PR TITLE
fix: GaussianBlur/MedianBlur のカーネル奇数チェックを追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - 無し
 
 ### Fixed
-- 無し
+- `GaussianBlurProcessor` / `MedianBlurProcessor` のカーネルサイズに対する奇数チェックを追加. 偶数・0 以下・1 を設定した場合, 実行時の `cv2.error` ではなく起動時に `ProcessorValidationError` を投げるよう修正. ([#(NA.)](https://github.com/kurorosu/pochivision/pull/))
 
 ### Removed
 - 無し

--- a/pochivision/processors/schema.py
+++ b/pochivision/processors/schema.py
@@ -20,8 +20,19 @@ from pydantic import (
 class GaussianBlurParams(BaseModel):
     """ガウシアンブラーのパラメータスキーマ."""
 
-    kernel_size: list[StrictInt]
+    kernel_size: list[StrictInt] = Field(min_length=2, max_length=2)
     sigma: StrictFloat = Field(ge=0)
+
+    @field_validator("kernel_size")
+    @classmethod
+    def kernel_size_must_be_odd(cls, v: list[int]) -> list[int]:
+        """kernel_size の各要素は 3 以上の奇数でなければならない."""
+        for item in v:
+            if item < 3 or item % 2 == 0:
+                raise ValueError(
+                    f"kernel_size elements must be odd integers >= 3, got {v}"
+                )
+        return v
 
 
 class AverageBlurParams(BaseModel):
@@ -33,7 +44,15 @@ class AverageBlurParams(BaseModel):
 class MedianBlurParams(BaseModel):
     """メディアンブラーのパラメータスキーマ."""
 
-    kernel_size: StrictInt
+    kernel_size: StrictInt = Field(ge=3)
+
+    @field_validator("kernel_size")
+    @classmethod
+    def kernel_size_must_be_odd(cls, v: int) -> int:
+        """kernel_size は奇数でなければならない."""
+        if v % 2 == 0:
+            raise ValueError(f"kernel_size must be odd, got {v}")
+        return v
 
 
 class GrayscaleParams(BaseModel):

--- a/pochivision/processors/validators/blur/gaussian.py
+++ b/pochivision/processors/validators/blur/gaussian.py
@@ -17,8 +17,44 @@ class GaussianBlurValidator(BaseValidator):
 
         Args:
             config (dict): バリデーション対象の設定辞書.
+
+        Raises:
+            ProcessorValidationError: 設定が不正な場合.
         """
         self.config = config
+        self.validate_config(config)
+
+    def validate_config(self, config: dict[str, Any]) -> None:
+        """
+        設定のバリデーションを実行する.
+
+        kernel_size は長さ 2 の list/tuple で, 両要素とも 3 以上の奇数でなければならない.
+
+        Args:
+            config (dict): バリデーション対象の設定辞書.
+
+        Raises:
+            ProcessorValidationError: kernel_size が不正な場合.
+        """
+        if "kernel_size" not in config:
+            # kernel_size 未指定時はデフォルト値を使用するため検証不要
+            return
+
+        kernel_size = config["kernel_size"]
+        if not isinstance(kernel_size, (list, tuple)) or len(kernel_size) != 2:
+            raise ProcessorValidationError(
+                "kernel_size must be a list/tuple of length 2, " f"got {kernel_size!r}"
+            )
+        for v in kernel_size:
+            if not isinstance(v, int) or isinstance(v, bool):
+                raise ProcessorValidationError(
+                    f"kernel_size elements must be int, got {v!r}"
+                )
+            if v < 3 or v % 2 == 0:
+                raise ProcessorValidationError(
+                    "kernel_size elements must be odd integers >= 3, "
+                    f"got {kernel_size!r}"
+                )
 
     def validate_image(self, image: np.ndarray) -> None:
         """

--- a/pochivision/processors/validators/blur/median.py
+++ b/pochivision/processors/validators/blur/median.py
@@ -17,8 +17,38 @@ class MedianBlurValidator(BaseValidator):
 
         Args:
             config (dict): バリデーション対象の設定辞書.
+
+        Raises:
+            ProcessorValidationError: 設定が不正な場合.
         """
         self.config = config
+        self.validate_config(config)
+
+    def validate_config(self, config: dict[str, Any]) -> None:
+        """
+        設定のバリデーションを実行する.
+
+        kernel_size はスカラー整数で, 3 以上の奇数でなければならない.
+
+        Args:
+            config (dict): バリデーション対象の設定辞書.
+
+        Raises:
+            ProcessorValidationError: kernel_size が不正な場合.
+        """
+        if "kernel_size" not in config:
+            # kernel_size 未指定時はデフォルト値を使用するため検証不要
+            return
+
+        kernel_size = config["kernel_size"]
+        if not isinstance(kernel_size, int) or isinstance(kernel_size, bool):
+            raise ProcessorValidationError(
+                f"kernel_size must be an int, got {kernel_size!r}"
+            )
+        if kernel_size < 3 or kernel_size % 2 == 0:
+            raise ProcessorValidationError(
+                f"kernel_size must be an odd integer >= 3, got {kernel_size!r}"
+            )
 
     def validate_image(self, image: np.ndarray) -> None:
         """

--- a/tests/processors/test_blur_processors.py
+++ b/tests/processors/test_blur_processors.py
@@ -126,6 +126,57 @@ def test_bilateral_filter_valid():
     assert result.dtype == np.uint8
 
 
+# GaussianBlur kernel_size バリデーション
+@pytest.mark.parametrize(
+    "kernel_size",
+    [[3, 3], [5, 5], [15, 15], (3, 3)],
+)
+def test_gaussian_blur_valid_kernel_size(kernel_size):
+    """GaussianBlur: 3 以上の奇数ペアで初期化が通ることを確認."""
+    config = {"kernel_size": kernel_size, "sigma": 1}
+    processor = GaussianBlurProcessor(name="gaussian_blur_ok", config=config)
+    assert processor.kernel_size == (kernel_size[0], kernel_size[1])
+
+
+@pytest.mark.parametrize(
+    "kernel_size",
+    [
+        [4, 4],  # 偶数
+        [3, 4],  # 片方偶数
+        [1, 1],  # 3 未満
+        [0, 0],  # 0
+        [-1, 3],  # 負数
+        [3],  # 長さ不正
+        5,  # list/tuple でない
+    ],
+)
+def test_gaussian_blur_invalid_kernel_size(kernel_size):
+    """GaussianBlur: 偶数・0・負数・長さ不正で ProcessorValidationError が発生."""
+    config = {"kernel_size": kernel_size, "sigma": 1}
+    with pytest.raises(ProcessorValidationError, match="kernel_size"):
+        GaussianBlurProcessor(name="gaussian_blur_ng", config=config)
+
+
+# MedianBlur kernel_size バリデーション
+@pytest.mark.parametrize("kernel_size", [3, 5, 15])
+def test_median_blur_valid_kernel_size(kernel_size):
+    """MedianBlur: 3 以上の奇数スカラーで初期化が通ることを確認."""
+    config = {"kernel_size": kernel_size}
+    processor = MedianBlurProcessor(name="median_blur_ok", config=config)
+    assert processor.kernel_size == kernel_size
+
+
+@pytest.mark.parametrize(
+    "kernel_size",
+    [4, 0, 1, -1, -3, [3, 3]],
+)
+def test_median_blur_invalid_kernel_size(kernel_size):
+    """MedianBlur: 偶数・0・1・負数・非 int で ProcessorValidationError が発生."""
+    config = {"kernel_size": kernel_size}
+    with pytest.raises(ProcessorValidationError, match="kernel_size"):
+        MedianBlurProcessor(name="median_blur_ng", config=config)
+
+
 # MotionBlur
 def test_motion_blur_valid():
     """モーションブラーの基本機能をテスト."""


### PR DESCRIPTION
## Summary

- `GaussianBlurProcessor` / `MedianBlurProcessor` のカーネル奇数チェックが未実装で, 偶数値で実行時に `cv2.error` が発生していた問題を修正.
- バリデータの `validate_config` と Pydantic スキーマの両方で検証する多層防御とし, 起動時に `ProcessorValidationError` を送出するよう変更.

## Related Issue

Closes #370

## Changes

- `pochivision/processors/validators/blur/gaussian.py`: `validate_config` を追加. `kernel_size` が長さ 2 の list/tuple で両要素が 3 以上の奇数であることを検証.
- `pochivision/processors/validators/blur/median.py`: `validate_config` を追加. `kernel_size` がスカラー整数で 3 以上の奇数であることを検証.
- `pochivision/processors/schema.py`: `GaussianBlurParams` / `MedianBlurParams` に `field_validator` を追加.
- `tests/processors/test_blur_processors.py`: 有効/無効な `kernel_size` パターンのパラメトリックテストを追加.
- `CHANGELOG.md`: `[Unreleased] Fixed` にエントリ追加.

## Test Plan

- [x] 偶数 (4, [4,4]), 0, 1, 負数の `kernel_size` で `ProcessorValidationError` が送出される
- [x] 奇数 3 以上 (3, 5, 15, [3,3], [15,15]) で初期化が通る

## Checklist

- [x] `uv run pre-commit run --all-files` 全 pass
