### PR TITLE
feat: 検出結果オーバーレイを追加 (bbox + 推論時間 / RTT / backend)

### DIFF
--- a/pochivision/capture_runner/detection_overlay.py
+++ b/pochivision/capture_runner/detection_overlay.py
@@ -1,0 +1,259 @@
+"""検出結果オーバーレイモジュール."""
+
+from dataclasses import dataclass
+
+import cv2
+import numpy as np
+
+from pochivision.request.api.detection.models import Detection, DetectionResponse
+
+
+@dataclass
+class DetectionContext:
+    """検出オーバーレイに表示する静的コンテキスト情報.
+
+    Attributes:
+        server_url: 検出 API サーバーの URL.
+        image_size: 送信画像サイズ ("WxH" 形式, またはリサイズなしの場合 None).
+    """
+
+    server_url: str
+    image_size: str | None = None
+
+
+class DetectionOverlay:
+    """プレビュー画面に検出結果 (複数 bbox) を描画するクラス.
+
+    各検出を bbox + `"class_name conf"` のラベルで描画し,
+    画面左上に以下を表示する:
+    - 検出数
+    - サーバー側推論時間 (e2e_time_ms)
+    - RTT (rtt_ms)
+    - バックエンド
+    - 送信画像サイズ (context 経由, 任意)
+    - サーバー URL (context 経由, 任意)
+
+    検出失敗時はエラーメッセージを表示する.
+
+    クラスごとの色は class_id から決定的に割り当てる.
+    """
+
+    INFERRING_TEXT = "Detecting..."
+    META_COLOR: tuple[int, int, int] = (200, 200, 200)
+    ERROR_COLOR: tuple[int, int, int] = (0, 0, 200)
+
+    # 決定的な色パレット (BGR). class_id % len(PALETTE) で割当.
+    PALETTE: tuple[tuple[int, int, int], ...] = (
+        (0, 200, 0),  # 緑
+        (0, 200, 200),  # 黄
+        (200, 100, 0),  # 青緑
+        (0, 100, 200),  # 橙
+        (200, 0, 200),  # マゼンタ
+        (200, 0, 0),  # 青
+        (100, 200, 0),  # 若緑
+        (0, 0, 200),  # 赤
+    )
+
+    def __init__(self, context: DetectionContext | None = None) -> None:
+        """コンストラクタ.
+
+        Args:
+            context: サーバー URL や画像サイズなどの静的情報.
+        """
+        self.result: DetectionResponse | None = None
+        self.error_message: str | None = None
+        self.context = context
+        self._inferring = False
+
+    def update(self, result: DetectionResponse) -> None:
+        """検出結果を更新する.
+
+        エラーメッセージがある場合はクリアする.
+
+        Args:
+            result: 検出 API からのレスポンス.
+        """
+        self.result = result
+        self.error_message = None
+
+    def set_error(self, message: str) -> None:
+        """エラーメッセージを設定する.
+
+        Args:
+            message: 表示するエラーメッセージ.
+        """
+        self.error_message = message
+        self.result = None
+
+    def clear(self) -> None:
+        """検出結果とエラーメッセージをクリアする."""
+        self.result = None
+        self.error_message = None
+
+    def set_inferring(self, inferring: bool) -> None:
+        """推論中フラグを設定する.
+
+        Args:
+            inferring: 推論中かどうか.
+        """
+        self._inferring = inferring
+
+    def get_color(self, class_id: int) -> tuple[int, int, int]:
+        """class_id に対応する決定的な BGR 色を返す.
+
+        Args:
+            class_id: クラス ID.
+
+        Returns:
+            BGR カラータプル.
+        """
+        return self.PALETTE[class_id % len(self.PALETTE)]
+
+    def draw(self, frame: np.ndarray) -> np.ndarray:
+        """フレームに bbox とメタ情報を描画する.
+
+        Args:
+            frame: 描画先のフレーム. このフレームを直接変更する.
+
+        Returns:
+            検出結果が描画されたフレーム.
+        """
+        inferring = self._inferring
+        result = self.result
+        error = self.error_message
+
+        if inferring and result is None and error is None:
+            self._draw_text(frame, self.INFERRING_TEXT, self.META_COLOR, y=30)
+            return frame
+
+        if error is not None:
+            self._draw_error(frame, error)
+            return frame
+
+        if result is None:
+            return frame
+
+        self._draw_result(frame, result)
+        return frame
+
+    def _draw_result(self, frame: np.ndarray, result: DetectionResponse) -> None:
+        """検出結果 (bbox + メタ情報) を描画する.
+
+        Args:
+            frame: 描画先のフレーム.
+            result: 検出結果.
+        """
+        for det in result.detections:
+            self._draw_bbox(frame, det)
+
+        lines: list[tuple[str, tuple[int, int, int]]] = [
+            (f"Detections: {len(result.detections)}", self.META_COLOR),
+            (f"Inference: {result.e2e_time_ms:.1f}ms", self.META_COLOR),
+            (f"RTT: {result.rtt_ms:.1f}ms", self.META_COLOR),
+            (f"Backend: {result.backend}", self.META_COLOR),
+        ]
+        if self.context and self.context.image_size:
+            lines.append((f"ImageSize: {self.context.image_size}", self.META_COLOR))
+        if self.context:
+            lines.append((f"Server: {self.context.server_url}", self.META_COLOR))
+
+        y = 30
+        for text, c in lines:
+            self._draw_text(frame, text, c, y=y)
+            y += 25
+
+    def _draw_bbox(self, frame: np.ndarray, det: Detection) -> None:
+        """1 つの検出を bbox + ラベルで描画する.
+
+        Args:
+            frame: 描画先のフレーム.
+            det: 検出結果 1 件.
+        """
+        color = self.get_color(det.class_id)
+        x1, y1, x2, y2 = (int(v) for v in det.bbox)
+        cv2.rectangle(frame, (x1, y1), (x2, y2), color, 2)
+
+        label = f"{det.class_name} {det.confidence:.2f}"
+        font = cv2.FONT_HERSHEY_SIMPLEX
+        font_scale = 0.5
+        thickness = 1
+        (tw, th), baseline = cv2.getTextSize(label, font, font_scale, thickness)
+        label_y = y1 - 6 if y1 - 6 - th >= 0 else y1 + th + 6
+
+        cv2.rectangle(
+            frame,
+            (x1, label_y - th - 4),
+            (x1 + tw + 4, label_y + baseline),
+            color,
+            thickness=cv2.FILLED,
+        )
+        cv2.putText(
+            frame,
+            label,
+            (x1 + 2, label_y),
+            font,
+            font_scale,
+            (0, 0, 0),
+            thickness,
+            cv2.LINE_AA,
+        )
+
+    def _draw_error(self, frame: np.ndarray, error: str) -> None:
+        """エラーメッセージを描画する.
+
+        Args:
+            frame: 描画先のフレーム.
+            error: エラーメッセージ.
+        """
+        lines: list[tuple[str, tuple[int, int, int]]] = [
+            (f"Error: {error}", self.ERROR_COLOR),
+        ]
+        if self.context:
+            lines.append((f"Server: {self.context.server_url}", self.META_COLOR))
+
+        y = 30
+        for text, c in lines:
+            self._draw_text(frame, text, c, y=y)
+            y += 25
+
+    def _draw_text(
+        self,
+        frame: np.ndarray,
+        text: str,
+        color: tuple[int, int, int],
+        y: int,
+    ) -> None:
+        """フレーム左上にアウトライン付きテキストを描画する.
+
+        Args:
+            frame: 描画先のフレーム.
+            text: 表示テキスト.
+            color: BGR カラータプル.
+            y: 描画 Y 座標.
+        """
+        font = cv2.FONT_HERSHEY_SIMPLEX
+        font_scale = 0.6
+        thickness = 2
+        outline_thickness = thickness + 2
+        x = 10
+
+        cv2.putText(
+            frame,
+            text,
+            (x, y),
+            font,
+            font_scale,
+            (0, 0, 0),
+            outline_thickness,
+            cv2.LINE_AA,
+        )
+        cv2.putText(
+            frame,
+            text,
+            (x, y),
+            font,
+            font_scale,
+            color,
+            thickness,
+            cv2.LINE_AA,
+        )

