### PR TITLE
refactor: GrayscaleProcessor で既にグレースケールの入力を早期リターン

### DIFF
--- a/pochivision/processors/grayscale.py
+++ b/pochivision/processors/grayscale.py
@@ -55,6 +55,13 @@ class GrayscaleProcessor(BaseProcessor):
         """
         self.validator.validate_image(image)
 
+        # 既にグレースケール (2D, もしくは 3D で 1 チャンネル) の場合は
+        # 冗長な cv2 呼び出しを避けるために早期リターンする.
+        if image.ndim == 2:
+            return image
+        if image.ndim == 3 and image.shape[2] == 1:
+            return image.squeeze(axis=2)
+
         try:
             return to_grayscale(image)
         except Exception as e:

--- a/tests/processors/test_grayscale_processor.py
+++ b/tests/processors/test_grayscale_processor.py
@@ -29,6 +29,32 @@ def test_grayscale_already_grayscale():
 
     assert result.ndim == 2
     assert result.shape == (10, 10)
+    # 早期リターンにより同一オブジェクトが返されること (冗長変換が発生しない)
+    assert result is gray_image
+
+
+def test_grayscale_already_grayscale_3d_single_channel():
+    """3 次元 1 チャンネル画像は 2 次元グレースケールに整形されて返される."""
+    processor = GrayscaleProcessor(name="grayscale", config={})
+    gray_image = np.ones((10, 10, 1), dtype=np.uint8) * 100
+    result = processor.process(gray_image)
+
+    assert result.ndim == 2
+    assert result.shape == (10, 10)
+    assert result.dtype == np.uint8
+    # 値が保持されていること
+    assert np.array_equal(result, gray_image.squeeze(axis=2))
+
+
+def test_grayscale_double_apply_is_idempotent():
+    """grayscale を 2 回適用しても例外にならず同じ結果を返す."""
+    processor = GrayscaleProcessor(name="grayscale", config={})
+    first = processor.process(DUMMY_COLOR)
+    second = processor.process(first)
+
+    assert second.ndim == 2
+    assert second.shape == (10, 10)
+    assert np.array_equal(first, second)
 
 
 def test_grayscale_empty_image():


### PR DESCRIPTION
## Summary

- `GrayscaleProcessor.process` が既にグレースケール化された画像 (`ndim == 2` もしくは `shape[2] == 1`) を受け取った場合に早期リターンし, 冗長な `cv2` 呼び出しを回避する.

## Related Issue

Closes #381

## Changes

- `pochivision/processors/grayscale.py`: `ndim == 2` または 3 次元 1 チャンネルの入力に対して早期リターンするロジックを追加.
- `tests/processors/test_grayscale_processor.py`: 3 次元 1 チャンネル画像の処理, 2 次元入力で同一オブジェクトが返ること, 2 回適用しても冪等であることのテストを追加.

## Test Plan

- [x] 2 次元グレースケール入力で冗長な変換が発生せず同一オブジェクトが返る
- [x] 3 次元 1 チャンネル入力が 2 次元に整形されて返される
- [x] `grayscale` を 2 回適用しても例外が出ず冪等である
- [x] 既存のカラー入力・バリデーション系テストが引き続き pass する

## Checklist

- [x] pre-commit 全 pass