### PR TITLE
refactor: ContourProcessor で findContours の階層情報を保持

### DIFF
--- a/pochivision/processors/contour.py
+++ b/pochivision/processors/contour.py
@@ -13,6 +13,34 @@ from .registry import register_processor
 from .validators.contour import ContourValidator
 
 
+def find_contours_compat(
+    image: np.ndarray, mode: int, method: int
+) -> tuple[list[np.ndarray], np.ndarray | None]:
+    """バージョン非依存な ``cv2.findContours`` ラッパー.
+
+    OpenCV 3.x では ``(image, contours, hierarchy)`` の 3 要素,
+    OpenCV 4.x では ``(contours, hierarchy)`` の 2 要素を返すため,
+    戻り値数の違いを吸収して ``(contours, hierarchy)`` で統一する.
+
+    Args:
+        image (np.ndarray): 入力画像 (8bit シングルチャンネル推奨).
+        mode (int): 輪郭抽出モード (``cv2.RETR_*``).
+        method (int): 輪郭近似方法 (``cv2.CHAIN_APPROX_*``).
+
+    Returns:
+        tuple[list[np.ndarray], np.ndarray | None]:
+            - 検出された輪郭のリスト.
+            - 階層情報 ``(1, N, 4)`` 形状の配列. 輪郭が無い場合は ``None``.
+    """
+    result = cv2.findContours(image, mode, method)
+    # OpenCV 4.x: (contours, hierarchy), OpenCV 3.x: (image, contours, hierarchy)
+    if len(result) == 2:
+        contours, hierarchy = result
+    else:
+        _, contours, hierarchy = result
+    return list(contours), hierarchy
+
+
 @register_processor("contour")
 class ContourProcessor(BaseProcessor):
     """画像から輪郭を抽出するプロセッサー."""
@@ -54,6 +82,25 @@ class ContourProcessor(BaseProcessor):
         self._inside_color = self.config.get(
             "inside_color", default_vals["inside_color"]
         )
+
+        # 直近の findContours 結果 (後段や将来の階層フィルタ拡張で参照可能).
+        self._last_contours: list[np.ndarray] = []
+        self._last_hierarchy: np.ndarray | None = None
+
+    @property
+    def last_contours(self) -> list[np.ndarray]:
+        """直近の ``process`` 呼び出しで検出された輪郭のリストを返す."""
+        return self._last_contours
+
+    @property
+    def last_hierarchy(self) -> np.ndarray | None:
+        """直近の ``process`` 呼び出しで得られた階層情報を返す.
+
+        Returns:
+            np.ndarray | None: ``cv2.findContours`` が返す ``(1, N, 4)`` 形状の
+            階層情報. 輪郭が検出されない場合は ``None``.
+        """
+        return self._last_hierarchy
 
     @staticmethod
     def _get_retrieval_mode(mode_str: str) -> int:
@@ -160,9 +207,13 @@ class ContourProcessor(BaseProcessor):
                 else:
                     gray_image = gray_image.astype(np.uint8)
 
-            contours, _ = cv2.findContours(
+            contours, hierarchy = find_contours_compat(
                 gray_image, self._retrieval_mode, self._approximation_method
             )
+
+            # 階層情報を後段で参照できるよう保持 (Issue #383).
+            self._last_contours = list(contours)
+            self._last_hierarchy = hierarchy
 
             if self._select_mode == "rank":
                 # ランクによる選択

--- a/tests/processors/test_contour_processor.py
+++ b/tests/processors/test_contour_processor.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 from pochivision.exceptions import ProcessorValidationError
-from pochivision.processors.contour import ContourProcessor
+from pochivision.processors.contour import ContourProcessor, find_contours_compat
 from pochivision.processors.validators.contour import ContourValidator
 
 
@@ -379,6 +379,85 @@ class TestContourProcessor:
             ContourProcessor._get_approximation_method("unknown")
             == cv2.CHAIN_APPROX_SIMPLE
         )
