### PR TITLE
fix: CannyEdgeProcessor で Inf 値もフィルタし float32 で省メモリ化

### DIFF
--- a/pochivision/processors/edge_detection.py
+++ b/pochivision/processors/edge_detection.py
@@ -64,9 +64,12 @@ class CannyEdgeProcessor(BaseProcessor):
                 gray_image = gray_image.astype(np.uint8)
             else:
                 try:
-                    dst = np.empty_like(gray_image, dtype=np.float64)
+                    dst = np.empty_like(gray_image, dtype=np.float32)
                     cv2.normalize(gray_image, dst, 0, 255, cv2.NORM_MINMAX)
-                    gray_image = np.nan_to_num(dst, nan=0.0).astype(np.uint8)
+                    # NaN と Inf を 0 にクランプし, uint8 キャスト時の不正値を防ぐ.
+                    gray_image = np.nan_to_num(
+                        dst, nan=0.0, posinf=0.0, neginf=0.0
+                    ).astype(np.uint8)
                 except cv2.error as e:
                     raise ProcessorRuntimeError(
                         f"Failed to convert image to uint8 for Canny: {e}"

--- a/tests/processors/test_edge_detection_processor.py
+++ b/tests/processors/test_edge_detection_processor.py
@@ -175,6 +175,48 @@ class TestCannyEdgeProcessor:
             "3-channel color image." in str(excinfo.value)
         )
 
+    def test_process_image_with_nan_values(self):
+        """NaN を含む入力が 0 にクランプされ, 正常にエッジ検出されるかテスト."""
+        image_float = (np.random.rand(100, 100) * 1000).astype(np.float32)
+        image_float[0, 0] = np.nan
+        image_float[50, 50] = np.nan
+        config = CannyEdgeProcessor.get_default_config()
+        processor = CannyEdgeProcessor(name="canny_nan", config=config)
+        processed_image = processor.process(image_float.copy())
+        assert processed_image.shape == (100, 100)
+        assert processed_image.dtype == np.uint8
+        # 出力に不正値が含まれないこと.
+        assert not np.any(np.isnan(processed_image.astype(np.float32)))
+
+    def test_process_image_with_inf_values(self):
+        """Inf を含む入力が 0 にクランプされ, 正常にエッジ検出されるかテスト."""
+        image_float = (np.random.rand(100, 100) * 1000).astype(np.float32)
+        image_float[0, 0] = np.inf
+        image_float[10, 10] = -np.inf
+        image_float[50, 50] = np.inf
+        config = CannyEdgeProcessor.get_default_config()
+        processor = CannyEdgeProcessor(name="canny_inf", config=config)
+        processed_image = processor.process(image_float.copy())
+        assert processed_image.shape == (100, 100)
+        assert processed_image.dtype == np.uint8
+        # uint8 なので範囲は [0, 255] に収まる.
+        assert processed_image.min() >= 0
+        assert processed_image.max() <= 255
+
+    def test_process_image_with_nan_and_inf_values(self):
+        """NaN と Inf 両方を含む入力が 0 にクランプされるかテスト."""
+        image_float = (np.random.rand(100, 100) * 1000).astype(np.float32)
+        image_float[0, 0] = np.nan
+        image_float[0, 1] = np.inf
+        image_float[0, 2] = -np.inf
+        config = CannyEdgeProcessor.get_default_config()
+        processor = CannyEdgeProcessor(name="canny_nan_inf", config=config)
+        processed_image = processor.process(image_float.copy())
+        assert processed_image.shape == (100, 100)
+        assert processed_image.dtype == np.uint8
+        assert processed_image.min() >= 0
+        assert processed_image.max() <= 255
+
     def test_process_image_normalize_fail(self):
         """cv2.normalize でエラーが発生するケースのテスト (例: 0次元配列)."""
         image_problematic = np.array(0, dtype=np.int32)


### PR DESCRIPTION
## Summary

- `CannyEdgeProcessor` の uint8 正規化経路で, NaN のみを 0 置換していたため Inf が uint8 キャスト時に不正値となる問題を修正.
- 正規化用バッファを `float64` から `float32` に変更し, メモリ使用量を削減.

## Related Issue

Closes #376

## Changes

- `pochivision/processors/edge_detection.py`: `np.nan_to_num` に `posinf=0.0, neginf=0.0` を追加. `dst` の dtype を `np.float32` に変更.
- `tests/processors/test_edge_detection_processor.py`: NaN / Inf / 両者混在入力に対するテストを追加.

## Test Plan

- [x] NaN を含む float 入力が正常に処理され, 出力が uint8 範囲に収まる
- [x] Inf (正負) を含む float 入力が 0 にクランプされ, 出力が uint8 範囲に収まる
- [x] NaN と Inf 混在入力でも出力が uint8 範囲に収まる

## Checklist

- [x] pre-commit 全 pass
