### PR TITLE
feat: 検出 API の処理時間メトリクスを CSV に定期保存

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@
 - pochidetection 検出 API クライアント (`DetectionClient`) を追加. `DetectConfig` / 専用例外 / サンプル `config/detect_config.json` 同梱. ([#403](https://github.com/kurorosu/pochivision/pull/403))
 - `DetectionOverlay` を追加. `DetectionResponse` を受けて bbox / ラベル / メタ情報 (検出数 / e2e_time_ms / rtt_ms / backend) を描画. class ID からの決定的 8 色パレット内蔵. ([#407](https://github.com/kurorosu/pochivision/pull/407))
 - 常時検出ランタイムを `CaptureRunner` に統合. `time.perf_counter()` ベースのスロットリング + 非同期スレッドで検出し `DetectionOverlay` に反映. `i` キーで ON/OFF トグル, detect モードは ROI 無効化. `DetectionOverlay` の state 更新 / draw を `threading.Lock` で保護. ([#414](https://github.com/kurorosu/pochivision/pull/414))
+- 検出 API の処理時間メトリクス (`e2e_time_ms` / `phase_times_ms` / `rtt_ms` / GPU clock・VRAM・温度) を `metrics_interval_s` 間隔でサンプリングし `capture/<run>/detection_metrics.csv` に pandas 経由で保存する `MetricsRecorder` を追加. 設定は `detect_config.json` の `metrics_interval_s` で制御. ((NA.))
 
 ### Changed
-- **BREAKING**: 検出モードの有効化を `DetectConfig.mode` から CLI フラグ `--detect` に変更. 既存 JSON の `mode` キーは warning を出して無視 (後方互換). ((NA.))
+- **BREAKING**: 検出モードの有効化を `DetectConfig.mode` から CLI フラグ `--detect` に変更. 既存 JSON の `mode` キーは warning を出して無視 (後方互換). ([#416](https://github.com/kurorosu/pochivision/pull/416))
+- `DetectionResponse` に `phase_times_ms` / `gpu_clock_mhz` / `gpu_vram_used_mb` / `gpu_temperature_c` フィールドを追加. サーバー未提供時は空 dict / None で補う. ((NA.))
 - **BREAKING**: API クライアント / config のキー名を `url` → `base_url`, `format` → `image_format` に統一. 既存 `config/*.json` は要更新. ([#412](https://github.com/kurorosu/pochivision/pull/412))
 - `DetectionClient` のバリデーション / レスポンスパースを堅牢化. frame dtype / shape / timeout / URL / JSON / 型不一致を適切な例外にマッピング. ([#406](https://github.com/kurorosu/pochivision/pull/406))
 - `DetectionOverlay` で bbox 異常値 (NaN / Inf / 反転 / フレーム外) をガード, ラベル矩形をフレーム範囲でクリップ. 非 BGR 3ch フレームは描画しない. ([#410](https://github.com/kurorosu/pochivision/pull/410))

--- a/README.md
+++ b/README.md
@@ -125,8 +125,11 @@ uv run pochi run --detect --detect-config config/my_detect.json
 | `timeout` | No | `5.0` | リクエストタイムアウト (秒) |
 | `jpeg_quality` | No | `90` | JPEG 圧縮品質 (1-100, `image_format="jpeg"` のとき) |
 | `detect_fps` | No | `5.0` | `--detect` 有効時の検出リクエスト頻度 (Hz) |
+| `metrics_interval_s` | No | `0.0` | 処理時間メトリクスのサンプリング間隔 (秒). 0 以下で無効 |
 
 起動直後は検出 OFF の状態で待機します. `i` キーで検出の ON/OFF をトグルできます (classify モードの「`i` で推論」と対称). 接続失敗やタイムアウト時はキャプチャループを止めず, overlay にエラーメッセージが表示されます.
+
+`metrics_interval_s` を正の値 (例: `1.0`) に設定すると, 指定間隔ごとに検出 API のレスポンスから処理時間メトリクス (`e2e_time_ms` / phase 別 / RTT / GPU clock / VRAM / 温度) を採取し, 終了時に `capture/<timestamp>/detection_metrics.csv` へ pandas 経由で書き出します. 毎フレームではなくダウンサンプリングするため, 高 FPS 運用でもファイル肥大化しません.
 
 ### `pochi extract` - 特徴量抽出
 

--- a/config/detect_config.json
+++ b/config/detect_config.json
@@ -4,5 +4,6 @@
     "score_threshold": 0.5,
     "timeout": 5.0,
     "jpeg_quality": 90,
-    "detect_fps": 5.0
+    "detect_fps": 5.0,
+    "metrics_interval_s": 0.0
 }

--- a/pochivision/capture_runner/metrics_recorder.py
+++ b/pochivision/capture_runner/metrics_recorder.py
@@ -1,0 +1,130 @@
+"""検出 API の処理時間メトリクスをサンプリングして CSV に保存するモジュール."""
+
+import threading
+import time
+from datetime import datetime
+from pathlib import Path
+
+import pandas as pd
+
+from pochivision.capturelib.log_manager import LogManager
+from pochivision.request.api.detection.models import DetectionResponse
+
+_CSV_COLUMNS: list[str] = [
+    "timestamp_iso",
+    "elapsed_s",
+    "num_detections",
+    "e2e_time_ms",
+    "rtt_ms",
+    "backend",
+    "phase_preprocess_ms",
+    "phase_inference_ms",
+    "phase_inference_gpu_ms",
+    "phase_postprocess_ms",
+    "gpu_clock_mhz",
+    "gpu_vram_used_mb",
+    "gpu_temperature_c",
+]
+
+
+class MetricsRecorder:
+    """検出レスポンスから処理時間メトリクスをサンプリングして保存する.
+
+    `maybe_record()` は呼び出しごとにサンプリング間隔を判定し, 間隔経過時のみ
+    内部リストに追記する. `flush()` で pandas DataFrame 化して CSV に書き出す.
+
+    Attributes:
+        interval_s: サンプリング間隔 (秒). 0 以下は無効.
+        out_path: CSV 出力先パス.
+    """
+
+    def __init__(self, interval_s: float, out_path: Path) -> None:
+        """初期化する.
+
+        Args:
+            interval_s: サンプリング間隔 (秒). 0 以下のとき常に記録しない.
+            out_path: CSV 出力先パス.
+        """
+        self.interval_s = interval_s
+        self.out_path = Path(out_path)
+        self._logger = LogManager().get_logger()
+        # Why: elapsed_s を monotonic 起点で計測するため, 生成時刻を記録する.
+        self._start_monotonic = time.monotonic()
+        # Why: スレッドセーフな append / flush のため lock で保護する.
+        self._lock = threading.Lock()
+        self._rows: list[dict[str, object]] = []
+        self._last_sampled_monotonic: float = -float("inf")
+
+    def maybe_record(
+        self,
+        response: DetectionResponse,
+        now_monotonic: float | None = None,
+    ) -> bool:
+        """サンプリング間隔が経過していれば内部バッファに 1 行追記する.
+
+        Args:
+            response: 検出レスポンス.
+            now_monotonic: 現在時刻 (``time.monotonic()``). テスト用. None なら自動計測.
+
+        Returns:
+            追記した場合 True, スキップした場合 False.
+        """
+        if self.interval_s <= 0:
+            return False
+
+        current = now_monotonic if now_monotonic is not None else time.monotonic()
+        with self._lock:
+            if current - self._last_sampled_monotonic < self.interval_s:
+                return False
+            self._last_sampled_monotonic = current
+            phases = response.phase_times_ms
+            row: dict[str, object] = {
+                "timestamp_iso": datetime.now().isoformat(timespec="milliseconds"),
+                "elapsed_s": round(current - self._start_monotonic, 3),
+                "num_detections": len(response.detections),
+                "e2e_time_ms": response.e2e_time_ms,
+                "rtt_ms": response.rtt_ms,
+                "backend": response.backend,
+                "phase_preprocess_ms": phases.get("pipeline_preprocess_ms"),
+                "phase_inference_ms": phases.get("pipeline_inference_ms"),
+                "phase_inference_gpu_ms": phases.get("pipeline_inference_gpu_ms"),
+                "phase_postprocess_ms": phases.get("pipeline_postprocess_ms"),
+                "gpu_clock_mhz": response.gpu_clock_mhz,
+                "gpu_vram_used_mb": response.gpu_vram_used_mb,
+                "gpu_temperature_c": response.gpu_temperature_c,
+            }
+            self._rows.append(row)
+        return True
+
+    def flush(self) -> Path | None:
+        """内部バッファを pandas DataFrame 化して CSV に書き出す.
+
+        バッファが空のときは何もしない. 書き出し後はバッファをクリアする.
+
+        Returns:
+            書き出した CSV パス. バッファが空だった場合は None.
+        """
+        with self._lock:
+            if not self._rows:
+                return None
+            df = pd.DataFrame(self._rows, columns=_CSV_COLUMNS)
+            rows_to_write = self._rows
+            self._rows = []
+
+        try:
+            self.out_path.parent.mkdir(parents=True, exist_ok=True)
+            df.to_csv(self.out_path, index=False, encoding="utf-8")
+        except OSError as e:
+            # Why: 書き出し失敗時はバッファに戻してやり直せるようにする.
+            with self._lock:
+                self._rows = rows_to_write + self._rows
+            self._logger.error(f"Failed to write metrics CSV: {e}")
+            return None
+        self._logger.info(f"Metrics saved: {self.out_path} ({len(rows_to_write)} rows)")
+        return self.out_path
+
+    @property
+    def row_count(self) -> int:
+        """現在のバッファ行数を返す (テスト用)."""
+        with self._lock:
+            return len(self._rows)

--- a/pochivision/capture_runner/viewer.py
+++ b/pochivision/capture_runner/viewer.py
@@ -18,6 +18,7 @@ from pochivision.capture_runner.inference_overlay import (
     InferenceContext,
     InferenceOverlay,
 )
+from pochivision.capture_runner.metrics_recorder import MetricsRecorder
 from pochivision.capture_runner.roi_selector import RoiSelector
 from pochivision.capturelib.camera_config_saver import save_camera_config
 from pochivision.capturelib.camera_setup import CameraSetup
@@ -64,6 +65,7 @@ class LivePreviewRunner:
         camera_setup: CameraSetup | None = None,
         detection_client: DetectionClient | None = None,
         detect_fps: float = DEFAULT_DETECTION_FPS,
+        metrics_interval_s: float = 0.0,
     ) -> None:
         """
         LivePreviewRunnerを初期化する.
@@ -82,6 +84,8 @@ class LivePreviewRunner:
             detection_client: pochidetection 検出 API クライアント（オプション）.
                 指定時は detect モードで動作.
             detect_fps: 検出モード時のスロットリング頻度 (Hz).
+            metrics_interval_s: 検出メトリクスのサンプリング間隔 (秒). 0 以下で無効.
+                出力は `pipeline.output_dir / "detection_metrics.csv"`.
         """
         self.cap = cap
         self.pipeline = pipeline
@@ -116,6 +120,15 @@ class LivePreviewRunner:
         self._detecting_lock = threading.Lock()
         self._detection_state_lock = threading.Lock()
         self._detection_thread: threading.Thread | None = None
+
+        # detect モードでメトリクス間隔が設定されていれば recorder を生成する.
+        # 出力先は pipeline.output_dir に固定 (他の成果物と同じ run ディレクトリ).
+        self._metrics_recorder: MetricsRecorder | None = None
+        if self.is_detect_mode and metrics_interval_s > 0:
+            self._metrics_recorder = MetricsRecorder(
+                interval_s=metrics_interval_s,
+                out_path=Path(pipeline.output_dir) / "detection_metrics.csv",
+            )
 
     def _build_inference_context(self) -> InferenceContext | None:
         """推論クライアントからオーバーレイ用コンテキストを構築する.
@@ -455,6 +468,8 @@ class LivePreviewRunner:
             with self._detection_state_lock:
                 if self._detection_enabled:
                     self.detection_overlay.update(result)
+            if self._metrics_recorder is not None:
+                self._metrics_recorder.maybe_record(result)
         except DetectionConnectionError as e:
             with self._detection_state_lock:
                 if self._detection_enabled:
@@ -605,6 +620,11 @@ class LivePreviewRunner:
         # 検出ワーカースレッドの完了待機
         if self._detection_thread is not None:
             self._detection_thread.join(timeout=5.0)
+
+        # メトリクス CSV の書き出し (検出 worker 完了後に行うことで
+        # 最後のサンプルが取り込まれた状態で flush される).
+        if self._metrics_recorder is not None:
+            self._metrics_recorder.flush()
 
         # 推論クライアントのクリーンアップ
         if self.inference_client:

--- a/pochivision/cli/commands/run.py
+++ b/pochivision/cli/commands/run.py
@@ -246,7 +246,7 @@ def _run_preview(
             preview_config.get("height", DEFAULT_PREVIEW_HEIGHT),
         )
 
-        detection_client, detect_fps = _build_detection_client(
+        detection_client, detect_fps, metrics_interval_s = _build_detection_client(
             detect_config_path, detect_enabled, logger
         )
         inference_client = None
@@ -262,6 +262,7 @@ def _run_preview(
             camera_setup=camera_setup,
             detection_client=detection_client,
             detect_fps=detect_fps,
+            metrics_interval_s=metrics_interval_s,
         )
         app.run()
 
@@ -306,12 +307,12 @@ def _build_inference_client(
 
 def _build_detection_client(
     detect_config_path: str, detect_enabled: bool, logger: logging.Logger
-) -> tuple[DetectionClient | None, float]:
+) -> tuple[DetectionClient | None, float, float]:
     """検出クライアントを構築する.
 
     `detect_enabled=True` (CLI の `--detect` フラグ指定) のときのみクライアントを
     生成する. 設定ファイルが存在しない, または読み込みに失敗した場合は
-    (None, デフォルト fps) を返す (分類モードにフォールバック).
+    (None, デフォルト fps, 0.0) を返す (分類モードにフォールバック).
 
     Args:
         detect_config_path: 検出設定ファイルのパス.
@@ -319,22 +320,22 @@ def _build_detection_client(
         logger: ロガー.
 
     Returns:
-        (DetectionClient or None, detect_fps).
+        (DetectionClient or None, detect_fps, metrics_interval_s).
     """
     if not detect_enabled:
-        return None, DEFAULT_DETECTION_FPS
+        return None, DEFAULT_DETECTION_FPS, 0.0
 
     if not Path(detect_config_path).exists():
         logger.warning(
             f"--detect is set but config file is missing: {detect_config_path} "
             f"(falling back to classify mode)"
         )
-        return None, DEFAULT_DETECTION_FPS
+        return None, DEFAULT_DETECTION_FPS, 0.0
     try:
         detect_cfg = load_detect_config(detect_config_path)
     except (ConfigLoadError, ConfigValidationError, ValueError) as e:
         logger.warning(f"Detect config not loaded, skipping: {e}")
-        return None, DEFAULT_DETECTION_FPS
+        return None, DEFAULT_DETECTION_FPS, 0.0
 
     try:
         client = DetectionClient(
@@ -348,7 +349,12 @@ def _build_detection_client(
             f"Detection API enabled: {detect_cfg.base_url} "
             f"(fps={detect_cfg.detect_fps})"
         )
-        return client, detect_cfg.detect_fps
+        if detect_cfg.metrics_interval_s > 0:
+            logger.info(
+                f"Detection metrics sampling enabled: "
+                f"interval={detect_cfg.metrics_interval_s}s"
+            )
+        return client, detect_cfg.detect_fps, detect_cfg.metrics_interval_s
     except ValueError as e:
         logger.warning(f"Detection client not initialized: {e}")
-        return None, detect_cfg.detect_fps
+        return None, detect_cfg.detect_fps, detect_cfg.metrics_interval_s

--- a/pochivision/request/api/detection/client.py
+++ b/pochivision/request/api/detection/client.py
@@ -211,11 +211,16 @@ class DetectionClient:
                 )
                 for d in raw_detections
             )
+            phase_times_ms = data.get("phase_times_ms") or {}
             return DetectionResponse(
                 detections=detections,
                 e2e_time_ms=data["e2e_time_ms"],
                 backend=data["backend"],
                 rtt_ms=round(rtt_ms, 3),
+                phase_times_ms=dict(phase_times_ms),
+                gpu_clock_mhz=data.get("gpu_clock_mhz"),
+                gpu_vram_used_mb=data.get("gpu_vram_used_mb"),
+                gpu_temperature_c=data.get("gpu_temperature_c"),
             )
         except (KeyError, IndexError, TypeError) as e:
             raise DetectionError(f"検出レスポンスのフォーマットが不正です: {e}") from e

--- a/pochivision/request/api/detection/config.py
+++ b/pochivision/request/api/detection/config.py
@@ -39,6 +39,9 @@ class DetectConfig:
         jpeg_quality: JPEG 圧縮品質 (1-100). image_format="jpeg" のとき使用.
         detect_fps: 検出モードが CLI `--detect` で有効化された際の検出リクエスト頻度
             (Hz). 入力 FPS より低い値を設定してスロットリング. 正の数のみ.
+        metrics_interval_s: 処理時間メトリクス (e2e / phase / RTT / GPU) を
+            サンプリングする間隔 (秒). 0 以下で無効. 出力先は実行ごとの
+            `capture/.../detection_metrics.csv`.
     """
 
     base_url: str
@@ -47,6 +50,7 @@ class DetectConfig:
     timeout: float = DEFAULT_DETECTION_TIMEOUT
     jpeg_quality: int = DEFAULT_DETECTION_JPEG_QUALITY
     detect_fps: float = DEFAULT_DETECTION_FPS
+    metrics_interval_s: float = 0.0
 
 
 def load_detect_config(path: str) -> DetectConfig:
@@ -133,6 +137,13 @@ def _build_detect_config(data: dict[str, Any]) -> DetectConfig:
             f"'detect_fps' は正の数値である必要があります: {detect_fps!r}"
         )
 
+    metrics_interval_s = data.get("metrics_interval_s", 0.0)
+    if not isinstance(metrics_interval_s, (int, float)) or metrics_interval_s < 0:
+        raise ConfigValidationError(
+            f"'metrics_interval_s' は 0 以上の数値である必要があります: "
+            f"{metrics_interval_s!r}"
+        )
+
     return DetectConfig(
         base_url=base_url,
         image_format=image_format,
@@ -140,4 +151,5 @@ def _build_detect_config(data: dict[str, Any]) -> DetectConfig:
         timeout=float(timeout),
         jpeg_quality=jpeg_quality,
         detect_fps=float(detect_fps),
+        metrics_interval_s=float(metrics_interval_s),
     )

--- a/pochivision/request/api/detection/models.py
+++ b/pochivision/request/api/detection/models.py
@@ -1,6 +1,6 @@
 """検出 API のレスポンスモデルを定義するモジュール."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 
 @dataclass(frozen=True)
@@ -29,9 +29,19 @@ class DetectionResponse:
         e2e_time_ms: サーバー側エンドツーエンド処理時間 (ミリ秒).
         backend: 使用バックエンド.
         rtt_ms: クライアント側ネットワーク往復時間 (ミリ秒).
+        phase_times_ms: Pipeline 内のフェーズ別タイミング (ms). サーバー未提供時は空 dict.
+            想定キー: pipeline_preprocess_ms / pipeline_inference_ms /
+            pipeline_postprocess_ms / pipeline_inference_gpu_ms.
+        gpu_clock_mhz: GPU graphics clock (MHz). サーバーが取得できない場合 None.
+        gpu_vram_used_mb: GPU VRAM 使用量 (MB). サーバーが取得できない場合 None.
+        gpu_temperature_c: GPU 温度 (℃). サーバーが取得できない場合 None.
     """
 
     detections: tuple[Detection, ...]
     e2e_time_ms: float
     backend: str
     rtt_ms: float
+    phase_times_ms: dict[str, float] = field(default_factory=dict)
+    gpu_clock_mhz: int | None = None
+    gpu_vram_used_mb: int | None = None
+    gpu_temperature_c: int | None = None

--- a/tests/capture_runner/test_metrics_recorder.py
+++ b/tests/capture_runner/test_metrics_recorder.py
@@ -1,0 +1,169 @@
+"""MetricsRecorder のテスト."""
+
+import pandas as pd
+import pytest
+
+from pochivision.capture_runner.metrics_recorder import MetricsRecorder
+from pochivision.request.api.detection.models import Detection, DetectionResponse
+
+
+def _make_response(
+    detections: tuple[Detection, ...] = (),
+    e2e_time_ms: float = 10.0,
+    rtt_ms: float = 2.0,
+    backend: str = "onnx-cuda",
+    phase_times_ms: dict[str, float] | None = None,
+    gpu_clock_mhz: int | None = 1770,
+    gpu_vram_used_mb: int | None = 2048,
+    gpu_temperature_c: int | None = 55,
+) -> DetectionResponse:
+    """テスト用の DetectionResponse を組み立てる."""
+    return DetectionResponse(
+        detections=detections,
+        e2e_time_ms=e2e_time_ms,
+        backend=backend,
+        rtt_ms=rtt_ms,
+        phase_times_ms=phase_times_ms or {},
+        gpu_clock_mhz=gpu_clock_mhz,
+        gpu_vram_used_mb=gpu_vram_used_mb,
+        gpu_temperature_c=gpu_temperature_c,
+    )
+
+
+class TestMaybeRecord:
+    """maybe_record のサンプリング挙動テスト."""
+
+    def test_disabled_when_interval_zero(self, tmp_path):
+        recorder = MetricsRecorder(interval_s=0.0, out_path=tmp_path / "m.csv")
+        assert recorder.maybe_record(_make_response(), now_monotonic=100.0) is False
+        assert recorder.row_count == 0
+
+    def test_disabled_when_interval_negative(self, tmp_path):
+        recorder = MetricsRecorder(interval_s=-0.5, out_path=tmp_path / "m.csv")
+        assert recorder.maybe_record(_make_response(), now_monotonic=100.0) is False
+        assert recorder.row_count == 0
+
+    def test_first_call_records(self, tmp_path):
+        recorder = MetricsRecorder(interval_s=1.0, out_path=tmp_path / "m.csv")
+        assert recorder.maybe_record(_make_response(), now_monotonic=100.0) is True
+        assert recorder.row_count == 1
+
+    def test_second_call_before_interval_skipped(self, tmp_path):
+        recorder = MetricsRecorder(interval_s=1.0, out_path=tmp_path / "m.csv")
+        recorder.maybe_record(_make_response(), now_monotonic=100.0)
+        assert recorder.maybe_record(_make_response(), now_monotonic=100.5) is False
+        assert recorder.row_count == 1
+
+    def test_second_call_after_interval_records(self, tmp_path):
+        recorder = MetricsRecorder(interval_s=1.0, out_path=tmp_path / "m.csv")
+        recorder.maybe_record(_make_response(), now_monotonic=100.0)
+        assert recorder.maybe_record(_make_response(), now_monotonic=101.0) is True
+        assert recorder.row_count == 2
+
+    def test_records_all_fields(self, tmp_path):
+        recorder = MetricsRecorder(interval_s=0.5, out_path=tmp_path / "m.csv")
+        resp = _make_response(
+            detections=(
+                Detection(0, "pochi", 0.9, (1.0, 2.0, 3.0, 4.0)),
+                Detection(1, "taro", 0.8, (5.0, 6.0, 7.0, 8.0)),
+            ),
+            e2e_time_ms=12.3,
+            rtt_ms=3.4,
+            backend="trt",
+            phase_times_ms={
+                "pipeline_preprocess_ms": 1.1,
+                "pipeline_inference_ms": 8.2,
+                "pipeline_inference_gpu_ms": 7.9,
+                "pipeline_postprocess_ms": 0.5,
+            },
+            gpu_clock_mhz=1800,
+            gpu_vram_used_mb=3000,
+            gpu_temperature_c=62,
+        )
+        recorder.maybe_record(resp, now_monotonic=10.0)
+        recorder.flush()
+
+        df = pd.read_csv(tmp_path / "m.csv")
+        row = df.iloc[0]
+        assert row["num_detections"] == 2
+        assert row["e2e_time_ms"] == 12.3
+        assert row["rtt_ms"] == 3.4
+        assert row["backend"] == "trt"
+        assert row["phase_preprocess_ms"] == 1.1
+        assert row["phase_inference_ms"] == 8.2
+        assert row["phase_inference_gpu_ms"] == 7.9
+        assert row["phase_postprocess_ms"] == 0.5
+        assert row["gpu_clock_mhz"] == 1800
+        assert row["gpu_vram_used_mb"] == 3000
+        assert row["gpu_temperature_c"] == 62
+
+
+class TestFlush:
+    """flush のテスト."""
+
+    def test_writes_csv_with_header(self, tmp_path):
+        recorder = MetricsRecorder(interval_s=0.5, out_path=tmp_path / "m.csv")
+        recorder.maybe_record(_make_response(), now_monotonic=10.0)
+        recorder.maybe_record(_make_response(), now_monotonic=11.0)
+
+        path = recorder.flush()
+        assert path == tmp_path / "m.csv"
+
+        df = pd.read_csv(path)
+        assert len(df) == 2
+        assert "timestamp_iso" in df.columns
+        assert "elapsed_s" in df.columns
+
+    def test_empty_buffer_returns_none(self, tmp_path):
+        recorder = MetricsRecorder(interval_s=1.0, out_path=tmp_path / "m.csv")
+        assert recorder.flush() is None
+        assert not (tmp_path / "m.csv").exists()
+
+    def test_flush_clears_buffer(self, tmp_path):
+        recorder = MetricsRecorder(interval_s=0.5, out_path=tmp_path / "m.csv")
+        recorder.maybe_record(_make_response(), now_monotonic=10.0)
+        recorder.flush()
+        assert recorder.row_count == 0
+
+    def test_missing_phase_and_gpu_fields_become_empty(self, tmp_path):
+        """サーバーが phase_times_ms / GPU を返さない場合は空セルで書き出す."""
+        recorder = MetricsRecorder(interval_s=0.5, out_path=tmp_path / "m.csv")
+        resp = _make_response(
+            phase_times_ms={},
+            gpu_clock_mhz=None,
+            gpu_vram_used_mb=None,
+            gpu_temperature_c=None,
+        )
+        recorder.maybe_record(resp, now_monotonic=10.0)
+        recorder.flush()
+
+        df = pd.read_csv(tmp_path / "m.csv")
+        # 欠損値は NaN として読み込まれる
+        assert pd.isna(df.iloc[0]["phase_inference_ms"])
+        assert pd.isna(df.iloc[0]["gpu_clock_mhz"])
+        assert pd.isna(df.iloc[0]["gpu_vram_used_mb"])
+        assert pd.isna(df.iloc[0]["gpu_temperature_c"])
+
+    def test_creates_parent_directory(self, tmp_path):
+        """存在しない親ディレクトリも自動作成される."""
+        nested = tmp_path / "nested" / "dir" / "m.csv"
+        recorder = MetricsRecorder(interval_s=0.5, out_path=nested)
+        recorder.maybe_record(_make_response(), now_monotonic=10.0)
+        recorder.flush()
+        assert nested.exists()
+
+
+class TestElapsedSeconds:
+    """elapsed_s カラムのテスト."""
+
+    def test_elapsed_measured_from_init(self, tmp_path):
+        """elapsed_s は recorder 生成時刻起点で計測される."""
+        recorder = MetricsRecorder(interval_s=0.5, out_path=tmp_path / "m.csv")
+        start = recorder._start_monotonic  # type: ignore[attr-defined]
+        recorder.maybe_record(_make_response(), now_monotonic=start + 1.5)
+        recorder.maybe_record(_make_response(), now_monotonic=start + 3.0)
+        recorder.flush()
+
+        df = pd.read_csv(tmp_path / "m.csv")
+        assert df.iloc[0]["elapsed_s"] == pytest.approx(1.5, abs=0.01)
+        assert df.iloc[1]["elapsed_s"] == pytest.approx(3.0, abs=0.01)

--- a/tests/cli/test_build_detection_client.py
+++ b/tests/cli/test_build_detection_client.py
@@ -31,23 +31,27 @@ class TestBuildDetectionClient:
         path = _write_valid_config(tmp_path)
         logger = logging.getLogger("test")
 
-        client, fps = _build_detection_client(str(path), False, logger)
+        client, fps, metrics_interval = _build_detection_client(
+            str(path), False, logger
+        )
 
         assert client is None
         # fps はデフォルト値 (config を読まないため)
         assert fps == 5.0
+        assert metrics_interval == 0.0
 
     def test_detect_flag_on_builds_client(self, tmp_path):
         """`--detect` 指定 + 有効 config で DetectionClient が構築される."""
         path = _write_valid_config(tmp_path, detect_fps=10.0)
         logger = logging.getLogger("test")
 
-        client, fps = _build_detection_client(str(path), True, logger)
+        client, fps, metrics_interval = _build_detection_client(str(path), True, logger)
 
         try:
             assert isinstance(client, DetectionClient)
             assert client.base_url == "http://localhost:8000"
             assert fps == 10.0
+            assert metrics_interval == 0.0
         finally:
             if client is not None:
                 client.close()
@@ -58,10 +62,13 @@ class TestBuildDetectionClient:
         logger = logging.getLogger("test")
 
         with caplog.at_level("WARNING"):
-            client, fps = _build_detection_client(str(missing_path), True, logger)
+            client, fps, metrics_interval = _build_detection_client(
+                str(missing_path), True, logger
+            )
 
         assert client is None
         assert fps == 5.0  # デフォルト
+        assert metrics_interval == 0.0
         assert any(
             "--detect" in rec.message and "missing" in rec.message
             for rec in caplog.records
@@ -74,10 +81,13 @@ class TestBuildDetectionClient:
         logger = logging.getLogger("test")
 
         with caplog.at_level("WARNING"):
-            client, fps = _build_detection_client(str(path), True, logger)
+            client, fps, metrics_interval = _build_detection_client(
+                str(path), True, logger
+            )
 
         assert client is None
         assert fps == 5.0
+        assert metrics_interval == 0.0
 
     def test_legacy_mode_key_does_not_affect_behavior(self, tmp_path):
         """廃止された `mode` フィールドが JSON に残っていても `--detect` 無効なら構築しない."""
@@ -94,5 +104,27 @@ class TestBuildDetectionClient:
         logger = logging.getLogger("test")
 
         # --detect 未指定: mode="detect" が残っていても classify のまま
-        client, _ = _build_detection_client(str(path), False, logger)
+        client, _, _ = _build_detection_client(str(path), False, logger)
         assert client is None
+
+    def test_metrics_interval_propagated(self, tmp_path):
+        """`metrics_interval_s` が config から読まれて返り値に含まれる."""
+        path = tmp_path / "detect_config.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "base_url": "http://localhost:8000",
+                    "metrics_interval_s": 2.0,
+                }
+            ),
+            encoding="utf-8",
+        )
+        logger = logging.getLogger("test")
+
+        client, _, metrics_interval = _build_detection_client(str(path), True, logger)
+
+        try:
+            assert metrics_interval == 2.0
+        finally:
+            if client is not None:
+                client.close()

--- a/tests/request/api/detection/test_client.py
+++ b/tests/request/api/detection/test_client.py
@@ -367,3 +367,54 @@ class TestDetect:
         client.detect(_make_frame())
 
         assert '"score_threshold":0.25' in captured_payload[0].replace(" ", "")
+
+    def test_phase_times_and_gpu_metrics_parsed(self):
+        """phase_times_ms / GPU メトリクスをレスポンスから取り込むことを確認."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={
+                    "detections": [],
+                    "e2e_time_ms": 5.0,
+                    "backend": "onnx-cuda",
+                    "phase_times_ms": {
+                        "pipeline_preprocess_ms": 1.2,
+                        "pipeline_inference_ms": 2.5,
+                        "pipeline_inference_gpu_ms": 2.1,
+                        "pipeline_postprocess_ms": 0.8,
+                    },
+                    "gpu_clock_mhz": 1770,
+                    "gpu_vram_used_mb": 2048,
+                    "gpu_temperature_c": 55,
+                },
+            )
+
+        client = DetectionClient(base_url="http://localhost:8000")
+        client._client = httpx.Client(transport=httpx.MockTransport(handler))
+
+        response = client.detect(_make_frame())
+
+        assert response.phase_times_ms["pipeline_preprocess_ms"] == 1.2
+        assert response.phase_times_ms["pipeline_inference_ms"] == 2.5
+        assert response.phase_times_ms["pipeline_inference_gpu_ms"] == 2.1
+        assert response.phase_times_ms["pipeline_postprocess_ms"] == 0.8
+        assert response.gpu_clock_mhz == 1770
+        assert response.gpu_vram_used_mb == 2048
+        assert response.gpu_temperature_c == 55
+
+    def test_phase_times_and_gpu_metrics_default_when_missing(self):
+        """phase_times_ms / GPU メトリクスが欠落していても既存クライアントが壊れない."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=_VALID_RESPONSE)
+
+        client = DetectionClient(base_url="http://localhost:8000")
+        client._client = httpx.Client(transport=httpx.MockTransport(handler))
+
+        response = client.detect(_make_frame())
+
+        assert response.phase_times_ms == {}
+        assert response.gpu_clock_mhz is None
+        assert response.gpu_vram_used_mb is None
+        assert response.gpu_temperature_c is None

--- a/tests/request/api/detection/test_config.py
+++ b/tests/request/api/detection/test_config.py
@@ -160,6 +160,27 @@ class TestLoadDetectConfig:
         with pytest.raises(ConfigValidationError, match="detect_fps"):
             load_detect_config(str(path))
 
+    def test_metrics_interval_default_disabled(self, tmp_path):
+        path = _write_config(tmp_path, {"base_url": "http://localhost:8000"})
+        config = load_detect_config(str(path))
+        assert config.metrics_interval_s == 0.0
+
+    def test_metrics_interval_custom(self, tmp_path):
+        path = _write_config(
+            tmp_path,
+            {"base_url": "http://localhost:8000", "metrics_interval_s": 2.5},
+        )
+        config = load_detect_config(str(path))
+        assert config.metrics_interval_s == 2.5
+
+    def test_metrics_interval_negative_raises(self, tmp_path):
+        path = _write_config(
+            tmp_path,
+            {"base_url": "http://localhost:8000", "metrics_interval_s": -1.0},
+        )
+        with pytest.raises(ConfigValidationError, match="metrics_interval_s"):
+            load_detect_config(str(path))
+
 
 class TestDetectConfig:
     """DetectConfig のテスト."""


### PR DESCRIPTION
## Summary

- 検出 API のタイミング情報 (`e2e_time_ms` / `phase_times_ms` / `rtt_ms` / GPU clock / VRAM / 温度) を `metrics_interval_s` 間隔でサンプリングし, pandas 経由で `capture/<run>/detection_metrics.csv` に保存する機構を追加.
- CLI フラグではなく `detect_config.json` の `metrics_interval_s` で制御 (既存の検出関連設定と一貫性を保つ).
- pochidetection の `DetectResponse` 拡張 ([pochidetection#584](https://github.com/kurorosu/pochidetection/pull/584)) に合わせ `DetectionResponse` も `phase_times_ms` / `gpu_clock_mhz` / `gpu_vram_used_mb` / `gpu_temperature_c` を取り込むよう拡張.

## Related Issue

Closes #417

## Changes

- `pochivision/request/api/detection/models.py`: `DetectionResponse` に 4 フィールド追加 (既存コンストラクタは互換).
- `pochivision/request/api/detection/client.py`: `_parse_response` で新フィールドを `data.get()` で拾う. サーバー未提供時は空 dict / None.
- `pochivision/request/api/detection/config.py`: `DetectConfig.metrics_interval_s: float` を追加. 0 以下で無効 (バリデーションは非負の数値).
- `pochivision/capture_runner/metrics_recorder.py` (新規): `MetricsRecorder` クラス. `maybe_record()` で間隔判定, `flush()` で pandas → CSV. 書き出し失敗時はバッファ復元.
- `pochivision/capture_runner/viewer.py`: `metrics_interval_s` 引数を追加. detect モードかつ > 0 のとき `MetricsRecorder` を初期化, `_detection_worker` 成功時に `maybe_record()`, `_cleanup` で `flush()`.
- `pochivision/cli/commands/run.py`: `_build_detection_client` の戻り値を `(client, fps, metrics_interval_s)` に拡張. `LivePreviewRunner` へ伝搬.
- `config/detect_config.json`: サンプル値として `metrics_interval_s: 0.0` (無効) を追記.
- `tests/`: `MetricsRecorder` / client `_parse_response` / config バリデーション / `_build_detection_client` のテスト追加 / 更新.
- `README.md` / `CHANGELOG.md`: 新フィールドとメトリクス記録フローを追記.

## Code Changes

```python
# pochivision/capture_runner/viewer.py (抜粋)
self._metrics_recorder: MetricsRecorder | None = None
if self.is_detect_mode and metrics_interval_s > 0:
    self._metrics_recorder = MetricsRecorder(
        interval_s=metrics_interval_s,
        out_path=Path(pipeline.output_dir) / "detection_metrics.csv",
    )
```

## Test Plan

- [x] `interval_s <= 0` のとき `maybe_record()` は記録しない
- [x] 初回呼び出しは無条件で記録する
- [x] 間隔未経過の 2 回目はスキップされる
- [x] 間隔経過後の 2 回目は記録される
- [x] `flush()` がヘッダ付き CSV を書き出し, バッファをクリアする
- [x] サーバーが `phase_times_ms` / GPU メトリクスを返さない場合は空セル (NaN) で出力される
- [x] 親ディレクトリが存在しなくても自動作成される
- [x] `elapsed_s` は recorder 生成時刻を起点に計測される
- [x] `DetectionResponse` に新フィールドが正しくマッピングされる (有/無両ケース)
- [x] `DetectConfig.metrics_interval_s` のデフォルト / カスタム値 / 負値バリデーション
- [x] `_build_detection_client` が `metrics_interval_s` を伝搬する

## Checklist

- [x] pre-commit 全 pass (black / isort / pydocstyle / mypy / gitleaks / pytest)