--- a/pochivision/capture_runner/detection_overlay.py
+++ b/pochivision/capture_runner/detection_overlay.py
@@ -98,7 +98,7 @@ class DetectionOverlay:
         """
         self._inferring = inferring
 
-    def get_color(self, class_id: int) -> tuple[int, int, int]:
+    def _get_color(self, class_id: int) -> tuple[int, int, int]:
         """class_id に対応する決定的な BGR 色を返す.
 
         Args:
@@ -112,12 +112,17 @@ class DetectionOverlay:
     def draw(self, frame: np.ndarray) -> np.ndarray:
         """フレームに bbox とメタ情報を描画する.
 
+        BGR 3 チャネル以外のフレームは描画せずそのまま返す.
+
         Args:
             frame: 描画先のフレーム. このフレームを直接変更する.
 
         Returns:
             検出結果が描画されたフレーム.
         """
+        if frame.ndim != 3 or frame.shape[2] != 3:
+            return frame
+
         inferring = self._inferring
         result = self.result
         error = self.error_message
@@ -165,12 +170,25 @@ class DetectionOverlay:
     def _draw_bbox(self, frame: np.ndarray, det: Detection) -> None:
         """1 つの検出を bbox + ラベルで描画する.
 
+        NaN / Inf を含む bbox, x2 <= x1 または y2 <= y1 の反転 bbox,
+        完全にフレーム外の bbox はスキップする.
+
         Args:
             frame: 描画先のフレーム.
             det: 検出結果 1 件.
         """
