### PR TITLE
fix: mask_composition のマスク合成ロジックを明確化しクリーンアップ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - 無し
 
 ### Fixed
-- 無し
+- `MaskCompositionProcessor` のマスク合成ロジックを明確化. 白領域に `target_image` を出力し 黒領域は 0 で埋めるセマンティクスに統一. 不要なカラー往復変換を削除し, shape/dtype のミスマッチ検証を追加. ([#(NA.)](https://github.com/kurorosu/pochivision/pull/(NA.)))
 
 ### Removed
 - 無し

--- a/pochivision/processors/mask_composition.py
+++ b/pochivision/processors/mask_composition.py
@@ -5,7 +5,7 @@ from typing import Any
 import cv2
 import numpy as np
 
-from pochivision.exceptions import ProcessorRuntimeError
+from pochivision.exceptions import ProcessorRuntimeError, ProcessorValidationError
 from pochivision.processors import BaseProcessor
 from pochivision.processors.registry import register_processor
 from pochivision.processors.resize import ResizeProcessor
@@ -14,14 +14,24 @@ from pochivision.processors.validators.mask_composition import MaskCompositionVa
 
 @register_processor("mask_composition")
 class MaskCompositionProcessor(BaseProcessor):
-    """
-    2値化画像をマスクとして使用し、元画像と合成するプロセッサー.
+    """2値化画像をマスクとして使用し ターゲット画像と合成するプロセッサ.
 
-    2値化画像の白ピクセル部分または黒ピクセル部分を、指定した元画像のピクセルで置き換えます。
-    マスク画像とターゲット画像のサイズが異なる場合は、ターゲット画像をリサイズします。
-    オプションで、マスクの白ピクセル領域に基づいてトリミングを行うことができます。
+    セマンティクス:
+        入力された 2値マスク画像の白領域 (画素値 >= 128) を "有効" 領域とみなし,
+        その部分に ``target_image`` のピクセルを出力する.
+        "無効" 領域 (画素値 < 128) は黒 (0) で埋める.
 
-    このプロセッサはパイプラインモードでのみ使用可能です。パラレルモードでは動作しません。
+        ``use_white_pixels=False`` の場合はマスクの白黒を反転した上で上記規則を
+        適用するため, 黒領域に ``target_image`` が出力される.
+
+        以前の実装では無効領域に元のマスク画像 (必要に応じてカラー化したもの) を
+        重ねる不明瞭な挙動があったが, 直感に反するため本バージョンから削除した.
+
+    マスク画像とターゲット画像のサイズが異なる場合, ターゲット画像を
+    マスク画像のサイズにリサイズする.
+    オプションで, マスクの白ピクセル領域に基づいてトリミングを行うことができる.
+
+    このプロセッサはパイプラインモードでのみ使用可能. パラレルモードでは動作しない.
 
     登録名:
         "mask_composition"
@@ -30,11 +40,11 @@ class MaskCompositionProcessor(BaseProcessor):
         {
             "mask_composition": {
                 "target_image": "original",
-                # 合成する元画像の識別子（"original"または他のプロセッサ名）
+                # 合成する元画像の識別子 ("original" または他のプロセッサ名)
                 "use_white_pixels": true,
-                # trueの場合、白ピクセル部分を元画像で置き換え。falseの場合は黒ピクセル部分を置き換え
+                # true: 白領域に target_image を出力. false: 黒領域に target_image を出力
                 "enable_cropping": false,
-                # trueの場合、マスクの白ピクセル領域に基づいてトリミングを実行
+                # true: マスクの白ピクセル領域に基づいてトリミング
                 "crop_margin": 5
                 # トリミング時の余白ピクセル数
             }
@@ -42,8 +52,7 @@ class MaskCompositionProcessor(BaseProcessor):
     """
 
     def __init__(self, name: str, config: dict[str, Any]) -> None:
-        """
-        MaskCompositionProcessorを初期化.
+        """プロセッサを初期化.
 
         Args:
             name (str): プロセッサ名.
@@ -68,20 +77,19 @@ class MaskCompositionProcessor(BaseProcessor):
         )
         self.crop_margin = self.config.get("crop_margin", default_config["crop_margin"])
 
-        # ターゲット画像（実行時に設定）
+        # ターゲット画像 (実行時に設定)
         self.target_image: np.ndarray | None = None
 
-        # リサイズプロセッサの準備（サイズはprocess内で動的設定）
+        # リサイズプロセッサの準備 (サイズは process 内で動的設定)
         resize_config = ResizeProcessor.get_default_config()
-        # マスク合成では正確なサイズ合わせが必要なため、アスペクト比保持を無効化
+        # マスク合成では正確なサイズ合わせが必要なため アスペクト比保持を無効化
         resize_config["preserve_aspect_ratio"] = False
         self.resize_processor = ResizeProcessor(
             name="resize_for_mask_composition", config=resize_config
         )
 
     def set_target_image(self, image: np.ndarray) -> None:
-        """
-        合成するターゲット画像を設定.
+        """合成するターゲット画像を設定.
 
         Args:
             image (np.ndarray): ターゲット画像.
@@ -89,8 +97,7 @@ class MaskCompositionProcessor(BaseProcessor):
         self.target_image = image
 
     def set_pipeline_mode(self, mode: str) -> None:
-        """
-        パイプラインモードを設定.
+        """パイプラインモードを設定.
 
         Args:
             mode (str): パイプラインモード ("pipeline" または "parallel").
@@ -104,32 +111,24 @@ class MaskCompositionProcessor(BaseProcessor):
             )
 
     def _find_crop_bounds(self, mask: np.ndarray) -> tuple[int, int, int, int] | None:
-        """
-        マスクの白ピクセル領域に基づいてトリミング範囲を計算.
+        """マスクの白ピクセル領域に基づいてトリミング範囲を計算.
 
         Args:
-            mask (np.ndarray): 2値化マスク画像（グレースケール）.
+            mask (np.ndarray): 2値化マスク画像 (グレースケール).
 
         Returns:
-            tuple[int, int, int, int] | None: トリミング範囲 (y_min, y_max, x_min, x_max)
-                                                白ピクセルが見つからない場合はNone
+            tuple[int, int, int, int] | None: トリミング範囲
+                (y_min, y_max, x_min, x_max). 白ピクセルが存在しない場合は None.
         """
-        # 白ピクセル（255）の座標を取得
         white_pixels = np.where(mask == 255)
-
         if len(white_pixels[0]) == 0:
-            # 白ピクセルが見つからない場合
             return None
 
-        # Y軸（行）の最小・最大値
         raw_y_min = int(np.min(white_pixels[0]))
         raw_y_max = int(np.max(white_pixels[0]))
-
-        # X軸（列）の最小・最大値
         raw_x_min = int(np.min(white_pixels[1]))
         raw_x_max = int(np.max(white_pixels[1]))
 
-        # マージンを適用（画像境界を超えないように調整）
         height, width = mask.shape
         y_min = max(0, raw_y_min - self.crop_margin)
         y_max = min(height - 1, raw_y_max + self.crop_margin)
@@ -141,12 +140,12 @@ class MaskCompositionProcessor(BaseProcessor):
     def _crop_image(
         self, image: np.ndarray, bounds: tuple[int, int, int, int]
     ) -> np.ndarray:
-        """
-        指定された範囲で画像をトリミング.
+        """指定された範囲で画像をトリミング.
 
         Args:
             image (np.ndarray): トリミング対象の画像.
-            bounds (tuple[int, int, int, int]): トリミング範囲 (y_min, y_max, x_min, x_max).
+            bounds (tuple[int, int, int, int]): トリミング範囲
+                (y_min, y_max, x_min, x_max).
 
         Returns:
             np.ndarray: トリミングされた画像.
@@ -154,69 +153,111 @@ class MaskCompositionProcessor(BaseProcessor):
         y_min, y_max, x_min, x_max = bounds
         return image[y_min : y_max + 1, x_min : x_max + 1]
 
-    def process(self, mask_image: np.ndarray) -> np.ndarray:
-        """
-        マスク画像を使用して元画像と合成.
+    def _to_grayscale_mask(self, mask_image: np.ndarray) -> np.ndarray:
+        """マスク画像をグレースケール 2値マスクに変換.
+
+        入力がカラー (3ch) の場合は BGR→GRAY 変換を行う.
+        既にグレースケール (2D) の場合はそのまま返す.
 
         Args:
-            mask_image (np.ndarray): マスク画像（2値化画像）.
+            mask_image (np.ndarray): マスク画像 (2D グレースケールまたは 3ch カラー).
 
         Returns:
-            np.ndarray: 合成後の画像.
+            np.ndarray: 2D グレースケールマスク.
+        """
+        if mask_image.ndim == 3:
+            return cv2.cvtColor(mask_image, cv2.COLOR_BGR2GRAY)
+        return mask_image
+
+    def _align_target_to_mask(
+        self, target_image: np.ndarray, mask_shape: tuple[int, ...]
+    ) -> np.ndarray:
+        """ターゲット画像をマスクの高さ/幅にリサイズ.
+
+        Args:
+            target_image (np.ndarray): ターゲット画像.
+            mask_shape (tuple[int, ...]): マスク画像の shape.
+
+        Returns:
+            np.ndarray: マスクと同じ (H, W) を持つターゲット画像.
+        """
+        if (
+            target_image.shape[0] == mask_shape[0]
+            and target_image.shape[1] == mask_shape[1]
+        ):
+            return target_image.copy()
+
+        self.resize_processor.width = mask_shape[1]
+        self.resize_processor.height = mask_shape[0]
+        return self.resize_processor.process(target_image)
+
+    def _validate_target_mask_compatibility(
+        self, target_image: np.ndarray, mask_gray: np.ndarray
+    ) -> None:
+        """target_image と mask_gray の shape / dtype 整合性を検証.
+
+        Args:
+            target_image (np.ndarray): リサイズ済みターゲット画像.
+            mask_gray (np.ndarray): グレースケールマスク.
 
         Raises:
-            ProcessorRuntimeError: ターゲット画像が設定されていない場合や処理中にエラーが発生した場合.
+            ProcessorValidationError: shape または dtype が不整合な場合.
+        """
+        if target_image.shape[:2] != mask_gray.shape[:2]:
+            raise ProcessorValidationError(
+                "target_image and mask shape mismatch: "
+                f"target={target_image.shape[:2]}, mask={mask_gray.shape[:2]}"
+            )
+        if target_image.dtype != np.uint8 or mask_gray.dtype != np.uint8:
+            raise ProcessorValidationError(
+                "target_image and mask must be dtype uint8: "
+                f"target={target_image.dtype}, mask={mask_gray.dtype}"
+            )
+
+    def process(self, mask_image: np.ndarray) -> np.ndarray:
+        """マスク画像を使用してターゲット画像と合成.
+
+        白領域 (>= 128) に ``target_image`` のピクセルを出力し,
+        黒領域 (< 128) を 0 で埋める.
+        ``use_white_pixels=False`` の場合は白黒を反転して適用する.
+
+        Args:
+            mask_image (np.ndarray): 2値化マスク画像 (グレースケール or カラー).
+
+        Returns:
+            np.ndarray: 合成後の画像. ターゲット画像と同じチャンネル数.
+
+        Raises:
+            ProcessorRuntimeError: ターゲット画像未設定または処理失敗時.
+            ProcessorValidationError: 入力画像や shape / dtype が不正な場合.
         """
         if self.target_image is None:
             raise ProcessorRuntimeError(
                 f"Target image '{self.target_image_name}' is not set"
             )
 
-        # 入力画像のバリデーション
+        # 入力マスクのバリデーション (2値画像であること等)
         self.validator.validate_image(mask_image)
 
         try:
-            # マスク画像をグレースケールに変換（既にグレースケールの場合はそのまま）
-            if len(mask_image.shape) == 3:
-                mask_gray = cv2.cvtColor(mask_image, cv2.COLOR_BGR2GRAY)
-            else:
-                mask_gray = mask_image
+            # マスクをグレースケール 2値に統一
+            mask_gray = self._to_grayscale_mask(mask_image)
 
-            # ターゲット画像とマスク画像のサイズが異なる場合、リサイズする
-            target_image = self.target_image.copy()
-            if (
-                target_image.shape[0] != mask_image.shape[0]
-                or target_image.shape[1] != mask_image.shape[1]
-            ):
+            # ターゲットをマスクサイズに合わせる
+            target_image = self._align_target_to_mask(
+                self.target_image, mask_gray.shape
+            )
 
-                # リサイズプロセッサのパラメータを設定
-                self.resize_processor.width = mask_image.shape[1]
-                self.resize_processor.height = mask_image.shape[0]
+            # shape / dtype の整合性を検証
+            self._validate_target_mask_compatibility(target_image, mask_gray)
 
-                # リサイズ実行
-                target_image = self.resize_processor.process(target_image)
+            # use_white_pixels=False の場合は白黒を反転して扱う
+            effective_mask = (
+                mask_gray if self.use_white_pixels else cv2.bitwise_not(mask_gray)
+            )
 
-            # 結果画像の初期化（マスクの大きさに合わせる）
-            result = np.zeros_like(target_image)
-
-            # マスクを作成（白ピクセルまたは黒ピクセルを使用）
-            if self.use_white_pixels:
-                # 白ピクセル部分（255）をマスクとして使用
-                mask = mask_gray
-            else:
-                # 黒ピクセル部分（0）をマスクとして使用
-                mask = cv2.bitwise_not(mask_gray)
-
-            result = cv2.bitwise_and(target_image, target_image, mask=mask)
-            inv_mask = cv2.bitwise_not(mask)
-
-            if len(mask_image.shape) == 2:
-                mask_to_use = cv2.cvtColor(mask_image, cv2.COLOR_GRAY2BGR)
-            else:
-                mask_to_use = mask_image
-
-            mask_part = cv2.bitwise_and(mask_to_use, mask_to_use, mask=inv_mask)
-            result = cv2.add(result, mask_part)
+            # 有効領域に target_image を出力, 無効領域は 0
+            result = cv2.bitwise_and(target_image, target_image, mask=effective_mask)
 
             if self.enable_cropping:
                 crop_bounds = self._find_crop_bounds(mask_gray)
@@ -225,6 +266,8 @@ class MaskCompositionProcessor(BaseProcessor):
 
             return result
 
+        except ProcessorValidationError:
+            raise
         except cv2.error as e:
             raise ProcessorRuntimeError(f"Error during mask composition: {e}")
         except Exception as e:
@@ -232,15 +275,14 @@ class MaskCompositionProcessor(BaseProcessor):
 
     @staticmethod
     def get_default_config() -> dict[str, Any]:
-        """
-        マスク合成プロセッサのデフォルト設定を返す.
+        """マスク合成プロセッサのデフォルト設定を返す.
 
         Returns:
             dict[str, Any]: デフォルト設定.
         """
         return {
             "target_image": "original",  # デフォルトはオリジナル画像
-            "use_white_pixels": True,  # デフォルトでは白ピクセル部分を元画像で置き換え
+            "use_white_pixels": True,  # 白領域に target_image を出力
             "enable_cropping": False,  # デフォルトではトリミング無効
-            "crop_margin": 5,  # デフォルトのトリミング余白は5ピクセル
+            "crop_margin": 5,  # デフォルトのトリミング余白は 5 ピクセル
         }

--- a/tests/processors/test_mask_composition_processor.py
+++ b/tests/processors/test_mask_composition_processor.py
@@ -53,29 +53,40 @@ class TestMaskCompositionProcessorProcess:
         with pytest.raises(ProcessorRuntimeError, match="not set"):
             processor.process(dummy_binary_image)
 
-    def test_process_with_white_pixels(self, dummy_binary_image: np.ndarray):
-        """白ピクセル部分をターゲット画像で置き換える."""
+    def test_process_with_white_pixels(self):
+        """白領域に target_image を出力し 黒領域は 0 で埋める."""
         processor = MaskCompositionProcessor(name="mask_composition", config={})
-        target = np.full((100, 100, 3), 128, dtype=np.uint8)
+        mask = np.zeros((50, 50), dtype=np.uint8)
+        mask[10:40, 10:40] = 255  # 中央に白領域
+        target = np.full((50, 50, 3), 128, dtype=np.uint8)
         processor.set_target_image(target)
 
-        result = processor.process(dummy_binary_image)
+        result = processor.process(mask)
 
-        assert result.shape == (100, 100, 3)
+        assert result.shape == (50, 50, 3)
         assert result.dtype == np.uint8
+        # 白領域は target の値 (128)
+        assert np.all(result[20, 20] == 128)
+        # 黒領域は 0
+        assert np.all(result[0, 0] == 0)
 
-    def test_process_with_black_pixels(self, dummy_binary_image: np.ndarray):
-        """use_white_pixels=False で黒ピクセル部分を置き換える."""
+    def test_process_with_black_pixels(self):
+        """use_white_pixels=False で黒領域に target_image が出力される."""
         processor = MaskCompositionProcessor(
             name="mask_composition", config={"use_white_pixels": False}
         )
-        target = np.full((100, 100, 3), 128, dtype=np.uint8)
+        mask = np.zeros((50, 50), dtype=np.uint8)
+        mask[10:40, 10:40] = 255  # 中央に白領域
+        target = np.full((50, 50, 3), 128, dtype=np.uint8)
         processor.set_target_image(target)
 
-        result = processor.process(dummy_binary_image)
+        result = processor.process(mask)
 
-        assert result.shape == (100, 100, 3)
+        assert result.shape == (50, 50, 3)
         assert result.dtype == np.uint8
+        # 反転により 元の白領域は 0, 元の黒領域に target (128) が出力
+        assert np.all(result[20, 20] == 0)
+        assert np.all(result[0, 0] == 128)
 
     def test_process_with_color_binary_mask(self, dummy_binary_color_image: np.ndarray):
         """カラー2値画像をマスクとして使用できる."""
@@ -128,6 +139,16 @@ class TestMaskCompositionProcessorProcess:
         non_binary = np.full((100, 100), 100, dtype=np.uint8)
         with pytest.raises(ProcessorValidationError, match="binary"):
             processor.process(non_binary)
+
+    def test_process_dtype_mismatch_raises(
+        self, processor: MaskCompositionProcessor, dummy_binary_image: np.ndarray
+    ):
+        """target_image の dtype が uint8 でない場合に ProcessorValidationError."""
+        # float 型の target_image は uint8 ではないため不整合
+        target_float = np.full((100, 100, 3), 0.5, dtype=np.float32)
+        processor.set_target_image(target_float)
+        with pytest.raises(ProcessorValidationError, match="uint8"):
+            processor.process(dummy_binary_image)
 
 
 class TestMaskCompositionProcessorPipelineMode:


### PR DESCRIPTION
## Summary

- `MaskCompositionProcessor` のマスク合成ロジックから余計な後処理 (無効領域に元マスク画像を重畳する 4 行) を削除.
- セマンティクスを明確化: 白領域 (>= 128) に `target_image` を出力, 黒領域は 0 で埋める. `use_white_pixels=False` では白黒を反転して適用.
- 処理を `_to_grayscale_mask` / `_align_target_to_mask` / `_validate_target_mask_compatibility` に分割.

## Related Issue

Closes #373

## Changes

- `pochivision/processors/mask_composition.py`: 余計な後処理を削除しロジックを関数分割. docstring にセマンティクスを明記.
- `tests/processors/test_mask_composition_processor.py`: 白/黒領域の具体的画素値検証に更新. `test_process_dtype_mismatch_raises` 追加.
- `CHANGELOG.md`: `[Unreleased] Fixed` にエントリ追加.

### 破壊的変更
- `use_white_pixels=False` のとき無効領域に残っていた元マスクのピクセル値が 0 (黒) に統一される.

## Test Plan

- [x] `use_white_pixels=True` で白領域に `target_image` のピクセルが出力され, 黒領域が 0 で埋められる
- [x] `use_white_pixels=False` で黒領域に `target_image` のピクセルが出力される
- [x] `target_image` とマスクの shape / dtype 不整合で `ProcessorValidationError` が送出される

## Checklist

- [x] `uv run pre-commit run --all-files` 全 pass
