### PR TITLE
refactor: Registry で重複登録時に例外を発生させる

### DIFF
--- a/pochivision/exceptions/__init__.py
+++ b/pochivision/exceptions/__init__.py
@@ -2,18 +2,24 @@
 
 from .base import VisionCaptureError
 from .config import CameraConfigError, ConfigLoadError, ConfigValidationError
-from .extractor import ExtractorValidationError
+from .extractor import ExtractorRegistrationError, ExtractorValidationError
 from .inference import InferenceConnectionError, InferenceError
-from .processor import ProcessorRuntimeError, ProcessorValidationError
+from .processor import (
+    ProcessorRegistrationError,
+    ProcessorRuntimeError,
+    ProcessorValidationError,
+)
 
 __all__ = [
     "VisionCaptureError",
     "ProcessorValidationError",
     "ProcessorRuntimeError",
+    "ProcessorRegistrationError",
     "ConfigValidationError",
     "ConfigLoadError",
     "CameraConfigError",
     "ExtractorValidationError",
+    "ExtractorRegistrationError",
     "InferenceError",
     "InferenceConnectionError",
 ]

--- a/pochivision/exceptions/extractor.py
+++ b/pochivision/exceptions/extractor.py
@@ -7,3 +7,9 @@ class ExtractorValidationError(VisionCaptureError, ValueError):
     """特徴量抽出器の入力バリデーションエラー用例外クラス."""
 
     pass
+
+
+class ExtractorRegistrationError(VisionCaptureError, ValueError):
+    """特徴量抽出器のレジストリ登録エラー用例外クラス."""
+
+    pass

--- a/pochivision/exceptions/processor.py
+++ b/pochivision/exceptions/processor.py
@@ -13,3 +13,9 @@ class ProcessorRuntimeError(VisionCaptureError, RuntimeError):
     """プロセッサ実行時のエラー用例外クラス."""
 
     pass
+
+
+class ProcessorRegistrationError(VisionCaptureError, ValueError):
+    """プロセッサのレジストリ登録エラー用例外クラス."""
+
+    pass

--- a/pochivision/feature_extractors/registry.py
+++ b/pochivision/feature_extractors/registry.py
@@ -13,6 +13,7 @@
 from typing import Any, Callable
 
 from pochivision.capturelib.log_manager import LogManager
+from pochivision.exceptions import ExtractorRegistrationError
 
 from .base import BaseFeatureExtractor
 from .schema import EXTRACTOR_SCHEMA_MAP
@@ -25,23 +26,37 @@ FEATURE_EXTRACTOR_REGISTRY: dict[str, type[BaseFeatureExtractor]] = {}
 
 def register_feature_extractor(
     name: str,
+    override: bool = False,
 ) -> Callable[[type[BaseFeatureExtractor]], type[BaseFeatureExtractor]]:
     """
     特徴量抽出器クラスを名前付きで登録するためのデコレータ.
 
     Args:
         name (str): 登録する特徴量抽出器の名前.
+        override (bool): True の場合, 既存登録の上書きを許可する.
+            False (デフォルト) の場合, 重複登録時に例外を送出する.
 
     Returns:
         Callable: デコレートされたクラスをそのまま返す.
+
+    Raises:
+        ExtractorRegistrationError: 同名の特徴量抽出器が既に登録されており,
+            ``override=False`` の場合.
     """
 
     def decorator(cls: type[BaseFeatureExtractor]) -> type[BaseFeatureExtractor]:
         if name in FEATURE_EXTRACTOR_REGISTRY:
+            existing = FEATURE_EXTRACTOR_REGISTRY[name]
+            if not override:
+                raise ExtractorRegistrationError(
+                    f"Feature extractor '{name}' is already registered "
+                    f"({existing.__name__}). "
+                    f"Pass override=True to replace it with {cls.__name__}."
+                )
             logger.warning(
                 f"Feature extractor '{name}' is already registered "
-                f"({FEATURE_EXTRACTOR_REGISTRY[name].__name__}), "
-                f"overwriting with {cls.__name__}"
+                f"({existing.__name__}), "
+                f"overwriting with {cls.__name__} (override=True)"
             )
         FEATURE_EXTRACTOR_REGISTRY[name] = cls
         return cls

--- a/pochivision/processors/registry.py
+++ b/pochivision/processors/registry.py
@@ -13,11 +13,12 @@
 from typing import Any, Callable
 
 from pochivision.capturelib.log_manager import LogManager
-
-logger = LogManager().get_logger()
+from pochivision.exceptions import ProcessorRegistrationError
 
 from .base import BaseProcessor
 from .schema import PROCESSOR_SCHEMA_MAP
