### PR TITLE
docs: CHANGELOG Unreleased に 0.7.0 以降の PR エントリを追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@
 ## [Unreleased]
 
 ### Added
-- 無し
+- pochidetection 検出 API クライアント (`DetectionClient`) を追加. base64 エンコードで画像を送信し, bbox + class + confidence を取得する. `DetectConfig`, 専用例外 (`DetectionError` / `DetectionConnectionError`), サンプル設定 `config/detect_config.json` を同梱. ([#403](https://github.com/kurorosu/pochivision/pull/403))
+- `DetectionOverlay` を追加し, `DetectionResponse` を受けてフレームに bbox / ラベル / メタ情報 (検出数, e2e_time_ms, rtt_ms, backend) を描画する. クラス ID から決定的に割り当てる 8 色パレットを内蔵. ([#407](https://github.com/kurorosu/pochivision/pull/407))
 
 ### Changed
-- 無し
+- `DetectionClient` のバリデーションとレスポンスパースを堅牢化. フレーム dtype / shape / timeout / 接続先 URL / malformed JSON / detection 要素の型不一致を検知して適切な例外にマッピング. dtype 送信を `frame.dtype.name` で正規化. `inference/__init__.py` の docstring 半角スペースも統一. ([#406](https://github.com/kurorosu/pochivision/pull/406))
+- `DetectionOverlay` で bbox 異常値 (NaN / Inf / 反転 / フレーム外) をガードしてスキップし, ラベル矩形をフレーム範囲でクリップ. BGR 3 チャネル以外のフレームは描画せず返す. スレッド安全性の注意書きを docstring に追加 (lock は #402 で導入予定). ([#410](https://github.com/kurorosu/pochivision/pull/410))
 
 ### Fixed
 - 無し


### PR DESCRIPTION
## Summary

- 0.7.0 リリース後にマージされた PR #403 / #406 / #407 / #410 を CHANGELOG の `[Unreleased]` に追記. 記載漏れの遡及対応.

## Related Issue

無し

## Changes

- `CHANGELOG.md`: Added に pochidetection クライアント ([#403](https://github.com/kurorosu/pochivision/pull/403)) と検出オーバーレイ ([#407](https://github.com/kurorosu/pochivision/pull/407)) を追記. Changed にレビュー対応 PR ([#406](https://github.com/kurorosu/pochivision/pull/406) / [#410](https://github.com/kurorosu/pochivision/pull/410)) を追記.

## Test Plan

- [x] ドキュメントのみの変更のため機能影響なし (pre-commit 全 pass で確認)

## Checklist

- [x] pre-commit 全 pass