### PR TITLE
fix: adaptive 2値化の block_size を起動時に検証し c を int にキャスト

### DIFF
--- a/pochivision/processors/binarization.py
+++ b/pochivision/processors/binarization.py
@@ -200,7 +200,8 @@ class GaussianAdaptiveBinarizationProcessor(BaseProcessor):
         self.logger = LogManager().get_logger()
         self.validator = GaussianAdaptiveBinarizationValidator(self.config)
         self.block_size: int = self.config.get("block_size", 11)
-        self.c_value: int | float = self.config.get("c", 2)
+        # cv2.adaptiveThreshold は C を int で期待するため int へキャストする.
+        self.c_value: int = int(self.config.get("c", 2))
 
     def process(self, image: np.ndarray) -> np.ndarray:
         """
@@ -285,7 +286,8 @@ class MeanAdaptiveBinarizationProcessor(BaseProcessor):
         self.logger = LogManager().get_logger()
         self.validator = MeanAdaptiveBinarizationValidator(self.config)
         self.block_size: int = self.config.get("block_size", 11)
-        self.c_value: int | float = self.config.get("c", 2)
+        # cv2.adaptiveThreshold は C を int で期待するため int へキャストする.
+        self.c_value: int = int(self.config.get("c", 2))
 
     def process(self, image: np.ndarray) -> np.ndarray:
         """

--- a/pochivision/processors/validators/binarization/adaptive.py
+++ b/pochivision/processors/validators/binarization/adaptive.py
@@ -8,6 +8,35 @@ from pochivision.exceptions import ProcessorValidationError
 from pochivision.processors.validators.base import BaseValidator
 
 
+def _validate_adaptive_block_size(config: dict[str, Any], processor_label: str) -> None:
+    """
+    Adaptive 2値化系プロセッサの ``block_size`` を起動時に検証する共通関数.
+
+    ``block_size`` は ``int`` 型かつ 3 以上の奇数でなければならない.
+
+    Args:
+        config (dict[str, Any]): バリデーション対象の設定辞書.
+        processor_label (str): エラーメッセージに含めるプロセッサ名.
+
+    Raises:
+        ProcessorValidationError: ``block_size`` が不正な場合.
+    """
+    if "block_size" not in config:
+        return
+    block_size = config["block_size"]
+    # bool は int のサブクラスだが, ここでは無効として扱う.
+    if isinstance(block_size, bool) or not isinstance(block_size, int):
+        raise ProcessorValidationError(
+            f"{processor_label}: block_size must be an int, got "
+            f"{type(block_size).__name__} ({block_size!r})"
+        )
+    if block_size < 3 or block_size % 2 == 0:
+        raise ProcessorValidationError(
+            f"{processor_label}: block_size must be an odd integer >= 3, "
+            f"got {block_size}"
+        )
+
+
 class GaussianAdaptiveBinarizationValidator(BaseValidator):
     """
     ガウシアン適応的2値化用のバリデータ.
@@ -25,8 +54,12 @@ class GaussianAdaptiveBinarizationValidator(BaseValidator):
 
         Args:
             config (dict[str, Any]): バリデーション対象の設定辞書.
+
+        Raises:
+            ProcessorValidationError: ``block_size`` が奇数かつ 3 以上でない場合.
         """
         self.config = config
+        _validate_adaptive_block_size(config, "GaussianAdaptiveBinarization")
 
     def validate_image(self, image: np.ndarray) -> None:
         """
@@ -64,8 +97,12 @@ class MeanAdaptiveBinarizationValidator(BaseValidator):
 
         Args:
             config (dict[str, Any]): バリデーション対象の設定辞書.
+
+        Raises:
+            ProcessorValidationError: ``block_size`` が奇数かつ 3 以上でない場合.
         """
         self.config = config