+
+logger = LogManager().get_logger()
 
 # 名前とクラスのマッピングを保持する辞書
 PROCESSOR_REGISTRY: dict[str, type[BaseProcessor]] = {}
@@ -25,23 +26,37 @@ PROCESSOR_REGISTRY: dict[str, type[BaseProcessor]] = {}
 
 def register_processor(
     name: str,
+    override: bool = False,
 ) -> Callable[[type[BaseProcessor]], type[BaseProcessor]]:
     """
     画像処理プロセッサクラスを名前付きで登録するためのデコレータ.
 
     Args:
         name (str): 登録するプロセッサの名前.
+        override (bool): True の場合, 既存登録の上書きを許可する.
+            False (デフォルト) の場合, 重複登録時に例外を送出する.
 
     Returns:
         Callable: デコレートされたクラスをそのまま返す.
+
+    Raises:
+        ProcessorRegistrationError: 同名のプロセッサが既に登録されており,
+            ``override=False`` の場合.
     """
 
     def decorator(cls: type[BaseProcessor]) -> type[BaseProcessor]:
         if name in PROCESSOR_REGISTRY:
+            existing = PROCESSOR_REGISTRY[name]
+            if not override:
+                raise ProcessorRegistrationError(
+                    f"Processor '{name}' is already registered "
+                    f"({existing.__name__}). "
+                    f"Pass override=True to replace it with {cls.__name__}."
+                )
             logger.warning(
                 f"Processor '{name}' is already registered "
-                f"({PROCESSOR_REGISTRY[name].__name__}), "
-                f"overwriting with {cls.__name__}"
+                f"({existing.__name__}), "
+                f"overwriting with {cls.__name__} (override=True)"
             )
         PROCESSOR_REGISTRY[name] = cls
         return cls

--- a/tests/extractors/test_registry_duplicate.py
+++ b/tests/extractors/test_registry_duplicate.py
@@ -1,0 +1,80 @@
+"""feature_extractors/registry.py の重複登録チェックに関するテスト."""
+
+from collections.abc import Generator
+
+import numpy as np
+import pytest
+
+from pochivision.exceptions import ExtractorRegistrationError
+from pochivision.feature_extractors.base import BaseFeatureExtractor
+from pochivision.feature_extractors.registry import (
+    FEATURE_EXTRACTOR_REGISTRY,
+    register_feature_extractor,
+)
+
+
+class _DummyExtractorA(BaseFeatureExtractor):
+    """テスト用ダミー特徴量抽出器 A."""
+
+    def extract(self, image: np.ndarray) -> dict[str, float | int]:
+        """空辞書を返す."""
+        return {}
+
+    @staticmethod
+    def get_default_config() -> dict:
+        """デフォルト設定を返す."""
+        return {}
+
+    @staticmethod
+    def get_feature_names() -> list[str]:
+        """特徴量名リストを返す."""
+        return []
+
+
+class _DummyExtractorB(BaseFeatureExtractor):
+    """テスト用ダミー特徴量抽出器 B."""
+
+    def extract(self, image: np.ndarray) -> dict[str, float | int]:
+        """空辞書を返す."""
+        return {}
+
+    @staticmethod
+    def get_default_config() -> dict:
+        """デフォルト設定を返す."""
+        return {}
+
+    @staticmethod
+    def get_feature_names() -> list[str]:
+        """特徴量名リストを返す."""
+        return []
+
+
+@pytest.fixture
+def temp_name() -> Generator[str, None, None]:
+    """登録名を一意にし, テスト後にレジストリから除去するフィクスチャ."""
+    name = "__test_dup_extractor__"
+    FEATURE_EXTRACTOR_REGISTRY.pop(name, None)
+    yield name
+    FEATURE_EXTRACTOR_REGISTRY.pop(name, None)
+
+
+def test_register_extractor_first_time_succeeds(temp_name: str) -> None:
+    """初回登録は成功する."""
+    register_feature_extractor(temp_name)(_DummyExtractorA)
+    assert FEATURE_EXTRACTOR_REGISTRY[temp_name] is _DummyExtractorA
+
+
+def test_register_extractor_duplicate_raises(temp_name: str) -> None:
+    """重複登録時に ExtractorRegistrationError が送出される."""
+    register_feature_extractor(temp_name)(_DummyExtractorA)
+    with pytest.raises(ExtractorRegistrationError) as exc_info:
+        register_feature_extractor(temp_name)(_DummyExtractorB)
+    assert temp_name in str(exc_info.value)
+    assert FEATURE_EXTRACTOR_REGISTRY[temp_name] is _DummyExtractorA
+
+
+def test_register_extractor_override_true_overwrites(temp_name: str) -> None:
+    """override=True を指定すると上書きが許可される."""
+    register_feature_extractor(temp_name)(_DummyExtractorA)
+    register_feature_extractor(temp_name, override=True)(_DummyExtractorB)
+    assert FEATURE_EXTRACTOR_REGISTRY[temp_name] is _DummyExtractorB

