### PR TITLE
refactor: CLAHEProcessor に update_params メソッドを追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@
 - 無し
 
 ### Changed
-- 無し
+- `GrayscaleProcessor` で既にグレースケール化された入力 (`ndim == 2` / `shape[2] == 1`) を早期リターンし, 冗長な `cv2.cvtColor` 呼び出しを回避. ([#391](https://github.com/kurorosu/pochivision/pull/391))
+- `ContourProcessor` で `cv2.findContours` の階層情報 (`hierarchy`) を `last_contours` / `last_hierarchy` として保持. OpenCV 3.x/4.x 両対応の `find_contours_compat` ラッパーを追加. ([#392](https://github.com/kurorosu/pochivision/pull/392))
+- `CLAHEProcessor` に `update_params(clip_limit, tile_grid_size)` を追加. 内部 CLAHE オブジェクトを再生成することで動的なパラメータ変更に対応. ([#393](https://github.com/kurorosu/pochivision/pull/393))
 
 ### Fixed
 - `GaussianBlurProcessor` / `MedianBlurProcessor` のカーネルサイズに対する奇数チェックを追加. 偶数・0 以下・1 を設定した場合, 実行時の `cv2.error` ではなく起動時に `ProcessorValidationError` を投げるよう修正. ([#384](https://github.com/kurorosu/pochivision/pull/384))

--- a/pochivision/processors/clahe.py
+++ b/pochivision/processors/clahe.py
@@ -60,6 +60,48 @@ class CLAHEProcessor(BaseProcessor):
             clipLimit=self.clip_limit, tileGridSize=self.tile_grid_size
         )
 
+    def update_params(
+        self,
+        clip_limit: float | None = None,
+        tile_grid_size: tuple[int, int] | list[int] | None = None,
+    ) -> None:
+        """CLAHE のパラメータを動的に更新する.
+
+        指定されたパラメータを反映したうえで内部の CLAHE オブジェクトを再生成する.
+        省略されたパラメータは現在の値を維持する.
+
+        Args:
+            clip_limit (float | None, optional): 新しいコントラスト制限値.
+                正の値でなければならない. デフォルトは None (変更しない).
+            tile_grid_size (tuple[int, int] | list[int] | None, optional):
+                新しいタイルグリッドサイズ. 長さ 2 かつ各要素が正の整数でなければならない.
+                デフォルトは None (変更しない).
+
+        Raises:
+            ValueError: パラメータが不正な場合.
+        """
+        if clip_limit is not None:
+            if clip_limit <= 0:
+                raise ValueError(f"clip_limit must be > 0, got {clip_limit}")
+            self.clip_limit = float(clip_limit)
+
+        if tile_grid_size is not None:
+            size = tuple(tile_grid_size)
+            if len(size) != 2 or not all(isinstance(v, int) and v > 0 for v in size):
+                raise ValueError(
+                    "tile_grid_size must be a length-2 sequence of positive "
+                    f"integers, got {tile_grid_size}"
+                )
+            self.tile_grid_size = size
+
+        # 設定ディクショナリも同期させる.
+        self.config["clip_limit"] = self.clip_limit
+        self.config["tile_grid_size"] = list(self.tile_grid_size)
+
+        self.clahe = cv2.createCLAHE(
+            clipLimit=self.clip_limit, tileGridSize=self.tile_grid_size
+        )
+
     def process(self, image: np.ndarray) -> np.ndarray:
         """
         CLAHE処理を実行します.

--- a/pochivision/processors/clahe.py
+++ b/pochivision/processors/clahe.py
@@ -24,6 +24,13 @@ class CLAHEProcessor(BaseProcessor):
     - 'lab': LAB色空間に変換して輝度（L）チャンネルのみを平坦化
     - 'bgr': BGR各チャンネルを個別に平坦化
 
+    Note:
+        OpenCV の CLAHE オブジェクトは `__init__` 時に `cv2.createCLAHE()` で生成してキャッシュしている.
+        他の多くのプロセッサは `process()` 呼び出しごとに OpenCV 関数を呼ぶため属性の書き換えで
+        パラメータ変更が反映されるが, 本プロセッサはキャッシュ済みオブジェクトが使われるため
+        `clip_limit` / `tile_grid_size` 属性を書き換えても反映されない. 動的な変更には
+        `update_params()` を呼び出し内部オブジェクトを再生成する必要がある.
+
     登録名:
         "clahe"
 

--- a/tests/processors/test_clahe_processor.py
+++ b/tests/processors/test_clahe_processor.py
@@ -182,6 +182,106 @@ def test_clahe_invalid_color_mode():
         get_processor("clahe", {"color_mode": "invalid"})
 
 
+def test_clahe_update_params_clip_limit_only():
+    """update_params で clip_limit だけを更新できる."""
+    processor = CLAHEProcessor(name="clahe", config={})
+    assert processor.clip_limit == 2.0
+    assert processor.tile_grid_size == (8, 8)
+
+    processor.update_params(clip_limit=4.0)
+
+    assert processor.clip_limit == 4.0
+    # tile_grid_size は維持される.
+    assert processor.tile_grid_size == (8, 8)
+    # config も同期されている.
+    assert processor.config["clip_limit"] == 4.0
+    assert processor.config["tile_grid_size"] == [8, 8]
+
+
+def test_clahe_update_params_tile_grid_only():
+    """update_params で tile_grid_size だけを更新できる."""
+    processor = CLAHEProcessor(name="clahe", config={})
+
+    processor.update_params(tile_grid_size=[16, 16])
+
+    assert processor.clip_limit == 2.0
+    assert processor.tile_grid_size == (16, 16)
+    assert processor.config["tile_grid_size"] == [16, 16]
+
+
+def test_clahe_update_params_both():
+    """update_params で両方を同時に更新できる."""
+    processor = CLAHEProcessor(name="clahe", config={})
+
+    processor.update_params(clip_limit=3.5, tile_grid_size=(4, 4))
+
+    assert processor.clip_limit == 3.5
+    assert processor.tile_grid_size == (4, 4)
+
+
+def test_clahe_update_params_reflected_in_process():
+    """update_params 後の process() が新パラメータで動作する."""
+    processor = CLAHEProcessor(name="clahe", config={})
+
+    image = np.copy(DUMMY_GRAY_IMAGE)
+    image[30:70, 30:70] = 200
+
+    # 更新前の結果.
+    result_before = processor.process(image)
+
+    # パラメータ更新.
+    processor.update_params(clip_limit=10.0, tile_grid_size=(4, 4))
+    result_after = processor.process(image)
+
+    # 期待結果を新パラメータで cv2 から直接計算.
+    expected = cv2.createCLAHE(clipLimit=10.0, tileGridSize=(4, 4)).apply(image)
+    assert np.array_equal(result_after, expected)
+
+    # 更新前後で出力が変化している.
+    assert not np.array_equal(result_before, result_after)
+
+
+def test_clahe_update_params_invalid_clip_limit():
+    """不正な clip_limit は ValueError になる."""
+    processor = CLAHEProcessor(name="clahe", config={})
+
+    with pytest.raises(ValueError):
+        processor.update_params(clip_limit=0.0)
+
+    with pytest.raises(ValueError):
+        processor.update_params(clip_limit=-1.0)
+
+
+def test_clahe_update_params_invalid_tile_grid_size():
+    """不正な tile_grid_size は ValueError になる."""
+    processor = CLAHEProcessor(name="clahe", config={})
+
+    with pytest.raises(ValueError):
+        processor.update_params(tile_grid_size=[8])
+
+    with pytest.raises(ValueError):
+        processor.update_params(tile_grid_size=[8, 8, 8])
+
+    with pytest.raises(ValueError):
+        processor.update_params(tile_grid_size=[0, 8])
+
+    with pytest.raises(ValueError):
+        processor.update_params(tile_grid_size=[-1, 8])
+
+
+def test_clahe_update_params_no_args_is_noop():
+    """引数なしの update_params では値が変わらず CLAHE は再生成される."""
+    processor = CLAHEProcessor(name="clahe", config={})
+    old_clahe = processor.clahe
+
+    processor.update_params()
+
+    assert processor.clip_limit == 2.0
+    assert processor.tile_grid_size == (8, 8)
+    # 再生成されて別インスタンスになる.
+    assert processor.clahe is not old_clahe
+
+
 def test_clahe_invalid_input():
     """無効な入力テスト."""
     processor = CLAHEProcessor(name="clahe", config={})


### PR DESCRIPTION
## Summary

- `CLAHEProcessor` は `__init__` 時点で CLAHE オブジェクトを保持するため `clip_limit` や `tile_grid_size` を後から変更できなかった.
- `update_params()` メソッドを追加し, 内部の CLAHE オブジェクトを再生成することで動的なパラメータ変更を可能にした.

## Related Issue

Closes #382

## Changes

- `pochivision/processors/clahe.py`: `CLAHEProcessor.update_params(clip_limit, tile_grid_size)` を追加. 引数に応じて値を更新し, 不正値は `ValueError` を送出. `self.config` も同期したうえで `cv2.createCLAHE` を再生成する.
- `tests/processors/test_clahe_processor.py`: `update_params` の個別更新・同時更新・`process()` への反映・不正値・引数なし再生成を検証するテストを追加.

## Test Plan

- [x] `clip_limit` のみ / `tile_grid_size` のみ / 両方を更新した際にそれぞれ期待通りの値になる
- [x] `update_params` 後の `process()` が新しい CLAHE パラメータで動作することを `cv2.createCLAHE` の直接呼び出しと比較して確認
- [x] `clip_limit <= 0` および長さ不正・非正整数の `tile_grid_size` で `ValueError` が送出される
- [x] 引数なし呼び出しでは値は維持され, 内部 CLAHE インスタンスが再生成される
- [x] 既存テスト (10 件) が引き続き pass する

## Checklist

- [x] pre-commit 全 pass