+        _validate_adaptive_block_size(config, "MeanAdaptiveBinarization")
 
     def validate_image(self, image: np.ndarray) -> None:
         """

--- a/tests/processors/test_binarization_processor.py
+++ b/tests/processors/test_binarization_processor.py
@@ -253,6 +253,74 @@ def test_standard_binarization_empty_input_image():
     assert "input image is empty" in str(excinfo.value)
 
 
+@pytest.mark.parametrize(
+    "processor_cls, name",
+    [
+        (GaussianAdaptiveBinarizationProcessor, "gauss_adapt_bin"),
+        (MeanAdaptiveBinarizationProcessor, "mean_adapt_bin"),
+    ],
+)
+@pytest.mark.parametrize("invalid_block_size", [0, -1, 2, 4, 10])
+def test_adaptive_binarization_invalid_block_size_raises(
+    processor_cls: type, name: str, invalid_block_size: int
+) -> None:
+    """偶数/0/負の block_size は ProcessorValidationError を送出する."""
+    config = {"block_size": invalid_block_size, "c": 2}
+    with pytest.raises(ProcessorValidationError):
+        processor_cls(name=name, config=config)
+
+
+@pytest.mark.parametrize(
+    "processor_cls, name",
+    [
+        (GaussianAdaptiveBinarizationProcessor, "gauss_adapt_bin"),
+        (MeanAdaptiveBinarizationProcessor, "mean_adapt_bin"),
+    ],
+)
+def test_adaptive_binarization_float_block_size_raises(
+    processor_cls: type, name: str
+) -> None:
+    """小数の block_size は ProcessorValidationError を送出する."""
+    config = {"block_size": 3.0, "c": 2}
+    with pytest.raises(ProcessorValidationError):
+        processor_cls(name=name, config=config)
+
+
+@pytest.mark.parametrize(
+    "processor_cls, name",
+    [
+        (GaussianAdaptiveBinarizationProcessor, "gauss_adapt_bin"),
+        (MeanAdaptiveBinarizationProcessor, "mean_adapt_bin"),
+    ],
+)
+@pytest.mark.parametrize("valid_block_size", [3, 5, 11, 21])
+def test_adaptive_binarization_valid_block_size(
+    processor_cls: type, name: str, valid_block_size: int
+) -> None:
+    """奇数かつ 3 以上の block_size は例外を送出せず処理が成功する."""
+    config = {"block_size": valid_block_size, "c": 2}
+    processor = processor_cls(name=name, config=config)
+    result = processor.process(DUMMY_GRAY)
+    assert result.shape == DUMMY_GRAY.shape
+
+
+@pytest.mark.parametrize(
+    "processor_cls, name",
+    [
+        (GaussianAdaptiveBinarizationProcessor, "gauss_adapt_bin"),
+        (MeanAdaptiveBinarizationProcessor, "mean_adapt_bin"),
+    ],
+)
+def test_adaptive_binarization_c_value_is_cast_to_int(
+    processor_cls: type, name: str
+) -> None:
+    """float の c は int にキャストされる."""
+    config = {"block_size": 5, "c": 2.7}
+    processor = processor_cls(name=name, config=config)
+    assert isinstance(processor.c_value, int)
+    assert processor.c_value == 2
+
+
 def test_standard_binarization_invalid_input_shape():
     """StandardBinarizationProcessor の不正な形状の入力画像に対するテスト."""
     config = {"threshold": 128}


### PR DESCRIPTION
## Summary

- `GaussianAdaptiveBinarizationProcessor` / `MeanAdaptiveBinarizationProcessor` の `block_size` が奇数かつ 3 以上であることをインスタンス化時にバリデートし, 違反時は `ProcessorValidationError` を送出.
- `c` パラメータを `cv2.adaptiveThreshold` 呼び出し前に `int` へキャストし, float 混入時の OpenCV 側エラーを回避.

## Related Issue

Closes #374

## Changes

- `pochivision/processors/validators/binarization/adaptive.py`: `_validate_adaptive_block_size` 共通関数を追加.
- `pochivision/processors/binarization.py`: `c_value` を `int(...)` でキャストし型注釈を更新.
- `tests/processors/test_binarization_processor.py`: 偶数/0/負/小数 block_size の異常系と正常系, c の int キャストを検証.

## Test Plan

- [x] 偶数 `block_size` (2, 4, 10) で `ProcessorValidationError` が送出される
- [x] 0 および負の `block_size` で `ProcessorValidationError` が送出される
- [x] 小数 `block_size` で `ProcessorValidationError` が送出される
- [x] 奇数かつ 3 以上の `block_size` では正常に処理が完了する
- [x] float の `c` が int にキャストされて格納される

## Checklist

- [x] pre-commit 全 pass
