### PR TITLE
fix: pipeline モード失敗時の状態不整合と parallel モードの race condition を修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@
 - 無し
 
 ### Fixed
-- 無し
+- pipeline モードでプロセッサが失敗した際に古い `result` が後続プロセッサへ渡され状態不整合が発生する問題を修正. 失敗時はパイプラインを中断し, `processed_images` にエラー情報を記録する. ((NA.))
+- parallel モードで複数プロセッサが同一 numpy 配列を共有し `ImageSaver` の `file_naming_manager` も非スレッドセーフだった問題を修正. 各プロセッサへ `image.copy()` を渡し, `ImageSaver` に `threading.Lock` を追加. ((NA.))
 
 ### Removed
 - 無し

--- a/pochivision/core/image_saver.py
+++ b/pochivision/core/image_saver.py
@@ -1,5 +1,6 @@
 """画像の保存・ディレクトリ管理を行うモジュール."""
 
+import threading
 import time
 from pathlib import Path
 
@@ -12,6 +13,10 @@ from pochivision.utils.file_naming import get_file_naming_manager
 
 class ImageSaver:
     """画像ファイルの保存とディレクトリ管理を担当するクラス.
+
+    スレッドセーフ: `file_naming_manager` へのアクセスおよびファイル I/O は
+    内部ロックで保護されており, parallel モード等から複数スレッド同時に
+    `save()` が呼ばれても競合しない.
 
     Attributes:
         output_dir: 処理結果の保存先ルートディレクトリ.
@@ -28,6 +33,8 @@ class ImageSaver:
         self.output_dir = output_dir
         self.camera_index = camera_index
         self.logger = LogManager().get_logger()
+        # file_naming_manager と cv2.imwrite を保護するロック.
+        self._lock = threading.Lock()
 
     def get_processing_dir(self, process_name: str) -> Path:
         """処理結果保存用のサブディレクトリを取得する.