+
+    def test_last_hierarchy_is_preserved_after_process(self):
+        """process 実行後に階層情報が保持されていることをテストします."""
+        import cv2
+
+        # RETR_TREE で階層情報を取得する設定
+        processor = ContourProcessor(
+            name="contour_tree",
+            config={"retrieval_mode": "tree", "min_area": 0, "select_mode": "all"},
+        )
+
+        # 外側の四角形の内側に穴 (内側四角形) を持つ二値画像
+        binary_image = np.zeros((100, 100), dtype=np.uint8)
+        binary_image[10:90, 10:90] = 255  # 外側
+        binary_image[30:70, 30:70] = 0  # 穴
+        binary_image[40:60, 40:60] = 255  # 内側
+
+        processor.process(binary_image)
+
+        # 階層情報が保持されていること
+        assert processor.last_hierarchy is not None
+        assert isinstance(processor.last_hierarchy, np.ndarray)
+        # cv2.findContours の階層情報は (1, N, 4) 形状
+        assert processor.last_hierarchy.ndim == 3
+        assert processor.last_hierarchy.shape[2] == 4
+        # 輪郭数と階層情報のエントリ数が一致すること
+        assert processor.last_hierarchy.shape[1] == len(processor.last_contours)
+        # RETR_TREE で少なくとも 3 つの輪郭が検出されるはず
+        assert len(processor.last_contours) >= 3
+
+        # retrieval_mode が tree の場合, 親子関係を表す列 (index 3) に
+        # 非 -1 の値が少なくとも 1 つ存在すること (親あり輪郭が存在する).
+        hierarchy = processor.last_hierarchy[0]
+        assert any(row[3] != -1 for row in hierarchy)
+
+        # cv2 定数で呼び出した場合と同等の結果が得られること.
+        contours_direct, hierarchy_direct = find_contours_compat(
+            binary_image, cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE
+        )
+        assert len(contours_direct) == len(processor.last_contours)
+        assert hierarchy_direct is not None
+        assert hierarchy_direct.shape == processor.last_hierarchy.shape
+
+    def test_last_hierarchy_none_for_non_binary_image(self):
+        """非二値画像では階層情報が初期値 None のまま維持されることをテストします."""
+        processor = ContourProcessor(name="contour_nb", config={})
+        gray = create_test_image(50, 50, is_binary=False)
+        processor.process(gray)
+        # バリデーションで早期 return するため, 階層情報は初期値のまま.
+        assert processor.last_hierarchy is None
+        assert processor.last_contours == []
+
+    def test_find_contours_compat_returns_contours_and_hierarchy(self):
+        """find_contours_compat が輪郭と階層情報を返すことをテストします."""
+        import cv2
+
+        binary_image = np.zeros((60, 60), dtype=np.uint8)
+        binary_image[10:50, 10:50] = 255
+
+        contours, hierarchy = find_contours_compat(
+            binary_image, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE
+        )
+
+        assert isinstance(contours, list)
+        assert len(contours) == 1
+        assert hierarchy is not None
+        assert hierarchy.shape == (1, 1, 4)
+
+    def test_find_contours_compat_empty_image(self):
+        """find_contours_compat が輪郭ゼロの画像を安全に扱えることをテストします."""
+        import cv2
+
+        empty = np.zeros((20, 20), dtype=np.uint8)
+        contours, hierarchy = find_contours_compat(
+            empty, cv2.RETR_LIST, cv2.CHAIN_APPROX_SIMPLE
+        )
+        assert contours == []
+        # 輪郭ゼロの場合 hierarchy は None (OpenCV 4.x の仕様).
+        assert hierarchy is None
 
     def test_float_image_processing(self):
         """float32型の画像処理をテストします."""


### PR DESCRIPTION
## Summary

- `cv2.findContours` の戻り値を OpenCV 3.x/4.x 双方に対応するラッパー `find_contours_compat` で安全に展開するよう変更.
- 階層情報 (`hierarchy`) を破棄せず `ContourProcessor` 上で保持し, 後段の処理や将来の親子関係フィルタ拡張から参照可能にする.

## Related Issue

Closes #383

## Changes

- `pochivision/processors/contour.py`: `find_contours_compat` ヘルパを追加. `ContourProcessor` に `last_contours` / `last_hierarchy` プロパティを追加し, `process` 内で階層情報を保持するよう変更.
- `tests/processors/test_contour_processor.py`: 階層情報保持とラッパー関数に対するテストを追加.

## Test Plan

- [x] `RETR_TREE` で `last_hierarchy` が `(1, N, 4)` 形状で保持される
- [x] 輪郭数と `last_hierarchy` のエントリ数が一致する
- [x] 非二値画像では `last_hierarchy` が初期値 `None` のまま維持される
- [x] `find_contours_compat` が輪郭ゼロ入力でも `None` hierarchy を安全に返す
- [x] 既存テスト (26 件) がすべて pass する

## Checklist

- [x] pre-commit 全 pass