### PR TITLE
refactor: PR #403 レビューの軽微指摘を一括解消

### DIFF
--- a/pochivision/request/api/detection/client.py
+++ b/pochivision/request/api/detection/client.py
@@ -154,7 +154,7 @@ class DetectionClient:
             "image_data": image_data,
             "format": "raw",
             "shape": list(frame.shape),
-            "dtype": str(frame.dtype),
+            "dtype": frame.dtype.name,
         }
 
     def _encode_jpeg(self, frame: np.ndarray) -> dict[str, Any]:

--- a/pochivision/request/api/inference/__init__.py
+++ b/pochivision/request/api/inference/__init__.py
@@ -1,4 +1,4 @@
-"""inferenceパッケージ:pochitrain 推論 API との連携機能を提供します."""
+"""inference パッケージ: pochitrain 推論 API との連携機能を提供します."""
 
 from .client import InferenceClient
 from .config import InferConfig, ResizeConfig, load_infer_config

--- a/tests/request/api/detection/test_client.py
+++ b/tests/request/api/detection/test_client.py
@@ -281,6 +281,40 @@ class TestDetect:
         with pytest.raises(DetectionError, match="フォーマット"):
             client.detect(_make_frame())
 
+    def test_detections_field_wrong_type(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={
+                    "detections": "not-a-list",
+                    "e2e_time_ms": 1.0,
+                    "backend": "onnx",
+                },
+            )
+
+        client = DetectionClient(base_url="http://localhost:8000")
+        client._client = httpx.Client(transport=httpx.MockTransport(handler))
+
+        with pytest.raises(DetectionError, match="フォーマット"):
+            client.detect(_make_frame())
+
+    def test_detection_item_not_dict(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={
+                    "detections": [123],
+                    "e2e_time_ms": 1.0,
+                    "backend": "onnx",
+                },
+            )
+
+        client = DetectionClient(base_url="http://localhost:8000")
+        client._client = httpx.Client(transport=httpx.MockTransport(handler))
+
+        with pytest.raises(DetectionError, match="フォーマット"):
+            client.detect(_make_frame())
+
     def test_malformed_detection_item(self):
         def handler(request: httpx.Request) -> httpx.Response:
             return httpx.Response(


### PR DESCRIPTION
## Summary

- PR [#403](https://github.com/kurorosu/pochivision/pull/403) レビュー時に残った軽微指摘を一括対応. dtype 文字列正規化, malformed JSON パターン追加, inference docstring の spacing 修正.

## Related Issue

Closes #405

## Changes

- `pochivision/request/api/detection/client.py`: `_encode_raw` の dtype を `str(frame.dtype)` → `frame.dtype.name` に変更
- `pochivision/request/api/inference/__init__.py`: docstring の半角スペース補正
- `tests/request/api/detection/test_client.py`: malformed JSON パターン 2 件追加 (`detections` が list でない / 要素が dict でない)

## Test Plan

- [x] detections フィールドの型ミス (`"not-a-list"`) で `DetectionError` が送出される
- [x] detection item が dict でない場合でも `DetectionError` が送出される
- [x] `dtype.name` がサーバーへ送信される (既存 raw payload テストで検証)

## Checklist

- [x] pre-commit 全 pass
- [x] fixture 共通化 は対象クラスが異なるためスキップ.