### PR TITLE
refactor: API クライアント / config の命名を base_url / image_format に統一

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - `DetectionOverlay` を追加し, `DetectionResponse` を受けてフレームに bbox / ラベル / メタ情報 (検出数, e2e_time_ms, rtt_ms, backend) を描画する. クラス ID から決定的に割り当てる 8 色パレットを内蔵. ([#407](https://github.com/kurorosu/pochivision/pull/407))
 
 ### Changed
+- **BREAKING**: API クライアント / config の命名を統一. `InferConfig` / `DetectConfig` のフィールドと JSON キーを `url` → `base_url`, `format` → `image_format` に変更してクライアント引数名と揃えた. 既存 `config/infer_config.json` / `config/detect_config.json` を使っている場合は新しいキー名への更新が必要. ([(NA.)](https://github.com/kurorosu/pochivision/pull/0))
 - `DetectionClient` のバリデーションとレスポンスパースを堅牢化. フレーム dtype / shape / timeout / 接続先 URL / malformed JSON / detection 要素の型不一致を検知して適切な例外にマッピング. dtype 送信を `frame.dtype.name` で正規化. `inference/__init__.py` の docstring 半角スペースも統一. ([#406](https://github.com/kurorosu/pochivision/pull/406))
 - `DetectionOverlay` で bbox 異常値 (NaN / Inf / 反転 / フレーム外) をガードしてスキップし, ラベル矩形をフレーム範囲でクリップ. BGR 3 チャネル以外のフレームは描画せず返す. スレッド安全性の注意書きを docstring に追加 (lock は #402 で導入予定). ([#410](https://github.com/kurorosu/pochivision/pull/410))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - `DetectionOverlay` を追加し, `DetectionResponse` を受けてフレームに bbox / ラベル / メタ情報 (検出数, e2e_time_ms, rtt_ms, backend) を描画する. クラス ID から決定的に割り当てる 8 色パレットを内蔵. ([#407](https://github.com/kurorosu/pochivision/pull/407))
 
 ### Changed
-- **BREAKING**: API クライアント / config の命名を統一. `InferConfig` / `DetectConfig` のフィールドと JSON キーを `url` → `base_url`, `format` → `image_format` に変更してクライアント引数名と揃えた. 既存 `config/infer_config.json` / `config/detect_config.json` を使っている場合は新しいキー名への更新が必要. ([(NA.)](https://github.com/kurorosu/pochivision/pull/0))
+- **BREAKING**: API クライアント / config の命名を統一. `InferConfig` / `DetectConfig` のフィールドと JSON キーを `url` → `base_url`, `format` → `image_format` に変更してクライアント引数名と揃えた. 既存 `config/infer_config.json` / `config/detect_config.json` を使っている場合は新しいキー名への更新が必要. ([#412](https://github.com/kurorosu/pochivision/pull/412))
 - `DetectionClient` のバリデーションとレスポンスパースを堅牢化. フレーム dtype / shape / timeout / 接続先 URL / malformed JSON / detection 要素の型不一致を検知して適切な例外にマッピング. dtype 送信を `frame.dtype.name` で正規化. `inference/__init__.py` の docstring 半角スペースも統一. ([#406](https://github.com/kurorosu/pochivision/pull/406))
 - `DetectionOverlay` で bbox 異常値 (NaN / Inf / 反転 / フレーム外) をガードしてスキップし, ラベル矩形をフレーム範囲でクリップ. BGR 3 チャネル以外のフレームは描画せず返す. スレッド安全性の注意書きを docstring に追加 (lock は #402 で導入予定). ([#410](https://github.com/kurorosu/pochivision/pull/410))
 

--- a/README.en.md
+++ b/README.en.md
@@ -104,13 +104,15 @@ uv run pochi run --infer-config config/infer_config.json
 
 | Key | Required | Default | Description |
 |-----|----------|---------|-------------|
-| `url` | Yes | - | pochitrain inference API base URL |
-| `format` | No | `"jpeg"` | Image format (`"raw"` / `"jpeg"`) |
+| `base_url` | Yes | - | pochitrain inference API base URL |
+| `image_format` | No | `"jpeg"` | Image format (`"raw"` / `"jpeg"`) |
 | `resize.width` | No | None (no resize) | Target image width |
 | `resize.height` | No | None (no resize) | Target image height |
 | `resize.padding_color` | No | `[0, 0, 0]` | Padding color (BGR) |
 | `save_frame` | No | `false` | Save inference frame image to disk |
 | `save_csv` | No | `false` | Save inference results to CSV file |
+
+> **Migration (0.7 → 0.8)**: Keys renamed: `url` → `base_url`, `format` → `image_format`. Please rename the corresponding keys in your `config/infer_config.json` / `config/detect_config.json` (old keys will cause `ConfigValidationError: 'base_url' is required`).
 
 ### `pochi extract` - Extract features from images
 

--- a/README.md
+++ b/README.md
@@ -95,13 +95,15 @@ uv run pochi run --infer-config config/infer_config.json
 
 | キー | 必須 | デフォルト | 説明 |
 |------|------|-----------|------|
-| `url` | Yes | - | pochitrain 推論 API のベース URL |
-| `format` | No | `"jpeg"` | 画像送信形式 (`"raw"` / `"jpeg"`) |
+| `base_url` | Yes | - | pochitrain 推論 API のベース URL |
+| `image_format` | No | `"jpeg"` | 画像送信形式 (`"raw"` / `"jpeg"`) |
 | `resize.width` | No | なし (リサイズなし) | 送信画像の幅 |
 | `resize.height` | No | なし (リサイズなし) | 送信画像の高さ |
 | `resize.padding_color` | No | `[0, 0, 0]` | パディング色 (BGR) |
 | `save_frame` | No | `false` | 推論実行時にフレーム画像を保存するか |
 | `save_csv` | No | `false` | 推論結果を CSV ファイルに出力するか |
+
+> **Migration (0.7 → 0.8)**: キー名が `url` → `base_url`, `format` → `image_format` に変更されました. お使いの `config/infer_config.json` / `config/detect_config.json` の該当キーをリネームしてください (旧キーを含む設定は `ConfigValidationError: 'base_url' が必要です` エラーになります).
 
 ### `pochi extract` - 特徴量抽出
 

--- a/config/detect_config.json
+++ b/config/detect_config.json
@@ -1,6 +1,6 @@
 {
-    "url": "http://localhost:8000",
-    "format": "raw",
+    "base_url": "http://localhost:8000",
+    "image_format": "raw",
     "score_threshold": 0.5,
     "timeout": 5.0,
     "jpeg_quality": 90

--- a/config/infer_config.json
+++ b/config/infer_config.json
@@ -1,6 +1,6 @@
 {
-    "url": "http://localhost:8000",
-    "format": "raw",
+    "base_url": "http://localhost:8000",
+    "image_format": "raw",
     "resize": {
         "width": 512,
         "height": 512,

--- a/pochivision/cli/commands/run.py
+++ b/pochivision/cli/commands/run.py
@@ -227,13 +227,13 @@ def _run_preview(
             try:
                 infer_cfg = load_infer_config(infer_config_path)
                 inference_client = InferenceClient(
-                    base_url=infer_cfg.url,
-                    image_format=infer_cfg.format,
+                    base_url=infer_cfg.base_url,
+                    image_format=infer_cfg.image_format,
                     resize=infer_cfg.resize,
                     save_frame=infer_cfg.save_frame,
                     save_csv=infer_cfg.save_csv,
                 )
-                logger.info(f"Inference API enabled: {infer_cfg.url}")
+                logger.info(f"Inference API enabled: {infer_cfg.base_url}")
             except (ConfigLoadError, ConfigValidationError, ValueError) as e:
                 logger.warning(f"Inference config not loaded, skipping: {e}")
 

--- a/pochivision/request/api/detection/config.py
+++ b/pochivision/request/api/detection/config.py
@@ -81,7 +81,8 @@ def _build_detect_config(data: dict[str, Any]) -> DetectConfig:
         ("http://", "https://")
     ):
         raise ConfigValidationError(
-            f"'base_url' は http:// または https:// で始まる文字列必須: {base_url!r}"
+            f"'base_url' は http:// または https:// で始まる文字列である必要があります: "
+            f"{base_url!r}"
         )
 
     image_format = data.get("image_format", DEFAULT_DETECTION_FORMAT)

--- a/pochivision/request/api/detection/config.py
+++ b/pochivision/request/api/detection/config.py
@@ -27,16 +27,16 @@ class DetectConfig:
         responsibility として pochidetection#445 で扱う.
 
     Attributes:
-        url: pochidetection 検出 API のベース URL.
-        format: 画像送信形式 ("raw" or "jpeg"). raw は圧縮劣化なしで検出精度に有利,
+        base_url: pochidetection 検出 API のベース URL.
+        image_format: 画像送信形式 ("raw" or "jpeg"). raw は圧縮劣化なしで検出精度に有利,
             jpeg は転送量削減向き.
         score_threshold: 検出信頼度の下限しきい値 (0.0-1.0).
         timeout: リクエストタイムアウト (秒).
-        jpeg_quality: JPEG 圧縮品質 (1-100). format="jpeg" のとき使用.
+        jpeg_quality: JPEG 圧縮品質 (1-100). image_format="jpeg" のとき使用.
     """
 
-    url: str
-    format: str = DEFAULT_DETECTION_FORMAT
+    base_url: str
+    image_format: str = DEFAULT_DETECTION_FORMAT
     score_threshold: float = DEFAULT_DETECTION_SCORE_THRESHOLD
     timeout: float = DEFAULT_DETECTION_TIMEOUT
     jpeg_quality: int = DEFAULT_DETECTION_JPEG_QUALITY
@@ -74,18 +74,21 @@ def _build_detect_config(data: dict[str, Any]) -> DetectConfig:
     Raises:
         ConfigValidationError: 設定内容が不正な場合.
     """
-    if "url" not in data:
-        raise ConfigValidationError("検出設定に 'url' が必要です")
-    url = data["url"]
-    if not isinstance(url, str) or not url.startswith(("http://", "https://")):
+    if "base_url" not in data:
+        raise ConfigValidationError("検出設定に 'base_url' が必要です")
+    base_url = data["base_url"]
+    if not isinstance(base_url, str) or not base_url.startswith(
+        ("http://", "https://")
+    ):
         raise ConfigValidationError(
-            f"'url' は http:// または https:// で始まる文字列必須: {url!r}"
+            f"'base_url' は http:// または https:// で始まる文字列必須: {base_url!r}"
         )
 
-    fmt = data.get("format", DEFAULT_DETECTION_FORMAT)
-    if fmt not in _VALID_FORMATS:
+    image_format = data.get("image_format", DEFAULT_DETECTION_FORMAT)
+    if image_format not in _VALID_FORMATS:
         raise ConfigValidationError(
-            f"'format' は {_VALID_FORMATS} のいずれかである必要があります: {fmt!r}"
+            f"'image_format' は {_VALID_FORMATS} のいずれかである必要があります: "
+            f"{image_format!r}"
         )
 
     score_threshold = data.get("score_threshold", DEFAULT_DETECTION_SCORE_THRESHOLD)
@@ -111,8 +114,8 @@ def _build_detect_config(data: dict[str, Any]) -> DetectConfig:
         )
 
     return DetectConfig(
-        url=data["url"],
-        format=fmt,
+        base_url=base_url,
+        image_format=image_format,
         score_threshold=float(score_threshold),
         timeout=float(timeout),
         jpeg_quality=jpeg_quality,

--- a/pochivision/request/api/inference/config.py
+++ b/pochivision/request/api/inference/config.py
@@ -27,15 +27,15 @@ class InferConfig:
     """推論 API の設定.
 
     Attributes:
-        url: pochitrain 推論 API のベース URL.
-        format: 画像送信形式 ("raw" or "jpeg").
+        base_url: pochitrain 推論 API のベース URL.
+        image_format: 画像送信形式 ("raw" or "jpeg").
         resize: リサイズ設定 (None の場合はリサイズなし).
         save_frame: 推論実行時にフレーム画像を保存するかどうか.
         save_csv: 推論結果を CSV ファイルに出力するかどうか.
     """
 
-    url: str
-    format: str = "jpeg"
+    base_url: str
+    image_format: str = "jpeg"
     resize: ResizeConfig | None = None
     save_frame: bool = False
     save_csv: bool = False
@@ -76,13 +76,14 @@ def _build_infer_config(data: dict[str, Any]) -> InferConfig:
     Raises:
         ConfigValidationError: 設定内容が不正な場合.
     """
-    if "url" not in data:
-        raise ConfigValidationError("推論設定に 'url' が必要です")
+    if "base_url" not in data:
+        raise ConfigValidationError("推論設定に 'base_url' が必要です")
 
-    fmt = data.get("format", "jpeg")
-    if fmt not in _VALID_FORMATS:
+    image_format = data.get("image_format", "jpeg")
+    if image_format not in _VALID_FORMATS:
         raise ConfigValidationError(
-            f"'format' は {_VALID_FORMATS} のいずれかである必要があります: {fmt!r}"
+            f"'image_format' は {_VALID_FORMATS} のいずれかである必要があります: "
+            f"{image_format!r}"
         )
 
     resize = _build_resize_config(data.get("resize"))
@@ -100,8 +101,8 @@ def _build_infer_config(data: dict[str, Any]) -> InferConfig:
         )
 
     return InferConfig(
-        url=data["url"],
-        format=fmt,
+        base_url=data["base_url"],
+        image_format=image_format,
         resize=resize,
         save_frame=save_frame,
         save_csv=save_csv,

--- a/tests/request/api/detection/test_config.py
+++ b/tests/request/api/detection/test_config.py
@@ -52,7 +52,7 @@ class TestLoadDetectConfig:
         assert config.timeout == 10.0
         assert config.jpeg_quality == 75
 
-    def test_missing_url_raises(self, tmp_path):
+    def test_missing_base_url_raises(self, tmp_path):
         path = _write_config(tmp_path, {"image_format": "jpeg"})
         with pytest.raises(ConfigValidationError, match="base_url"):
             load_detect_config(str(path))
@@ -67,7 +67,7 @@ class TestLoadDetectConfig:
         with pytest.raises(ConfigValidationError, match="http"):
             load_detect_config(str(path))
 
-    def test_invalid_format_raises(self, tmp_path):
+    def test_invalid_image_format_raises(self, tmp_path):
         path = _write_config(
             tmp_path, {"base_url": "http://localhost:8000", "image_format": "png"}
         )

--- a/tests/request/api/detection/test_config.py
+++ b/tests/request/api/detection/test_config.py
@@ -23,12 +23,12 @@ class TestLoadDetectConfig:
     """load_detect_config のテスト."""
 
     def test_minimal_config(self, tmp_path):
-        path = _write_config(tmp_path, {"url": "http://localhost:8000"})
+        path = _write_config(tmp_path, {"base_url": "http://localhost:8000"})
         config = load_detect_config(str(path))
 
         assert isinstance(config, DetectConfig)
-        assert config.url == "http://localhost:8000"
-        assert config.format == "raw"
+        assert config.base_url == "http://localhost:8000"
+        assert config.image_format == "raw"
         assert config.score_threshold == 0.5
         assert config.timeout == 5.0
         assert config.jpeg_quality == 90
@@ -37,8 +37,8 @@ class TestLoadDetectConfig:
         path = _write_config(
             tmp_path,
             {
-                "url": "http://localhost:9000",
-                "format": "raw",
+                "base_url": "http://localhost:9000",
+                "image_format": "raw",
                 "score_threshold": 0.3,
                 "timeout": 10.0,
                 "jpeg_quality": 75,
@@ -46,56 +46,58 @@ class TestLoadDetectConfig:
         )
         config = load_detect_config(str(path))
 
-        assert config.url == "http://localhost:9000"
-        assert config.format == "raw"
+        assert config.base_url == "http://localhost:9000"
+        assert config.image_format == "raw"
         assert config.score_threshold == 0.3
         assert config.timeout == 10.0
         assert config.jpeg_quality == 75
 
     def test_missing_url_raises(self, tmp_path):
-        path = _write_config(tmp_path, {"format": "jpeg"})
-        with pytest.raises(ConfigValidationError, match="url"):
+        path = _write_config(tmp_path, {"image_format": "jpeg"})
+        with pytest.raises(ConfigValidationError, match="base_url"):
             load_detect_config(str(path))
 
     def test_invalid_url_scheme_raises(self, tmp_path):
-        path = _write_config(tmp_path, {"url": "localhost:8000"})
+        path = _write_config(tmp_path, {"base_url": "localhost:8000"})
         with pytest.raises(ConfigValidationError, match="http"):
             load_detect_config(str(path))
 
     def test_non_string_url_raises(self, tmp_path):
-        path = _write_config(tmp_path, {"url": 12345})
+        path = _write_config(tmp_path, {"base_url": 12345})
         with pytest.raises(ConfigValidationError, match="http"):
             load_detect_config(str(path))
 
     def test_invalid_format_raises(self, tmp_path):
         path = _write_config(
-            tmp_path, {"url": "http://localhost:8000", "format": "png"}
+            tmp_path, {"base_url": "http://localhost:8000", "image_format": "png"}
         )
-        with pytest.raises(ConfigValidationError, match="format"):
+        with pytest.raises(ConfigValidationError, match="image_format"):
             load_detect_config(str(path))
 
     def test_invalid_score_threshold_raises(self, tmp_path):
         path = _write_config(
-            tmp_path, {"url": "http://localhost:8000", "score_threshold": 1.5}
+            tmp_path, {"base_url": "http://localhost:8000", "score_threshold": 1.5}
         )
         with pytest.raises(ConfigValidationError, match="score_threshold"):
             load_detect_config(str(path))
 
     def test_invalid_timeout_raises(self, tmp_path):
-        path = _write_config(tmp_path, {"url": "http://localhost:8000", "timeout": -1})
+        path = _write_config(
+            tmp_path, {"base_url": "http://localhost:8000", "timeout": -1}
+        )
         with pytest.raises(ConfigValidationError, match="timeout"):
             load_detect_config(str(path))
 
     def test_invalid_jpeg_quality_raises(self, tmp_path):
         path = _write_config(
-            tmp_path, {"url": "http://localhost:8000", "jpeg_quality": 0}
+            tmp_path, {"base_url": "http://localhost:8000", "jpeg_quality": 0}
         )
         with pytest.raises(ConfigValidationError, match="jpeg_quality"):
             load_detect_config(str(path))
 
     def test_jpeg_quality_over_100_raises(self, tmp_path):
         path = _write_config(
-            tmp_path, {"url": "http://localhost:8000", "jpeg_quality": 101}
+            tmp_path, {"base_url": "http://localhost:8000", "jpeg_quality": 101}
         )
         with pytest.raises(ConfigValidationError, match="jpeg_quality"):
             load_detect_config(str(path))
@@ -103,12 +105,14 @@ class TestLoadDetectConfig:
     def test_score_threshold_boundaries_valid(self, tmp_path):
         for v in (0.0, 1.0):
             path = _write_config(
-                tmp_path, {"url": "http://localhost:8000", "score_threshold": v}
+                tmp_path, {"base_url": "http://localhost:8000", "score_threshold": v}
             )
             assert load_detect_config(str(path)).score_threshold == v
 
     def test_timeout_zero_raises(self, tmp_path):
-        path = _write_config(tmp_path, {"url": "http://localhost:8000", "timeout": 0})
+        path = _write_config(
+            tmp_path, {"base_url": "http://localhost:8000", "timeout": 0}
+        )
         with pytest.raises(ConfigValidationError, match="timeout"):
             load_detect_config(str(path))
 
@@ -121,6 +125,6 @@ class TestDetectConfig:
     """DetectConfig のテスト."""
 
     def test_frozen(self):
-        config = DetectConfig(url="http://localhost:8000")
+        config = DetectConfig(base_url="http://localhost:8000")
         with pytest.raises(Exception):
-            config.url = "http://other:8000"  # type: ignore[misc]
+            config.base_url = "http://other:8000"  # type: ignore[misc]

--- a/tests/request/api/inference/test_config.py
+++ b/tests/request/api/inference/test_config.py
@@ -157,12 +157,12 @@ class TestLoadInferConfigError:
         with pytest.raises(ConfigLoadError):
             load_infer_config(str(path))
 
-    def test_missing_url(self, tmp_path):
+    def test_missing_base_url(self, tmp_path):
         path = _write_config(tmp_path, {"image_format": "jpeg"})
         with pytest.raises(ConfigValidationError, match="base_url"):
             load_infer_config(path)
 
-    def test_invalid_format(self, tmp_path):
+    def test_invalid_image_format(self, tmp_path):
         path = _write_config(
             tmp_path,
             {

--- a/tests/request/api/inference/test_config.py
+++ b/tests/request/api/inference/test_config.py
@@ -26,8 +26,8 @@ class TestLoadInferConfigSuccess:
         path = _write_config(
             tmp_path,
             {
-                "url": "http://192.168.1.100:8000",
-                "format": "raw",
+                "base_url": "http://192.168.1.100:8000",
+                "image_format": "raw",
                 "resize": {
                     "width": 224,
                     "height": 224,
@@ -37,26 +37,26 @@ class TestLoadInferConfigSuccess:
         )
         config = load_infer_config(path)
 
-        assert config.url == "http://192.168.1.100:8000"
-        assert config.format == "raw"
+        assert config.base_url == "http://192.168.1.100:8000"
+        assert config.image_format == "raw"
         assert config.resize is not None
         assert config.resize.width == 224
         assert config.resize.height == 224
         assert config.resize.padding_color == (128, 128, 128)
 
     def test_minimal_config(self, tmp_path):
-        path = _write_config(tmp_path, {"url": "http://localhost:8000"})
+        path = _write_config(tmp_path, {"base_url": "http://localhost:8000"})
         config = load_infer_config(path)
 
-        assert config.url == "http://localhost:8000"
-        assert config.format == "jpeg"
+        assert config.base_url == "http://localhost:8000"
+        assert config.image_format == "jpeg"
         assert config.resize is None
         assert config.save_frame is False
 
     def test_save_frame_enabled(self, tmp_path):
         path = _write_config(
             tmp_path,
-            {"url": "http://localhost:8000", "save_frame": True},
+            {"base_url": "http://localhost:8000", "save_frame": True},
         )
         config = load_infer_config(path)
         assert config.save_frame is True
@@ -64,13 +64,13 @@ class TestLoadInferConfigSuccess:
     def test_save_csv_enabled(self, tmp_path):
         path = _write_config(
             tmp_path,
-            {"url": "http://localhost:8000", "save_csv": True},
+            {"base_url": "http://localhost:8000", "save_csv": True},
         )
         config = load_infer_config(path)
         assert config.save_csv is True
 
     def test_save_csv_default_false(self, tmp_path):
-        path = _write_config(tmp_path, {"url": "http://localhost:8000"})
+        path = _write_config(tmp_path, {"base_url": "http://localhost:8000"})
         config = load_infer_config(path)
         assert config.save_csv is False
 
@@ -78,7 +78,7 @@ class TestLoadInferConfigSuccess:
         path = _write_config(
             tmp_path,
             {
-                "url": "http://localhost:8000",
+                "base_url": "http://localhost:8000",
                 "resize": {"width": 320, "height": 240},
             },
         )
@@ -93,7 +93,7 @@ class TestLoadInferConfigSuccess:
         path = _write_config(
             tmp_path,
             {
-                "url": "http://localhost:8000",
+                "base_url": "http://localhost:8000",
                 "resize": {
                     "width": 224,
                     "height": 224,
@@ -109,7 +109,7 @@ class TestLoadInferConfigSuccess:
         path = _write_config(
             tmp_path,
             {
-                "url": "http://localhost:8000",
+                "base_url": "http://localhost:8000",
                 "resize": {
                     "width": 224,
                     "height": 224,
@@ -125,23 +125,23 @@ class TestLoadInferConfigSuccess:
         path = _write_config(
             tmp_path,
             {
-                "url": "http://localhost:8000",
-                "format": "jpeg",
+                "base_url": "http://localhost:8000",
+                "image_format": "jpeg",
             },
         )
         config = load_infer_config(path)
-        assert config.format == "jpeg"
+        assert config.image_format == "jpeg"
 
     def test_format_raw(self, tmp_path):
         path = _write_config(
             tmp_path,
             {
-                "url": "http://localhost:8000",
-                "format": "raw",
+                "base_url": "http://localhost:8000",
+                "image_format": "raw",
             },
         )
         config = load_infer_config(path)
-        assert config.format == "raw"
+        assert config.image_format == "raw"
 
 
 class TestLoadInferConfigError:
@@ -158,26 +158,26 @@ class TestLoadInferConfigError:
             load_infer_config(str(path))
 
     def test_missing_url(self, tmp_path):
-        path = _write_config(tmp_path, {"format": "jpeg"})
-        with pytest.raises(ConfigValidationError, match="url"):
+        path = _write_config(tmp_path, {"image_format": "jpeg"})
+        with pytest.raises(ConfigValidationError, match="base_url"):
             load_infer_config(path)
 
     def test_invalid_format(self, tmp_path):
         path = _write_config(
             tmp_path,
             {
-                "url": "http://localhost:8000",
-                "format": "png",
+                "base_url": "http://localhost:8000",
+                "image_format": "png",
             },
         )
-        with pytest.raises(ConfigValidationError, match="format"):
+        with pytest.raises(ConfigValidationError, match="image_format"):
             load_infer_config(path)
 
     def test_resize_missing_width(self, tmp_path):
         path = _write_config(
             tmp_path,
             {
-                "url": "http://localhost:8000",
+                "base_url": "http://localhost:8000",
                 "resize": {"height": 224},
             },
         )
@@ -188,7 +188,7 @@ class TestLoadInferConfigError:
         path = _write_config(
             tmp_path,
             {
-                "url": "http://localhost:8000",
+                "base_url": "http://localhost:8000",
                 "resize": {"width": 224},
             },
         )
@@ -199,7 +199,7 @@ class TestLoadInferConfigError:
         path = _write_config(
             tmp_path,
             {
-                "url": "http://localhost:8000",
+                "base_url": "http://localhost:8000",
                 "resize": {"width": 0, "height": 224},
             },
         )
@@ -210,7 +210,7 @@ class TestLoadInferConfigError:
         path = _write_config(
             tmp_path,
             {
-                "url": "http://localhost:8000",
+                "base_url": "http://localhost:8000",
                 "resize": {"width": -1, "height": 224},
             },
         )
@@ -221,7 +221,7 @@ class TestLoadInferConfigError:
         path = _write_config(
             tmp_path,
             {
-                "url": "http://localhost:8000",
+                "base_url": "http://localhost:8000",
                 "resize": {"width": 224, "height": 0},
             },
         )
@@ -232,7 +232,7 @@ class TestLoadInferConfigError:
         path = _write_config(
             tmp_path,
             {
-                "url": "http://localhost:8000",
+                "base_url": "http://localhost:8000",
                 "resize": {
                     "width": 224,
                     "height": 224,
@@ -246,7 +246,7 @@ class TestLoadInferConfigError:
     def test_save_frame_invalid_type(self, tmp_path):
         path = _write_config(
             tmp_path,
-            {"url": "http://localhost:8000", "save_frame": "yes"},
+            {"base_url": "http://localhost:8000", "save_frame": "yes"},
         )
         with pytest.raises(ConfigValidationError, match="save_frame"):
             load_infer_config(path)
@@ -254,7 +254,7 @@ class TestLoadInferConfigError:
     def test_save_csv_invalid_type(self, tmp_path):
         path = _write_config(
             tmp_path,
-            {"url": "http://localhost:8000", "save_csv": "yes"},
+            {"base_url": "http://localhost:8000", "save_csv": "yes"},
         )
         with pytest.raises(ConfigValidationError, match="save_csv"):
             load_infer_config(path)
@@ -263,7 +263,7 @@ class TestLoadInferConfigError:
         path = _write_config(
             tmp_path,
             {
-                "url": "http://localhost:8000",
+                "base_url": "http://localhost:8000",
                 "resize": {
                     "width": 224,
                     "height": 224,
@@ -279,10 +279,10 @@ class TestDataclassFrozen:
     """frozen dataclass のテスト."""
 
     def test_infer_config_frozen(self, tmp_path):
-        path = _write_config(tmp_path, {"url": "http://localhost:8000"})
+        path = _write_config(tmp_path, {"base_url": "http://localhost:8000"})
         config = load_infer_config(path)
         with pytest.raises(AttributeError):
-            config.url = "http://other:8000"  # type: ignore[misc]
+            config.base_url = "http://other:8000"  # type: ignore[misc]
 
     def test_resize_config_frozen(self):
         resize = ResizeConfig(width=224, height=224)


### PR DESCRIPTION
## Summary

- `InferConfig` / `DetectConfig` のフィールドと JSON キーを `url` → `base_url`, `format` → `image_format` に改名. クライアント引数 (`base_url` / `image_format`) と揃え, 呼び出し側での変換を不要に.
- 破壊的変更. 既存 config JSON は新しいキー名への移行が必要.

## Related Issue

Closes #404

## Changes

- `pochivision/request/api/detection/config.py`: `DetectConfig` フィールド改名 + バリデータ更新
- `pochivision/request/api/inference/config.py`: `InferConfig` フィールド改名 + バリデータ更新
- `config/detect_config.json`, `config/infer_config.json`: JSON キー更新
- `pochivision/cli/commands/run.py`: 呼び出し箇所を新フィールド名に追随
- `tests/request/api/detection/test_config.py`, `tests/request/api/inference/test_config.py`: アサーション・入力キー・エラーメッセージ match 文字列を更新
- `CHANGELOG.md`: BREAKING エントリ追加

## Test Plan

- [x] 新フィールド名で minimal / full config が読み込める
- [x] 旧キー (`url` / `format`) を含む JSON は `ConfigValidationError` になる
- [x] CLI 経由の推論クライアント初期化が引数名変更に追随して動く
- [x] frozen dataclass が新フィールド名でも書き換え不能

## Checklist

- [x] pre-commit 全 pass
