### PR TITLE
refactor: PR #407 レビューの軽微指摘を一括解消

### DIFF
--- a/pochivision/capture_runner/detection_overlay.py
+++ b/pochivision/capture_runner/detection_overlay.py
@@ -114,6 +114,13 @@ class DetectionOverlay:
 
         BGR 3 チャネル以外のフレームは描画せずそのまま返す.
 
+        Note:
+            本メソッドは `self.result` / `self.error_message` / `self._inferring`
+            を読み取るため, 複数スレッドから `update()` / `set_error()` /
+            `set_inferring()` と並行呼び出しすると TOCTOU 競合の可能性がある.
+            呼び出し側でシリアライズすること (ランタイム統合で lock を導入予定:
+            #402).
+
         Args:
             frame: 描画先のフレーム. このフレームを直接変更する.
 

--- a/pochivision/capture_runner/detection_overlay.py
+++ b/pochivision/capture_runner/detection_overlay.py
@@ -115,11 +115,12 @@ class DetectionOverlay:
         BGR 3 チャネル以外のフレームは描画せずそのまま返す.
 
         Note:
-            本メソッドは `self.result` / `self.error_message` / `self._inferring`
-            を読み取るため, 複数スレッドから `update()` / `set_error()` /
-            `set_inferring()` と並行呼び出しすると TOCTOU 競合の可能性がある.
-            呼び出し側でシリアライズすること (ランタイム統合で lock を導入予定:
-            #402).
+            スレッド安全性: 本メソッドは `self.result` / `self.error_message` /
+            `self._inferring` を読み取る. 複数スレッドからの `update()` /
+            `set_error()` / `set_inferring()` と並行実行すると TOCTOU 競合の
+            可能性あり. 呼び出し側でシリアライズすること. ランタイム統合で
+            lock を導入予定
+            ([#402](https://github.com/kurorosu/pochivision/issues/402)).
 
         Args:
             frame: 描画先のフレーム. このフレームを直接変更する.

--- a/tests/capture_runner/test_detection_overlay.py
+++ b/tests/capture_runner/test_detection_overlay.py
@@ -25,13 +25,17 @@ def _make_detection(
 
 
 def _make_response(
-    detections: tuple[Detection, ...] = (),
+    detections: tuple[Detection, ...] | None = None,
     e2e_time_ms: float = 12.3,
     rtt_ms: float = 65.1,
     backend: str = "onnx",
 ) -> DetectionResponse:
-    """テスト用の DetectionResponse を生成する."""
-    if not detections:
+    """テスト用の DetectionResponse を生成する.
+
+    detections が None の場合はデフォルトの Detection を 1 件含む.
+    空の検出結果をテストしたい場合は明示的に `()` を渡す.
+    """
+    if detections is None:
         detections = (_make_detection(),)
     return DetectionResponse(
         detections=detections,
@@ -88,6 +92,13 @@ class TestState:
         overlay.set_inferring(True)
         assert overlay._inferring is True
 
+    def test_error_then_result_clears_error(self):
+        overlay = DetectionOverlay()
+        overlay.set_error("connection refused")
+        overlay.update(_make_response())
+        assert overlay.error_message is None
+        assert overlay.result is not None
+
 
 class TestGetColor:
     """_get_color (決定的色割当) のテスト."""
@@ -134,12 +145,10 @@ class TestDraw:
         overlay = DetectionOverlay()
         overlay.update(_make_response(detections=()))
         frame = np.zeros((200, 400, 3), dtype=np.uint8)
-        # 空の tuple を渡すと _make_response がデフォルト値を入れてしまうので回避
-        overlay.result = DetectionResponse(
-            detections=(), e2e_time_ms=5.0, backend="onnx", rtt_ms=10.0
-        )
         result = overlay.draw(frame)
         assert result.sum() > 0
+        assert overlay.result is not None
+        assert overlay.result.detections == ()
 
     def test_bbox_drawn_within_frame(self):
         overlay = DetectionOverlay()
@@ -248,3 +257,18 @@ class TestDraw:
         overlay.update(_make_response(detections=(det,)))
         frame = np.zeros((200, 200, 3), dtype=np.uint8)
         overlay.draw(frame)
+
+    def test_text_outline_dark_pixels_drawn(self):
+        """テキストのアウトライン (黒ストローク) が描画されていることを検証.
+
+        LINE_AA のアンチエイリアスにより完全な (0, 0, 0) は稀なため,
+        白背景で十分に暗いピクセル (全チャネル 50 未満) の存在で検証する.
+        """
+        overlay = DetectionOverlay()
+        overlay.update(_make_response(detections=()))
+        frame = np.full((200, 400, 3), 255, dtype=np.uint8)
+        result = overlay.draw(frame)
+        dark_mask = (
+            (result[..., 0] < 50) & (result[..., 1] < 50) & (result[..., 2] < 50)
+        )
+        assert dark_mask.any()

--- a/tests/capture_runner/test_detection_overlay.py
+++ b/tests/capture_runner/test_detection_overlay.py
@@ -32,8 +32,11 @@ def _make_response(
 ) -> DetectionResponse:
     """テスト用の DetectionResponse を生成する.
 
-    detections が None の場合はデフォルトの Detection を 1 件含む.
-    空の検出結果をテストしたい場合は明示的に `()` を渡す.
+    - `detections=None` (デフォルト): 代表的な Detection を 1 件含む応答を返す
+    - `detections=()`: 空の検出応答を返す (メタ情報描画のみ検証したい場合に使う)
+    - `detections=(det1, det2, ...)`: 明示的に指定した検出だけを含む
+
+    暗黙のデフォルト検出に依存するテストは呼び出し側で意図を明記すること.
     """
     if detections is None:
         detections = (_make_detection(),)
@@ -141,8 +144,28 @@ class TestDraw:
         result = overlay.draw(frame)
         assert result.sum() > 0
 
+    def test_error_draws_without_context(self):
+        """context なしでも error メッセージが描画される."""
+        overlay = DetectionOverlay()
+        overlay.set_error("boom")
+        frame = np.zeros((200, 400, 3), dtype=np.uint8)
+        result = overlay.draw(frame)
+        assert result.sum() > 0
+
+    def test_result_takes_precedence_over_inferring(self):
+        """result がある状態で inferring=True でも 'Detecting...' ではなく result を描画する."""
+        overlay = DetectionOverlay()
+        overlay.update(_make_response(detections=()))
+        overlay.set_inferring(True)
+        frame = np.zeros((200, 400, 3), dtype=np.uint8)
+        result = overlay.draw(frame)
+        # 結果のメタが出ており, それは最終状態での result 優先の証左
+        assert result.sum() > 0
+        assert overlay.result is not None
+
     def test_empty_detections_draws_meta_only(self):
         overlay = DetectionOverlay()
+        # detections=() を明示して bbox 描画を発生させずメタ情報のみ描画することを検証
         overlay.update(_make_response(detections=()))
         frame = np.zeros((200, 400, 3), dtype=np.uint8)
         result = overlay.draw(frame)
@@ -261,8 +284,14 @@ class TestDraw:
     def test_text_outline_dark_pixels_drawn(self):
         """テキストのアウトライン (黒ストローク) が描画されていることを検証.
 
-        LINE_AA のアンチエイリアスにより完全な (0, 0, 0) は稀なため,
-        白背景で十分に暗いピクセル (全チャネル 50 未満) の存在で検証する.
+        実装は `cv2.putText` を 2 回呼び出す (outline: color=(0,0,0),
+        thickness=4 -> text: color=META_COLOR, thickness=2). LINE_AA による
+        アンチエイリアスで白背景と混合するため完全な (0, 0, 0) は中心に限られ,
+        ストローク中心付近の十分に暗いピクセルで存在確認する.
+
+        閾値 50 は「白 255 からの強い暗化があれば outline とみなせる」目安値で,
+        アンチエイリアスによる縁 (中間色) が通常 100-200 程度になる性質に基づく.
+        検出 bbox が描く塗りつぶしの影響を排除するため detections=() を使う.
         """
         overlay = DetectionOverlay()
         overlay.update(_make_response(detections=()))
@@ -272,3 +301,18 @@ class TestDraw:
             (result[..., 0] < 50) & (result[..., 1] < 50) & (result[..., 2] < 50)
         )
         assert dark_mask.any()
+
+    def test_text_outline_visible_on_black_background(self):
+        """黒背景でもアウトライン描画が text の色変化として現れることを検証."""
+        overlay = DetectionOverlay()
+        overlay.update(_make_response(detections=()))
+        frame = np.zeros((200, 400, 3), dtype=np.uint8)
+        result = overlay.draw(frame)
+        # 黒背景ではテキスト本体 (META_COLOR) が唯一の非黒ピクセル源
+        b, g, r = DetectionOverlay.META_COLOR
+        bright_mask = (
+            (result[..., 0] > b // 2)
+            & (result[..., 1] > g // 2)
+            & (result[..., 2] > r // 2)
+        )
+        assert bright_mask.any()


### PR DESCRIPTION
## Summary

- PR [#407](https://github.com/kurorosu/pochivision/pull/407) レビュー時に残った軽微指摘を一括対応. スレッド安全性の注意書き, fixture 整理, 追加テスト (状態遷移・アウトライン検証).

## Related Issue

Closes #409

## Changes

- `pochivision/capture_runner/detection_overlay.py`: `draw()` docstring にスレッド安全性 Note を追記 (lock 導入は [#402](https://github.com/kurorosu/pochivision/issues/402) で対応)
- `tests/capture_runner/test_detection_overlay.py`:
  - `_make_response` のデフォルトを `None` に変更し, 呼び出し側で空検出を明示化
  - `test_empty_detections_draws_meta_only` を `update()` のみで完結する形に整理
  - `test_error_then_result_clears_error` (エラー → 成功の遷移) を追加
  - `test_text_outline_dark_pixels_drawn` (アウトライン黒ストロークの描画検証) を追加

## Test Plan

- [x] `_make_response(detections=())` が空検出を正しく伝搬する
- [x] エラー状態から検出結果更新で `error_message` がクリアされる
- [x] 白背景に描画したとき, テキストアウトラインの暗ピクセルが存在する

## Checklist

- [x] pre-commit 全 pass