### PR TITLE
docs: BaseValidator docstring から削除済み validate_config の言及を除去

### DIFF
--- a/pochivision/processors/validators/base.py
+++ b/pochivision/processors/validators/base.py
@@ -8,13 +8,17 @@ from pochivision.exceptions import ProcessorValidationError
 
 
 class BaseValidator(ABC):
-    """
-    すべてのバリデータの基底クラス.
+    """すべてのバリデータの基底クラス.
 
-    各プロセッサ用バリデータは、このクラスを継承して
-    validate_config および validate_image メソッドを実装する必要があります.
+    各プロセッサ用バリデータは, このクラスを継承して `validate_image` を実装する.
+    共通バリデーションメソッドも提供する.
 
-    共通バリデーションメソッドも提供します.
+    Note:
+        設定 (config) の検証は本クラスの責務ではなく, プロセッサスキーマ
+        (`get_processor` 経由) に一本化されている. 過去に存在した
+        `validate_config` 抽象メソッドは PR #238 で意図的に削除済み.
+        config 検証ロジックを追加したい場合は, スキーマ側 (`schemas/`) を
+        拡張すること. バリデータに `validate_config` を再追加してはならない.
     """
 
     @abstractmethod


### PR DESCRIPTION
## Summary

- `BaseValidator` の docstring から削除済み `validate_config` への言及を除去.
- 設定検証はスキーマに一本化されている旨を Note として明記し, 再追加しないよう明文化.

## Related Issue

Closes #395

## Changes

- `pochivision/processors/validators/base.py`: クラス docstring を更新. `validate_config` への言及を削除し, スキーマ検証に一本化済みである旨と再追加禁止を Note に記載.

## Test Plan

- [x] docstring のみの変更のため機能影響なし (pre-commit 全 pass で確認)

## Checklist

- [x] pre-commit 全 pass