--- a/tests/processors/test_registry_duplicate.py
+++ b/tests/processors/test_registry_duplicate.py
@@ -1,0 +1,68 @@
+"""processors/registry.py の重複登録チェックに関するテスト."""
+
+from collections.abc import Generator
+
+import numpy as np
+import pytest
+
+from pochivision.exceptions import ProcessorRegistrationError
+from pochivision.processors.base import BaseProcessor
+from pochivision.processors.registry import PROCESSOR_REGISTRY, register_processor
+
+
+class _DummyProcessorA(BaseProcessor):
+    """テスト用ダミープロセッサ A."""
+
+    def process(self, image: np.ndarray) -> np.ndarray:
+        """入力画像をそのまま返す."""
+        return image
+
+    @staticmethod
+    def get_default_config() -> dict:
+        """デフォルト設定を返す."""
+        return {}
+
+
+class _DummyProcessorB(BaseProcessor):
+    """テスト用ダミープロセッサ B."""
+
+    def process(self, image: np.ndarray) -> np.ndarray:
+        """入力画像をそのまま返す."""
+        return image
+
+    @staticmethod
+    def get_default_config() -> dict:
+        """デフォルト設定を返す."""
+        return {}
+
+
+@pytest.fixture
+def temp_name() -> Generator[str, None, None]:
+    """登録名を一意にし, テスト後にレジストリから除去するフィクスチャ."""
+    name = "__test_dup_processor__"
+    PROCESSOR_REGISTRY.pop(name, None)
+    yield name
+    PROCESSOR_REGISTRY.pop(name, None)
+
+
+def test_register_processor_first_time_succeeds(temp_name: str) -> None:
+    """初回登録は成功する."""
+    register_processor(temp_name)(_DummyProcessorA)
+    assert PROCESSOR_REGISTRY[temp_name] is _DummyProcessorA
+
+
+def test_register_processor_duplicate_raises(temp_name: str) -> None:
+    """重複登録時に ProcessorRegistrationError が送出される."""
+    register_processor(temp_name)(_DummyProcessorA)
+    with pytest.raises(ProcessorRegistrationError) as exc_info:
+        register_processor(temp_name)(_DummyProcessorB)
+    assert temp_name in str(exc_info.value)
+    # 既存登録は維持される
+    assert PROCESSOR_REGISTRY[temp_name] is _DummyProcessorA
+
+
+def test_register_processor_override_true_overwrites(temp_name: str) -> None:
+    """override=True を指定すると上書きが許可される."""
+    register_processor(temp_name)(_DummyProcessorA)
+    register_processor(temp_name, override=True)(_DummyProcessorB)
+    assert PROCESSOR_REGISTRY[temp_name] is _DummyProcessorB


### PR DESCRIPTION
## Summary

- `@register_processor` / `@register_feature_extractor` の重複登録で警告ログのみ出して上書きする挙動を, 既定で例外送出に変更し, 予期しない上書きによるバグの混入を防ぐ.
- 意図的な置き換えのために `override=True` フラグを追加し, 後方互換の手段を確保.

## Related Issue

Closes #378

## Changes

- `pochivision/exceptions/processor.py`: `ProcessorRegistrationError` を新規追加.
- `pochivision/exceptions/extractor.py`: `ExtractorRegistrationError` を新規追加.
- `pochivision/exceptions/__init__.py`: 上記例外を公開.
- `pochivision/processors/registry.py`: `register_processor(name, override=False)` で重複時に `ProcessorRegistrationError` を送出. `override=True` 指定時のみ警告ログを出して上書き.
- `pochivision/feature_extractors/registry.py`: `register_feature_extractor(name, override=False)` で同様に `ExtractorRegistrationError` を送出.
- `tests/processors/test_registry_duplicate.py`: 初回登録成功 / 重複時例外 / `override=True` での上書きを検証する 3 ケースを追加.
- `tests/extractors/test_registry_duplicate.py`: 同等の 3 ケースを追加.

## Test Plan

- [x] 同名プロセッサの再登録で `ProcessorRegistrationError` が送出される
- [x] 同名特徴量抽出器の再登録で `ExtractorRegistrationError` が送出される
- [x] `override=True` 指定時のみ既存登録が上書きされる
- [x] 例外送出時に既存登録が変更されない
- [x] 既存の登録済みプロセッサ / 抽出器のロードに影響がない (全テスト pass)

## Checklist

- [x] pre-commit 全 pass
