### PR TITLE
refactor: overlay 色定数を DetectionOverlay / InferenceOverlay で統一

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - **BREAKING**: API クライアント / config の命名を統一. `InferConfig` / `DetectConfig` のフィールドと JSON キーを `url` → `base_url`, `format` → `image_format` に変更してクライアント引数名と揃えた. 既存 `config/infer_config.json` / `config/detect_config.json` を使っている場合は新しいキー名への更新が必要. ([#412](https://github.com/kurorosu/pochivision/pull/412))
 - `DetectionClient` のバリデーションとレスポンスパースを堅牢化. フレーム dtype / shape / timeout / 接続先 URL / malformed JSON / detection 要素の型不一致を検知して適切な例外にマッピング. dtype 送信を `frame.dtype.name` で正規化. `inference/__init__.py` の docstring 半角スペースも統一. ([#406](https://github.com/kurorosu/pochivision/pull/406))
 - `DetectionOverlay` で bbox 異常値 (NaN / Inf / 反転 / フレーム外) をガードしてスキップし, ラベル矩形をフレーム範囲でクリップ. BGR 3 チャネル以外のフレームは描画せず返す. スレッド安全性の注意書きを docstring に追加 (lock は #402 で導入予定). ([#410](https://github.com/kurorosu/pochivision/pull/410))
+- `DetectionOverlay` / `InferenceOverlay` の色定数定義方針を統一. `InferenceOverlay` の hardcoded 色 (メタグレー / エラー赤 / 信頼度の高中低) を `META_COLOR` / `ERROR_COLOR` / `HIGH_COLOR` / `MEDIUM_COLOR` / `LOW_COLOR` のクラス定数に整理. 共通色 (`META_COLOR` / `ERROR_COLOR`) は `capture_runner/_overlay_colors.py` に抽出して両オーバーレイから参照する. ((NA.))
 
 ### Fixed
 - 無し

--- a/pochivision/capture_runner/_overlay_colors.py
+++ b/pochivision/capture_runner/_overlay_colors.py
@@ -1,0 +1,11 @@
+"""オーバーレイ共通色定数モジュール.
+
+`DetectionOverlay` と `InferenceOverlay` で共通して使う色を定義する.
+各色は BGR (OpenCV のデフォルト) で表現する.
+"""
+
+META_COLOR: tuple[int, int, int] = (200, 200, 200)
+"""メタ情報 (推論時間, RTT, サーバー URL 等) の表示色. ライトグレー."""
+
+ERROR_COLOR: tuple[int, int, int] = (0, 0, 200)
+"""エラーメッセージの表示色. 赤."""

--- a/pochivision/capture_runner/detection_overlay.py
+++ b/pochivision/capture_runner/detection_overlay.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 import cv2
 import numpy as np
 
+from pochivision.capture_runner import _overlay_colors
 from pochivision.request.api.detection.models import Detection, DetectionResponse
 
 
@@ -39,8 +40,8 @@ class DetectionOverlay:
     """
 
     INFERRING_TEXT = "Detecting..."
-    META_COLOR: tuple[int, int, int] = (200, 200, 200)
-    ERROR_COLOR: tuple[int, int, int] = (0, 0, 200)
+    META_COLOR: tuple[int, int, int] = _overlay_colors.META_COLOR
+    ERROR_COLOR: tuple[int, int, int] = _overlay_colors.ERROR_COLOR
 
     # 決定的な色パレット (BGR). class_id % len(PALETTE) で割当.
     PALETTE: tuple[tuple[int, int, int], ...] = (

--- a/pochivision/capture_runner/inference_overlay.py
+++ b/pochivision/capture_runner/inference_overlay.py
@@ -44,6 +44,8 @@ class InferenceOverlay:
     ERROR_COLOR: tuple[int, int, int] = _overlay_colors.ERROR_COLOR
     HIGH_COLOR: tuple[int, int, int] = (0, 200, 0)
     MEDIUM_COLOR: tuple[int, int, int] = (0, 200, 200)
+    # 信頼度低を示す赤. 現状 ERROR_COLOR と同値だが意味 (有効な低信頼推論 vs 通信エラー)
+    # が異なるため独立定義する. 片方だけ変えたい将来の変更に備える.
     LOW_COLOR: tuple[int, int, int] = (0, 0, 200)
 
     def __init__(self, context: InferenceContext | None = None) -> None:

--- a/pochivision/capture_runner/inference_overlay.py
+++ b/pochivision/capture_runner/inference_overlay.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 import cv2
 import numpy as np
 
+from pochivision.capture_runner import _overlay_colors
 from pochivision.request.api.inference.models import PredictResponse
 
 
@@ -39,6 +40,11 @@ class InferenceOverlay:
     CONFIDENCE_LOW = 0.4
 
     INFERRING_TEXT = "Inferring..."
+    META_COLOR: tuple[int, int, int] = _overlay_colors.META_COLOR
+    ERROR_COLOR: tuple[int, int, int] = _overlay_colors.ERROR_COLOR
+    HIGH_COLOR: tuple[int, int, int] = (0, 200, 0)
+    MEDIUM_COLOR: tuple[int, int, int] = (0, 200, 200)
+    LOW_COLOR: tuple[int, int, int] = (0, 0, 200)
 
     def __init__(self, context: InferenceContext | None = None) -> None:
         """コンストラクタ.
@@ -98,7 +104,7 @@ class InferenceOverlay:
         error = self.error_message
 
         if inferring and result is None and error is None:
-            self._draw_text(frame, self.INFERRING_TEXT, (200, 200, 200), y=30)
+            self._draw_text(frame, self.INFERRING_TEXT, self.META_COLOR, y=30)
             return frame
 
         if error is not None:
@@ -122,14 +128,14 @@ class InferenceOverlay:
         lines: list[tuple[str, tuple[int, int, int]]] = [
             (f"Result: {result.class_name}", color),
             (f"Confidence: {result.confidence * 100:.1f}%", color),
-            (f"Inference: {result.e2e_time_ms:.1f}ms", (200, 200, 200)),
-            (f"RTT: {result.rtt_ms:.1f}ms", (200, 200, 200)),
+            (f"Inference: {result.e2e_time_ms:.1f}ms", self.META_COLOR),
+            (f"RTT: {result.rtt_ms:.1f}ms", self.META_COLOR),
         ]
 
         if self.context and self.context.image_size:
-            lines.append((f"ImageSize: {self.context.image_size}", (200, 200, 200)))
+            lines.append((f"ImageSize: {self.context.image_size}", self.META_COLOR))
         if self.context:
-            lines.append((f"Server: {self.context.server_url}", (200, 200, 200)))
+            lines.append((f"Server: {self.context.server_url}", self.META_COLOR))
 
         y = 30
         for text, c in lines:
@@ -144,11 +150,11 @@ class InferenceOverlay:
             error: エラーメッセージ.
         """
         lines: list[tuple[str, tuple[int, int, int]]] = [
-            (f"Error: {error}", (0, 0, 200)),
+            (f"Error: {error}", self.ERROR_COLOR),
         ]
 
         if self.context:
-            lines.append((f"Server: {self.context.server_url}", (200, 200, 200)))
+            lines.append((f"Server: {self.context.server_url}", self.META_COLOR))
 
         y = 30
         for text, c in lines:
@@ -207,7 +213,7 @@ class InferenceOverlay:
             BGR カラータプル.
         """
         if confidence >= self.CONFIDENCE_HIGH:
-            return (0, 200, 0)  # 緑
+            return self.HIGH_COLOR
         if confidence >= self.CONFIDENCE_LOW:
-            return (0, 200, 200)  # 黄
-        return (0, 0, 200)  # 赤
+            return self.MEDIUM_COLOR
+        return self.LOW_COLOR


### PR DESCRIPTION
## Summary

- `DetectionOverlay` と `InferenceOverlay` の色定数定義方針が非対称 (前者はクラス定数, 後者は hardcode) だったのを統一.
- 共通色 (メタグレー / エラー赤) を `pochivision/capture_runner/_overlay_colors.py` に抽出し, 両オーバーレイから参照する形に変更.

## Related Issue

Closes #408

## Changes

- `pochivision/capture_runner/_overlay_colors.py` を新規追加. `META_COLOR` / `ERROR_COLOR` を BGR で定義.
- `InferenceOverlay` に `META_COLOR` / `ERROR_COLOR` / `HIGH_COLOR` / `MEDIUM_COLOR` / `LOW_COLOR` をクラス定数として導入. `_draw_result` / `_draw_error` / `_get_color` / `draw` 内の hardcoded 色を定数参照に置換.
- `DetectionOverlay` の `META_COLOR` / `ERROR_COLOR` を `_overlay_colors` モジュール経由で取得するよう変更 (値は不変).
- `CHANGELOG.md`: Changed エントリ追加.

## Test Plan

- [x] 既存の `tests/capture_runner/test_inference_overlay.py` / `test_detection_overlay.py` がすべて pass
- [x] `InferenceOverlay._get_color()` が信頼度 high / medium / low に対して従来通りの BGR 値 `(0, 200, 0)` / `(0, 200, 200)` / `(0, 0, 200)` を返す
- [x] `DetectionOverlay.META_COLOR` / `ERROR_COLOR` / `PALETTE` が従来どおりクラス属性としてアクセス可能

## Checklist

- [x] pre-commit 全 pass