@@ -51,23 +58,28 @@ class ImageSaver:
         """
         save_dir = self.get_processing_dir(processor_name)
 
-        filename, id_index, image_index = get_file_naming_manager().get_filename(
-            processor_name, self.camera_index
-        )
-        path = save_dir / filename
+        # file_naming_manager のカウンタ採番とファイル書き込みはスレッド間で
+        # 競合し得るためロックで直列化する.
+        with self._lock:
+            filename, id_index, image_index = get_file_naming_manager().get_filename(
+                processor_name, self.camera_index
+            )
+            path = save_dir / filename
 
-        save_start = time.time()
-        try:
-            success = cv2.imwrite(str(path), image)
-            save_time = time.time() - save_start
-            if success:
-                height, width = image.shape[:2]
-                self.logger.info(
-                    f"Image saved ({processor_name}): {path} "
-                    f"({width}x{height}, "
-                    f"id={id_index}, image={image_index}, {save_time:.3f} sec)"
-                )
-            else:
-                self.logger.warning(f"Failed to save image ({processor_name}): {path}")
-        except Exception as e:
-            self.logger.error(f"Failed to save image ({processor_name}): {e}")
+            save_start = time.time()
+            try:
+                success = cv2.imwrite(str(path), image)
+                save_time = time.time() - save_start
+                if success:
+                    height, width = image.shape[:2]
+                    self.logger.info(
+                        f"Image saved ({processor_name}): {path} "
+                        f"({width}x{height}, "
+                        f"id={id_index}, image={image_index}, {save_time:.3f} sec)"
+                    )
+                else:
+                    self.logger.warning(
+                        f"Failed to save image ({processor_name}): {path}"
+                    )
+            except Exception as e:
+                self.logger.error(f"Failed to save image ({processor_name}): {e}")

--- a/pochivision/core/pipeline_executor.py
+++ b/pochivision/core/pipeline_executor.py
@@ -145,12 +145,17 @@ class PipelineExecutor:
 
         self.saver.save(image, "original")
 
-        processed_images = {"original": image.copy()}
+        # エラー発生時はプロセッサ名に対してエラー情報の dict を格納するため
+        # Any を許容する.
+        processed_images: dict[str, Any] = {"original": image.copy()}
         if self.mode == "parallel":
             for processor in self.processors:
                 try:
                     proc_start = time.time()
-                    result = processor.process(image)
+                    # parallel モードでは複数プロセッサが同一フレームを
+                    # 共有するため, in-place 変更による相互干渉を防ぐため
+                    # 各プロセッサに独立した copy を渡す.
+                    result = processor.process(image.copy())
                     proc_time = time.time() - proc_start
                     self.logger.info(
                         f"Processing time ({processor.name}): {proc_time:.3f} sec"
@@ -161,11 +166,32 @@ class PipelineExecutor:
                     self.logger.error(
                         f"Processor '{processor.name}' failed, skipping: {e}"
                     )
+                    # 失敗したプロセッサの痕跡を残して追跡可能にする.
+                    processed_images[processor.name] = {
+                        "error": True,
+                        "processor_name": processor.name,
+                        "exception": repr(e),
+                    }
 
         elif self.mode == "pipeline":
             result = image
+            pipeline_aborted = False
 
             for processor in self.processors:
+                if pipeline_aborted:
+                    # 直前のプロセッサ失敗時は後続を明示的にスキップし,
+                    # 古い `result` が次のプロセッサへ渡るのを防ぐ.
+                    self.logger.warning(
+                        f"Skipping processor '{processor.name}' "
+                        f"due to earlier pipeline failure"
+                    )
+                    processed_images[processor.name] = {
+                        "error": True,
+                        "processor_name": processor.name,
+                        "exception": "skipped_due_to_earlier_failure",
+                    }
+                    continue
+
                 try:
                     proc_start = time.time()
 
@@ -193,11 +219,26 @@ class PipelineExecutor:
                     )
                     processed_images[processor.name] = result
                 except Exception as e:
+                    # pipeline モードでは失敗時にパイプラインを中断する.
+                    # 古い `result` を次プロセッサへ渡さないことで状態不整合を防ぐ.
                     self.logger.error(
-                        f"Processor '{processor.name}' failed, skipping: {e}"
+                        f"Processor '{processor.name}' failed, "
+                        f"aborting pipeline: {e}"
                     )
+                    processed_images[processor.name] = {
+                        "error": True,
+                        "processor_name": processor.name,
+                        "exception": repr(e),
+                    }
+                    pipeline_aborted = True
 
-            self.saver.save(result, "pipeline")
+            if not pipeline_aborted:
+                self.saver.save(result, "pipeline")
+            else:
+                self.logger.warning(
+                    "Pipeline aborted due to processor failure; "
+                    "final result not saved"
+                )
 
         total_time = time.time() - start_time
         self.logger.info(f"Total processing time: {total_time:.3f} sec")

--- a/tests/core/test_image_saver.py
+++ b/tests/core/test_image_saver.py
@@ -1,5 +1,7 @@
 """ImageSaver のテスト."""
 
+import threading
+
 import cv2
 import numpy as np
 
@@ -60,3 +62,28 @@ class TestImageSaver:
 
         saved_files = list((tmp_path / "multi_test").glob("*"))
         assert len(saved_files) == 3
+
+    def test_save_is_thread_safe(self, tmp_path):
+        """並行呼び出しでも全画像が重複なく保存される.
+
+        threading.Lock による file_naming_manager 保護を検証する.
+        """
+        saver = ImageSaver(tmp_path)
+        num_threads = 8
+        per_thread = 5
+
+        def _worker() -> None:
+            """スレッドから複数回 save を呼び出す."""
+            for _ in range(per_thread):
+                saver.save(_create_test_image(), "concurrent")
+
+        threads = [threading.Thread(target=_worker) for _ in range(num_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        saved_files = list((tmp_path / "concurrent").glob("*"))
+        # 全件がユニークなファイル名で保存されている.
+        assert len(saved_files) == num_threads * per_thread
+        assert len({f.name for f in saved_files}) == num_threads * per_thread

--- a/tests/core/test_pipeline_executor.py
+++ b/tests/core/test_pipeline_executor.py
@@ -8,7 +8,68 @@ import pytest
 
 from pochivision.core.pipeline_executor import PipelineExecutor
 from pochivision.exceptions import CameraConfigError
+from pochivision.processors import BaseProcessor
 from pochivision.processors.registry import get_processor
+
+
+class _FailingProcessor(BaseProcessor):
+    """常に例外を送出するテスト用プロセッサ."""
+
+    def process(self, image: np.ndarray) -> np.ndarray:
+        """意図的に例外を送出する."""
+        raise RuntimeError("intentional failure")
+
+    @staticmethod
+    def get_default_config() -> dict:
+        """空のデフォルト設定を返す."""
+        return {}
+
+
+class _RecordingProcessor(BaseProcessor):
+    """受け取った画像を記録するテスト用プロセッサ.
+
+    parallel モードでコピー渡しされていることを検証するために,
+    受け取った配列の id と実体を記録する.
+    """
+
+    def __init__(self, name: str, config: dict | None = None) -> None:
+        """受け取った画像リストを初期化する."""
+        super().__init__(name=name, config=config or {})
+        self.received_ids: list[int] = []
+        self.received_sums: list[int] = []
+
+    def process(self, image: np.ndarray) -> np.ndarray:
+        """受け取り画像を記録し, in-place 変更して返す."""
+        self.received_ids.append(id(image))
+        # 受け取り時点の画素合計を記録 (in-place 0 埋め前).
+        self.received_sums.append(int(image.sum()))
+        # in-place 変更: 共有されていれば他プロセッサにも影響する.
+        image[...] = 0
+        return image
+
+    @staticmethod
+    def get_default_config() -> dict:
+        """空のデフォルト設定を返す."""
+        return {}
+
+
+class _CountingProcessor(BaseProcessor):
+    """呼び出し回数を数えるテスト用プロセッサ."""
+
+    def __init__(self, name: str, config: dict | None = None) -> None:
+        """呼び出しカウンタを初期化する."""
+        super().__init__(name=name, config=config or {})
+        self.call_count = 0
+
+    def process(self, image: np.ndarray) -> np.ndarray:
+        """呼び出し回数を加算して画像をそのまま返す."""
+        self.call_count += 1
+        return image
+
+    @staticmethod
+    def get_default_config() -> dict:
+        """空のデフォルト設定を返す."""
+        return {}
 
 
 def _create_test_image(width: int = 100, height: int = 80) -> np.ndarray:
@@ -241,3 +302,82 @@ class TestPipelineExecutorRun:
         assert len(pipeline_files) == 1
         result = cv2.imread(str(pipeline_files[0]))
         assert result.shape[1] == 50
+
+
+class TestPipelineExecutorRobustness:
+    """パイプライン堅牢化 (#371, #372) のテスト."""
+
+    def test_pipeline_mode_aborts_on_failure(self, tmp_path):
+        """pipeline モードでプロセッサ失敗時に後続が呼ばれない."""
+        failing = _FailingProcessor(name="failing", config={})
+        after = _CountingProcessor(name="after", config={})
+        executor = PipelineExecutor(
+            processors=[failing, after],
+            output_dir=tmp_path,
+            mode="pipeline",
+        )
+
+        image = _create_test_image()
+        executor.run(image)
+
+        # 失敗後のプロセッサは呼ばれない (パイプライン中断).
+        assert after.call_count == 0
+        # pipeline ディレクトリは作られない, もしくは空である.
+        pipeline_dir = tmp_path / "pipeline"
+        if pipeline_dir.exists():
+            assert len(list(pipeline_dir.glob("*"))) == 0
+
+    def test_pipeline_mode_failure_does_not_save_stale_result(self, tmp_path):
+        """pipeline モードで失敗時に古い result が pipeline に保存されない."""
+        resize = get_processor("resize", {"width": 50, "preserve_aspect_ratio": False})
+        failing = _FailingProcessor(name="failing", config={})
+        executor = PipelineExecutor(
+            processors=[resize, failing],
+            output_dir=tmp_path,
+            mode="pipeline",
+        )
+
+        image = _create_test_image()
+        executor.run(image)
+
+        pipeline_dir = tmp_path / "pipeline"
+        # 直前 resize の結果が "pipeline" として保存されていないこと.
+        if pipeline_dir.exists():
+            assert len(list(pipeline_dir.glob("*"))) == 0
+
+    def test_parallel_mode_failure_does_not_stop_others(self, tmp_path):
+        """parallel モードで一つ失敗しても他は実行される."""
+        failing = _FailingProcessor(name="failing", config={})
+        after = _CountingProcessor(name="after", config={})
+        executor = PipelineExecutor(
+            processors=[failing, after],
+            output_dir=tmp_path,
+            mode="parallel",
+        )
+
+        image = _create_test_image()
+        executor.run(image)
+
+        assert after.call_count == 1
+
+    def test_parallel_mode_passes_independent_copies(self, tmp_path):
+        """parallel モードで各プロセッサに独立したコピーが渡される."""
+        rec1 = _RecordingProcessor(name="rec1", config={})
+        rec2 = _RecordingProcessor(name="rec2", config={})
+        executor = PipelineExecutor(
+            processors=[rec1, rec2],
+            output_dir=tmp_path,
+            mode="parallel",
+        )
+
+        image = _create_test_image()
+        original_sum = int(image.sum())
+        executor.run(image)
+
+        # 入力画像は外部から変更されていない.
+        assert int(image.sum()) == original_sum
+        # 2 つのプロセッサが受け取った配列は異なる id (別オブジェクト).
+        assert rec1.received_ids[0] != rec2.received_ids[0]
+        # 1 つ目が in-place で 0 埋めしても, 2 つ目は元の画素を受け取る.
+        assert rec1.received_sums[0] == original_sum
+        assert rec2.received_sums[0] == original_sum


### PR DESCRIPTION
## Summary

- pipeline モードでプロセッサが失敗した際に古い `result` が後続に渡される状態不整合を修正 (#371). 失敗時はパイプラインを中断し `processed_images` にエラー情報を記録.
- parallel モードで numpy 配列共有による in-place 汚染と `file_naming_manager` の race condition を修正 (#372). 各プロセッサへ `image.copy()` を渡し, `ImageSaver` に `threading.Lock` を追加.

## Related Issue

- Closes #371
- Closes #372

## Changes

- `pochivision/core/pipeline_executor.py`: pipeline 失敗時の中断処理, parallel モードの `image.copy()` 渡し.
- `pochivision/core/image_saver.py`: `threading.Lock` で `file_naming_manager` と `cv2.imwrite` を保護.
- `tests/core/test_pipeline_executor.py`: 失敗時スキップ / copy 渡し検証を追加.
- `tests/core/test_image_saver.py`: スレッドセーフ検証を追加.
- `CHANGELOG.md`: `[Unreleased] Fixed` にエントリ追加.

## Test Plan

- [x] pipeline モードで途中プロセッサが失敗した場合, 後続プロセッサが呼ばれず `processed_images` にエラー情報が記録される
- [x] parallel モードで各プロセッサに独立した `image.copy()` が渡される
- [x] `ImageSaver.save()` を複数スレッドから同時実行してもファイル名が一意

## Checklist

- [x] `uv run pre-commit run --all-files` 全 pass