-        color = self.get_color(det.class_id)
-        x1, y1, x2, y2 = (int(v) for v in det.bbox)
+        bbox = det.bbox
+        if not all(np.isfinite(v) for v in bbox):
+            return
+
+        h, w = frame.shape[:2]
+        x1, y1, x2, y2 = (int(v) for v in bbox)
+        if x2 <= x1 or y2 <= y1:
+            return
+        if x2 < 0 or y2 < 0 or x1 >= w or y1 >= h:
+            return
+
+        color = self._get_color(det.class_id)
         cv2.rectangle(frame, (x1, y1), (x2, y2), color, 2)
 
         label = f"{det.class_name} {det.confidence:.2f}"
@@ -178,19 +196,30 @@ class DetectionOverlay:
         font_scale = 0.5
         thickness = 1
         (tw, th), baseline = cv2.getTextSize(label, font, font_scale, thickness)
-        label_y = y1 - 6 if y1 - 6 - th >= 0 else y1 + th + 6
+
+        # ラベル矩形がフレーム外に飛び出さないようクリップ
+        if y1 - 6 - th >= 0:
+            label_y = y1 - 6
+        else:
+            label_y = y1 + th + 6
+        rect_top = max(0, label_y - th - 4)
+        rect_bottom = min(h - 1, label_y + baseline)
+        rect_left = max(0, x1)
+        rect_right = min(w - 1, x1 + tw + 4)
+        if rect_top >= rect_bottom or rect_left >= rect_right:
+            return
 
         cv2.rectangle(
             frame,
-            (x1, label_y - th - 4),
-            (x1 + tw + 4, label_y + baseline),
+            (rect_left, rect_top),
+            (rect_right, rect_bottom),
             color,
             thickness=cv2.FILLED,
         )
         cv2.putText(
             frame,
             label,
-            (x1 + 2, label_y),
+            (rect_left + 2, label_y),
             font,
             font_scale,
             (0, 0, 0),

--- a/tests/capture_runner/test_detection_overlay.py
+++ b/tests/capture_runner/test_detection_overlay.py
@@ -90,20 +90,20 @@ class TestState:
 
 
 class TestGetColor:
-    """get_color (決定的色割当) のテスト."""
+    """_get_color (決定的色割当) のテスト."""
 
     def test_same_class_id_same_color(self):
         overlay = DetectionOverlay()
-        assert overlay.get_color(0) == overlay.get_color(0)
+        assert overlay._get_color(0) == overlay._get_color(0)
 
     def test_different_class_id_different_color(self):
         overlay = DetectionOverlay()
-        assert overlay.get_color(0) != overlay.get_color(1)
+        assert overlay._get_color(0) != overlay._get_color(1)
 
     def test_class_id_wraps_around_palette(self):
         overlay = DetectionOverlay()
         palette_size = len(DetectionOverlay.PALETTE)
-        assert overlay.get_color(0) == overlay.get_color(palette_size)
+        assert overlay._get_color(0) == overlay._get_color(palette_size)
 
 
 class TestDraw:
@@ -156,7 +156,7 @@ class TestDraw:
         overlay.update(_make_response(detections=(det,)))
         frame = np.zeros((200, 200, 3), dtype=np.uint8)
         result = overlay.draw(frame)
-        expected_color = overlay.get_color(2)
+        expected_color = overlay._get_color(2)
         # bbox 辺上のどこかに期待色が存在する
         b, g, r = expected_color
         match = (result[..., 0] == b) & (result[..., 1] == g) & (result[..., 2] == r)
@@ -171,8 +171,8 @@ class TestDraw:
         overlay.update(_make_response(detections=dets))
         frame = np.zeros((240, 240, 3), dtype=np.uint8)
         result = overlay.draw(frame)
-        c0 = overlay.get_color(0)
-        c1 = overlay.get_color(1)
+        c0 = overlay._get_color(0)
+        c1 = overlay._get_color(1)
         has_c0 = (
             (result[..., 0] == c0[0])
             & (result[..., 1] == c0[1])
@@ -191,4 +191,60 @@ class TestDraw:
         det = _make_detection(bbox=(0.0, 0.0, 50.0, 30.0))
         overlay.update(_make_response(detections=(det,)))
         frame = np.zeros((200, 300, 3), dtype=np.uint8)
+        overlay.draw(frame)
+
+    def test_inverted_bbox_is_skipped(self):
+        overlay = DetectionOverlay()
+        # メタ情報描画領域 (左上) と干渉しないよう右下に inverted bbox を置く
+        det = _make_detection(bbox=(350.0, 350.0, 250.0, 250.0))
+        overlay.update(_make_response(detections=(det,)))
+        frame = np.zeros((400, 400, 3), dtype=np.uint8)
+        original = frame.copy()
+        result = overlay.draw(frame)
+        # 反転 bbox が描画スキップされ, 該当領域に描画がないことを確認
+        np.testing.assert_array_equal(
+            result[245:355, 245:355], original[245:355, 245:355]
+        )
+
+    def test_nan_bbox_does_not_crash(self):
+        overlay = DetectionOverlay()
+        det = _make_detection(bbox=(float("nan"), 10.0, 100.0, 100.0))
+        overlay.update(_make_response(detections=(det,)))
+        frame = np.zeros((200, 200, 3), dtype=np.uint8)
+        overlay.draw(frame)
+
+    def test_inf_bbox_does_not_crash(self):
+        overlay = DetectionOverlay()
+        det = _make_detection(bbox=(0.0, 0.0, float("inf"), 100.0))
+        overlay.update(_make_response(detections=(det,)))
+        frame = np.zeros((200, 200, 3), dtype=np.uint8)
+        overlay.draw(frame)
+
+    def test_bbox_completely_outside_frame_is_skipped(self):
+        overlay = DetectionOverlay()
+        det = _make_detection(bbox=(500.0, 500.0, 600.0, 600.0))
+        overlay.update(_make_response(detections=(det,)))
+        frame = np.zeros((200, 200, 3), dtype=np.uint8)
+        overlay.draw(frame)
+
+    def test_non_bgr_frame_returned_unchanged(self):
+        overlay = DetectionOverlay()
+        overlay.update(_make_response())
+        frame_gray = np.zeros((200, 200), dtype=np.uint8)
+        original = frame_gray.copy()
+        result = overlay.draw(frame_gray)
+        np.testing.assert_array_equal(result, original)
+
+    def test_confidence_zero_boundary(self):
+        overlay = DetectionOverlay()
+        det = _make_detection(confidence=0.0, bbox=(10.0, 10.0, 80.0, 80.0))
+        overlay.update(_make_response(detections=(det,)))
+        frame = np.zeros((200, 200, 3), dtype=np.uint8)
+        overlay.draw(frame)
+
+    def test_confidence_one_boundary(self):
+        overlay = DetectionOverlay()
+        det = _make_detection(confidence=1.0, bbox=(10.0, 10.0, 80.0, 80.0))
+        overlay.update(_make_response(detections=(det,)))
+        frame = np.zeros((200, 200, 3), dtype=np.uint8)
         overlay.draw(frame)

--- a/tests/capture_runner/test_detection_overlay.py
+++ b/tests/capture_runner/test_detection_overlay.py
@@ -1,0 +1,194 @@
+"""DetectionOverlay のテスト."""
+
+import numpy as np
+
+from pochivision.capture_runner.detection_overlay import (
+    DetectionContext,
+    DetectionOverlay,
+)
+from pochivision.request.api.detection.models import Detection, DetectionResponse
+
+
+def _make_detection(
+    class_id: int = 0,
+    class_name: str = "pochi",
+    confidence: float = 0.9,
+    bbox: tuple[float, float, float, float] = (10.0, 20.0, 100.0, 200.0),
+) -> Detection:
+    """テスト用の Detection を生成する."""
+    return Detection(
+        class_id=class_id,
+        class_name=class_name,
+        confidence=confidence,
+        bbox=bbox,
+    )
+
+
+def _make_response(
+    detections: tuple[Detection, ...] = (),
+    e2e_time_ms: float = 12.3,
+    rtt_ms: float = 65.1,
+    backend: str = "onnx",
+) -> DetectionResponse:
+    """テスト用の DetectionResponse を生成する."""
+    if not detections:
+        detections = (_make_detection(),)
+    return DetectionResponse(
+        detections=detections,
+        e2e_time_ms=e2e_time_ms,
+        backend=backend,
+        rtt_ms=rtt_ms,
+    )
+
+
+def _make_context() -> DetectionContext:
+    """テスト用の DetectionContext を生成する."""
+    return DetectionContext(server_url="http://localhost:8000", image_size="640x640")
+
+
+class TestState:
+    """状態遷移のテスト."""
+
+    def test_initial_state(self):
+        overlay = DetectionOverlay()
+        assert overlay.result is None
+        assert overlay.error_message is None
+        assert overlay._inferring is False
+
+    def test_update(self):
+        overlay = DetectionOverlay()
+        result = _make_response()
+        overlay.update(result)
+        assert overlay.result is result
+        assert overlay.error_message is None
+
+    def test_update_clears_error(self):
+        overlay = DetectionOverlay()
+        overlay.set_error("connection error")
+        overlay.update(_make_response())
+        assert overlay.result is not None
+        assert overlay.error_message is None
+
+    def test_set_error_clears_result(self):
+        overlay = DetectionOverlay()
+        overlay.update(_make_response())
+        overlay.set_error("boom")
+        assert overlay.error_message == "boom"
+        assert overlay.result is None
+
+    def test_clear(self):
+        overlay = DetectionOverlay()
+        overlay.update(_make_response())
+        overlay.clear()
+        assert overlay.result is None
+        assert overlay.error_message is None
+
+    def test_set_inferring(self):
+        overlay = DetectionOverlay()
+        overlay.set_inferring(True)
+        assert overlay._inferring is True
+
+
+class TestGetColor:
+    """get_color (決定的色割当) のテスト."""
+
+    def test_same_class_id_same_color(self):
+        overlay = DetectionOverlay()
+        assert overlay.get_color(0) == overlay.get_color(0)
+
+    def test_different_class_id_different_color(self):
+        overlay = DetectionOverlay()
+        assert overlay.get_color(0) != overlay.get_color(1)
+
+    def test_class_id_wraps_around_palette(self):
+        overlay = DetectionOverlay()
+        palette_size = len(DetectionOverlay.PALETTE)
+        assert overlay.get_color(0) == overlay.get_color(palette_size)
+
+
+class TestDraw:
+    """draw のテスト."""
+
+    def test_no_result_returns_frame_unchanged(self):
+        overlay = DetectionOverlay()
+        frame = np.zeros((200, 400, 3), dtype=np.uint8)
+        original = frame.copy()
+        result = overlay.draw(frame)
+        np.testing.assert_array_equal(result, original)
+
+    def test_inferring_draws_text_when_no_result(self):
+        overlay = DetectionOverlay()
+        overlay.set_inferring(True)
+        frame = np.zeros((200, 400, 3), dtype=np.uint8)
+        result = overlay.draw(frame)
+        assert result.sum() > 0
+
+    def test_error_draws_on_frame(self):
+        overlay = DetectionOverlay(context=_make_context())
+        overlay.set_error("connection refused")
+        frame = np.zeros((200, 400, 3), dtype=np.uint8)
+        result = overlay.draw(frame)
+        assert result.sum() > 0
+
+    def test_empty_detections_draws_meta_only(self):
+        overlay = DetectionOverlay()
+        overlay.update(_make_response(detections=()))
+        frame = np.zeros((200, 400, 3), dtype=np.uint8)
+        # 空の tuple を渡すと _make_response がデフォルト値を入れてしまうので回避
+        overlay.result = DetectionResponse(
+            detections=(), e2e_time_ms=5.0, backend="onnx", rtt_ms=10.0
+        )
+        result = overlay.draw(frame)
+        assert result.sum() > 0
+
+    def test_bbox_drawn_within_frame(self):
+        overlay = DetectionOverlay()
+        det = _make_detection(bbox=(50.0, 60.0, 150.0, 180.0))
+        overlay.update(_make_response(detections=(det,)))
+        frame = np.zeros((240, 320, 3), dtype=np.uint8)
+        result = overlay.draw(frame)
+        # bbox 領域周辺にピクセルが書かれているか
+        assert result[60:180, 50:150].sum() > 0
+
+    def test_bbox_color_matches_class_id(self):
+        overlay = DetectionOverlay()
+        det = _make_detection(class_id=2, bbox=(20.0, 20.0, 100.0, 100.0))
+        overlay.update(_make_response(detections=(det,)))
+        frame = np.zeros((200, 200, 3), dtype=np.uint8)
+        result = overlay.draw(frame)
+        expected_color = overlay.get_color(2)
+        # bbox 辺上のどこかに期待色が存在する
+        b, g, r = expected_color
+        match = (result[..., 0] == b) & (result[..., 1] == g) & (result[..., 2] == r)
+        assert match.any()
+
+    def test_multiple_detections_different_colors(self):
+        overlay = DetectionOverlay()
+        dets = (
+            _make_detection(class_id=0, bbox=(10.0, 10.0, 80.0, 80.0)),
+            _make_detection(class_id=1, bbox=(100.0, 100.0, 180.0, 180.0)),
+        )
+        overlay.update(_make_response(detections=dets))
+        frame = np.zeros((240, 240, 3), dtype=np.uint8)
+        result = overlay.draw(frame)
+        c0 = overlay.get_color(0)
+        c1 = overlay.get_color(1)
+        has_c0 = (
+            (result[..., 0] == c0[0])
+            & (result[..., 1] == c0[1])
+            & (result[..., 2] == c0[2])
+        ).any()
+        has_c1 = (
+            (result[..., 0] == c1[0])
+            & (result[..., 1] == c1[1])
+            & (result[..., 2] == c1[2])
+        ).any()
+        assert has_c0 and has_c1
+
+    def test_label_y_at_top_of_frame_does_not_crash(self):
+        """bbox が画面上端に張り付いてもラベル描画で例外が出ない."""
+        overlay = DetectionOverlay()
+        det = _make_detection(bbox=(0.0, 0.0, 50.0, 30.0))
+        overlay.update(_make_response(detections=(det,)))
+        frame = np.zeros((200, 300, 3), dtype=np.uint8)
+        overlay.draw(frame)


### PR DESCRIPTION
## Summary

- `DetectionOverlay` を追加し, `DetectionResponse` を受け取ってフレームに bbox + ラベル + メタ情報 (検出数, e2e_time_ms, rtt_ms, backend) を描画する.
- 既存 `InferenceOverlay` の API / 状態遷移パターンを踏襲. viewer への統合は [#402](https://github.com/kurorosu/pochivision/issues/402) で対応予定.

## Related Issue

Closes #401

## Changes

- `pochivision/capture_runner/detection_overlay.py`: `DetectionOverlay`, `DetectionContext` を新規実装. クラス ID から決定的に BGR 色を割り当てる 8 色パレット.
- `tests/capture_runner/test_detection_overlay.py`: 状態遷移, 決定的色割当, 描画 (検出あり / なし / エラー / 推論中 / 画面端) のテスト.

## Test Plan

- [x] `update` / `set_error` / `clear` / `set_inferring` の状態遷移が期待通り
- [x] 同一 class_id は常に同色, パレット長を超えるとラップする
- [x] bbox がフレーム領域内に描画され, 期待色で塗られる
- [x] 複数検出で class_id ごとに別色が使われる
- [x] bbox が画面上端に張り付いてもラベル描画で例外が出ない
- [x] 検出 0 件でもメタ情報が描画される

## Checklist

- [x] pre-commit 全 pass