### PR TITLE
fix: ResizeProcessor のアスペクト比保持モードで四捨五入に変更

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 - `CannyEdgeProcessor` で NaN のみフィルタされ Inf が uint8 キャスト時に不正値となる問題を修正. `np.nan_to_num` に `posinf=0.0, neginf=0.0` を追加し, 正規化バッファを `float32` 化してメモリを削減. ([#387](https://github.com/kurorosu/pochivision/pull/387))
 - adaptive 2値化の `block_size` が奇数かつ 3 以上であることを起動時に検証するよう修正. 違反時は `ProcessorValidationError` を送出. `c` を `int` にキャスト. ([#388](https://github.com/kurorosu/pochivision/pull/388))
 - `EqualizeProcessor` / `CLAHEProcessor` で shape `(H, W, 1)` 画像の処理を修正. `ndim==2` / `shape[2]==1` / カラー の 3 分岐を明示化し, 不要な `cvtColor(GRAY2BGR)` を削除. ([#389](https://github.com/kurorosu/pochivision/pull/389))
-- `ResizeProcessor` のアスペクト比保持モードで `int()` 切り捨てによる 1px ずれを修正. `int(round(...))` で四捨五入に変更. (NA.)
+- `ResizeProcessor` のアスペクト比保持モードで `int()` 切り捨てによる 1px ずれを修正. `int(round(...))` で四捨五入に変更. ([#390](https://github.com/kurorosu/pochivision/pull/390))
 
 ### Removed
 - 無し

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,12 @@
 ### Fixed
 - `GaussianBlurProcessor` / `MedianBlurProcessor` のカーネルサイズに対する奇数チェックを追加. 偶数・0 以下・1 を設定した場合, 実行時の `cv2.error` ではなく起動時に `ProcessorValidationError` を投げるよう修正. ([#384](https://github.com/kurorosu/pochivision/pull/384))
 - `MaskCompositionProcessor` のマスク合成ロジックを明確化. 白領域に `target_image` を出力し 黒領域は 0 で埋めるセマンティクスに統一. 不要なカラー往復変換を削除し, shape/dtype のミスマッチ検証を追加. ([#385](https://github.com/kurorosu/pochivision/pull/385))
-- pipeline モードでプロセッサが失敗した際に古い `result` が後続プロセッサへ渡され状態不整合が発生する問題を修正. 失敗時はパイプラインを中断し, `processed_images` にエラー情報を記録する. (NA.)
-- parallel モードで複数プロセッサが同一 numpy 配列を共有し `ImageSaver` の `file_naming_manager` も非スレッドセーフだった問題を修正. 各プロセッサへ `image.copy()` を渡し, `ImageSaver` に `threading.Lock` を追加. (NA.)
+- pipeline モードでプロセッサが失敗した際に古い `result` が後続プロセッサへ渡され状態不整合が発生する問題を修正. 失敗時はパイプラインを中断し, `processed_images` にエラー情報を記録する. ([#386](https://github.com/kurorosu/pochivision/pull/386))
+- parallel モードで複数プロセッサが同一 numpy 配列を共有し `ImageSaver` の `file_naming_manager` も非スレッドセーフだった問題を修正. 各プロセッサへ `image.copy()` を渡し, `ImageSaver` に `threading.Lock` を追加. ([#386](https://github.com/kurorosu/pochivision/pull/386))
+- `CannyEdgeProcessor` で NaN のみフィルタされ Inf が uint8 キャスト時に不正値となる問題を修正. `np.nan_to_num` に `posinf=0.0, neginf=0.0` を追加し, 正規化バッファを `float32` 化してメモリを削減. ([#387](https://github.com/kurorosu/pochivision/pull/387))
+- adaptive 2値化の `block_size` が奇数かつ 3 以上であることを起動時に検証するよう修正. 違反時は `ProcessorValidationError` を送出. `c` を `int` にキャスト. ([#388](https://github.com/kurorosu/pochivision/pull/388))
+- `EqualizeProcessor` / `CLAHEProcessor` で shape `(H, W, 1)` 画像の処理を修正. `ndim==2` / `shape[2]==1` / カラー の 3 分岐を明示化し, 不要な `cvtColor(GRAY2BGR)` を削除. ([#389](https://github.com/kurorosu/pochivision/pull/389))
+- `ResizeProcessor` のアスペクト比保持モードで `int()` 切り捨てによる 1px ずれを修正. `int(round(...))` で四捨五入に変更. (NA.)
 
 ### Removed
 - 無し

--- a/pochivision/processors/resize.py
+++ b/pochivision/processors/resize.py
@@ -92,10 +92,12 @@ class ResizeProcessor(BaseProcessor):
 
         if self.aspect_ratio_mode == "width" and self.width is not None:
             target_w = self.width
-            target_h = int(target_w / aspect_ratio)
+            # 端数は四捨五入して 1px ずれを抑制
+            target_h = int(round(target_w / aspect_ratio))
         elif self.aspect_ratio_mode == "height" and self.height is not None:
             target_h = self.height
-            target_w = int(target_h * aspect_ratio)
+            # 端数は四捨五入して 1px ずれを抑制
+            target_w = int(round(target_h * aspect_ratio))
         else:
             # どちらも指定されていない場合は元のサイズを使用
             target_w = self.width if self.width is not None else orig_width

--- a/tests/processors/test_resize_processor.py
+++ b/tests/processors/test_resize_processor.py
@@ -77,6 +77,51 @@ def test_resize_height_only():
     assert result.dtype == np.uint8
 
 
+def test_resize_preserve_aspect_ratio_width_rounding():
+    """幅基準のアスペクト比保持で端数が四捨五入されることを検証.
+
+    元画像 1599x900 を width=800 で縮小した場合,
+    高さは 800 * 900 / 1599 = 450.2814... となり, 切り捨て (int) でも四捨五入でも 450.
+    差が出るケースとして 1601x900 -> height=450 を別テストで検証する.
+
+    ここでは端数 .5 以上のケースを直接確認する.
+    元画像 1000x333 を width=600 で縮小すると
+    target_h = 600 * 333 / 1000 = 199.8 -> 切り捨て 199, 四捨五入 200.
+    """
+    img = np.ones((333, 1000, 3), dtype=np.uint8) * 100
+    proc = ResizeProcessor(
+        name="resize",
+        config={
+            "width": 600,
+            "preserve_aspect_ratio": True,
+            "aspect_ratio_mode": "width",
+        },
+    )
+    result = proc.process(img)
+    # 600 * 333 / 1000 = 199.8 -> round -> 200 (切り捨てだと 199)
+    assert result.shape == (200, 600, 3)
+
+
+def test_resize_preserve_aspect_ratio_height_rounding():
+    """高さ基準のアスペクト比保持で端数が四捨五入されることを検証.
+
+    元画像 1599x900 を height=450 で縮小した場合,
+    幅は 450 * 1599 / 900 = 799.5 となり, 切り捨てだと 799, 四捨五入だと 800 となる.
+    """
+    img = np.ones((900, 1599, 3), dtype=np.uint8) * 100
+    proc = ResizeProcessor(
+        name="resize",
+        config={
+            "height": 450,
+            "preserve_aspect_ratio": True,
+            "aspect_ratio_mode": "height",
+        },
+    )
+    result = proc.process(img)
+    # 450 * 1599 / 900 = 799.5 -> round -> 800 (切り捨てなら 799)
+    assert result.shape == (450, 800, 3)
+
+
 def test_resize_validation_error():
     """パラメータバリデーションのテスト.
 


### PR DESCRIPTION
## Summary

- `ResizeProcessor` のアスペクト比保持モードで `int()` による切り捨てで発生していた 1px ずれを修正. `int(round(...))` に変更.
- 並行実装した 4 件の bug fix ([#386](https://github.com/kurorosu/pochivision/pull/386) 含む既マージ 1 件, 本 PR を含む 4 件の新規) の CHANGELOG エントリを本 PR にまとめて追加.

## Related Issue

Closes #380

## Changes

- `pochivision/processors/resize.py`: `_calculate_target_size` の 2 箇所で `int(round(...))` に変更.
- `tests/processors/test_resize_processor.py`: 端数で差が出るケース (1000x333→w=600, 1599x900→h=450) を検証するテストを追加.
- `CHANGELOG.md`: 並行 PR ([#386](https://github.com/kurorosu/pochivision/pull/386), [#387](https://github.com/kurorosu/pochivision/pull/387), [#388](https://github.com/kurorosu/pochivision/pull/388), [#389](https://github.com/kurorosu/pochivision/pull/389), 本 PR) のエントリをまとめて追加.

## Test Plan

- [x] 端数が出る入力で期待通りに四捨五入される
- [x] 既存の resize テストが全て通過

## Checklist

- [x] pre-commit 全 pass
