### PR TITLE
feat: 検出オーバーレイの Inference 表示を E2E に修正し phase 別推論時間を追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,12 @@
 - pochidetection 検出 API クライアント (`DetectionClient`) を追加. `DetectConfig` / 専用例外 / サンプル `config/detect_config.json` 同梱. ([#403](https://github.com/kurorosu/pochivision/pull/403))
 - `DetectionOverlay` を追加. `DetectionResponse` を受けて bbox / ラベル / メタ情報 (検出数 / e2e_time_ms / rtt_ms / backend) を描画. class ID からの決定的 8 色パレット内蔵. ([#407](https://github.com/kurorosu/pochivision/pull/407))
 - 常時検出ランタイムを `CaptureRunner` に統合. `time.perf_counter()` ベースのスロットリング + 非同期スレッドで検出し `DetectionOverlay` に反映. `i` キーで ON/OFF トグル, detect モードは ROI 無効化. `DetectionOverlay` の state 更新 / draw を `threading.Lock` で保護. ([#414](https://github.com/kurorosu/pochivision/pull/414))
-- 検出 API の処理時間メトリクス (`e2e_time_ms` / `phase_times_ms` / `rtt_ms` / GPU clock・VRAM・温度) を `metrics_interval_s` 間隔でサンプリングし `capture/<run>/detection_metrics.csv` に pandas 経由で保存する `MetricsRecorder` を追加. 設定は `detect_config.json` の `metrics_interval_s` で制御. ((NA.))
+- 検出 API の処理時間メトリクス (`e2e_time_ms` / `phase_times_ms` / `rtt_ms` / GPU clock・VRAM・温度) を `metrics_interval_s` 間隔でサンプリングし `capture/<run>/detection_metrics.csv` に pandas 経由で保存する `MetricsRecorder` を追加. 設定は `detect_config.json` の `metrics_interval_s` で制御. ([#418](https://github.com/kurorosu/pochivision/pull/418))
 
 ### Changed
 - **BREAKING**: 検出モードの有効化を `DetectConfig.mode` から CLI フラグ `--detect` に変更. 既存 JSON の `mode` キーは warning を出して無視 (後方互換). ([#416](https://github.com/kurorosu/pochivision/pull/416))
-- `DetectionResponse` に `phase_times_ms` / `gpu_clock_mhz` / `gpu_vram_used_mb` / `gpu_temperature_c` フィールドを追加. サーバー未提供時は空 dict / None で補う. ((NA.))
+- `DetectionResponse` に `phase_times_ms` / `gpu_clock_mhz` / `gpu_vram_used_mb` / `gpu_temperature_c` フィールドを追加. サーバー未提供時は空 dict / None で補う. ([#418](https://github.com/kurorosu/pochivision/pull/418))
+- `DetectionOverlay` の `Inference: X.Xms` 表示を実体に合わせ `E2E: X.Xms` に変更. `phase_times_ms.pipeline_inference_ms` が返る場合は純粋な推論時間を `Infer: X.Xms` として別行に追加. ((NA.))
 - **BREAKING**: API クライアント / config のキー名を `url` → `base_url`, `format` → `image_format` に統一. 既存 `config/*.json` は要更新. ([#412](https://github.com/kurorosu/pochivision/pull/412))
 - `DetectionClient` のバリデーション / レスポンスパースを堅牢化. frame dtype / shape / timeout / URL / JSON / 型不一致を適切な例外にマッピング. ([#406](https://github.com/kurorosu/pochivision/pull/406))
 - `DetectionOverlay` で bbox 異常値 (NaN / Inf / 反転 / フレーム外) をガード, ラベル矩形をフレーム範囲でクリップ. 非 BGR 3ch フレームは描画しない. ([#410](https://github.com/kurorosu/pochivision/pull/410))

--- a/pochivision/capture_runner/detection_overlay.py
+++ b/pochivision/capture_runner/detection_overlay.py
@@ -29,7 +29,8 @@ class DetectionOverlay:
     各検出を bbox + `"class_name conf"` のラベルで描画し,
     画面左上に以下を表示する:
     - 検出数
-    - サーバー側推論時間 (e2e_time_ms)
+    - E2E 時間 (e2e_time_ms: サーバー内エンドツーエンド. 前処理+推論+後処理込み)
+    - 純粋な推論時間 (phase_times_ms.pipeline_inference_ms, wall-clock)
     - RTT (rtt_ms)
     - バックエンド
     - 送信画像サイズ (context 経由, 任意)
@@ -166,21 +167,46 @@ class DetectionOverlay:
         for det in result.detections:
             self._draw_bbox(frame, det)
 
+        y = 30
+        for text, c in self._build_meta_lines(result):
+            self._draw_text(frame, text, c, y=y)
+            y += 25
+
+    def _build_meta_lines(
+        self, result: DetectionResponse
+    ) -> list[tuple[str, tuple[int, int, int]]]:
+        """メタ情報行を組み立てる (text, color) のリストを返す.
+
+        表示順は固定: Detections → E2E → Infer (phase あれば) → RTT → Backend →
+        ImageSize (context あれば) → Server (context あれば).
+
+        Args:
+            result: 検出結果.
+
+        Returns:
+            (表示テキスト, BGR 色) のリスト.
+        """
         lines: list[tuple[str, tuple[int, int, int]]] = [
             (f"Detections: {len(result.detections)}", self.META_COLOR),
-            (f"Inference: {result.e2e_time_ms:.1f}ms", self.META_COLOR),
-            (f"RTT: {result.rtt_ms:.1f}ms", self.META_COLOR),
-            (f"Backend: {result.backend}", self.META_COLOR),
+            (f"E2E: {result.e2e_time_ms:.1f}ms", self.META_COLOR),
         ]
+        # phase_times_ms が返っていれば純粋な推論時間を個別表示 (E2E とは別物).
+        # pipeline_inference_gpu_ms (CUDA Event 計測) は画面では省略し, 詳細解析は
+        # CSV 出力側に委ねる (画面の情報量を抑えるため).
+        infer_ms = result.phase_times_ms.get("pipeline_inference_ms")
+        if infer_ms is not None:
+            lines.append((f"Infer: {infer_ms:.1f}ms", self.META_COLOR))
+        lines.extend(
+            [
+                (f"RTT: {result.rtt_ms:.1f}ms", self.META_COLOR),
+                (f"Backend: {result.backend}", self.META_COLOR),
+            ]
+        )
         if self.context and self.context.image_size:
             lines.append((f"ImageSize: {self.context.image_size}", self.META_COLOR))
         if self.context:
             lines.append((f"Server: {self.context.server_url}", self.META_COLOR))
-
-        y = 30
-        for text, c in lines:
-            self._draw_text(frame, text, c, y=y)
-            y += 25
+        return lines
 
     def _draw_bbox(self, frame: np.ndarray, det: Detection) -> None:
         """1 つの検出を bbox + ラベルで描画する.

--- a/pochivision/request/api/detection/client.py
+++ b/pochivision/request/api/detection/client.py
@@ -211,6 +211,8 @@ class DetectionClient:
                 )
                 for d in raw_detections
             )
+            # 旧バージョンの pochidetection (phase_times_ms 未対応) や, サーバー側で
+            # null を返すケースに備え, 空 dict に正規化する.
             phase_times_ms = data.get("phase_times_ms") or {}
             return DetectionResponse(
                 detections=detections,

--- a/tests/capture_runner/test_detection_overlay.py
+++ b/tests/capture_runner/test_detection_overlay.py
@@ -29,6 +29,7 @@ def _make_response(
     e2e_time_ms: float = 12.3,
     rtt_ms: float = 65.1,
     backend: str = "onnx",
+    phase_times_ms: dict[str, float] | None = None,
 ) -> DetectionResponse:
     """テスト用の DetectionResponse を生成する.
 
@@ -45,6 +46,7 @@ def _make_response(
         e2e_time_ms=e2e_time_ms,
         backend=backend,
         rtt_ms=rtt_ms,
+        phase_times_ms=phase_times_ms or {},
     )
 
 
@@ -316,3 +318,69 @@ class TestDraw:
             & (result[..., 2] > r // 2)
         )
         assert bright_mask.any()
+
+
+class TestBuildMetaLines:
+    """`_build_meta_lines` のテスト (表示テキスト組み立て)."""
+
+    def _texts(self, overlay: DetectionOverlay, result: DetectionResponse) -> list[str]:
+        return [text for text, _ in overlay._build_meta_lines(result)]
+
+    def test_e2e_label_replaces_inference_label(self):
+        """旧 `Inference:` ラベルは使われず `E2E:` で e2e_time_ms を表示する."""
+        overlay = DetectionOverlay()
+        texts = self._texts(overlay, _make_response(detections=(), e2e_time_ms=12.3))
+
+        assert "E2E: 12.3ms" in texts
+        assert not any(t.startswith("Inference:") for t in texts)
+
+    def test_infer_line_absent_when_phase_times_empty(self):
+        """phase_times_ms が空なら `Infer:` 行は出さない."""
+        overlay = DetectionOverlay()
+        texts = self._texts(overlay, _make_response(detections=()))
+        assert not any(t.startswith("Infer:") for t in texts)
+
+    def test_infer_line_shown_when_phase_times_present(self):
+        """`pipeline_inference_ms` があれば `Infer:` 行が追加される."""
+        overlay = DetectionOverlay()
+        texts = self._texts(
+            overlay,
+            _make_response(
+                detections=(),
+                phase_times_ms={"pipeline_inference_ms": 8.2},
+            ),
+        )
+        assert "Infer: 8.2ms" in texts
+
+    def test_infer_line_ignores_gpu_phase_field(self):
+        """`pipeline_inference_gpu_ms` が併せて返っても画面には併記しない."""
+        overlay = DetectionOverlay()
+        texts = self._texts(
+            overlay,
+            _make_response(
+                detections=(),
+                phase_times_ms={
+                    "pipeline_inference_ms": 8.2,
+                    "pipeline_inference_gpu_ms": 7.9,
+                },
+            ),
+        )
+        assert "Infer: 8.2ms" in texts
+        assert not any("GPU" in t for t in texts)
+
+    def test_order_is_detections_e2e_infer_rtt_backend(self):
+        """表示順が Detections → E2E → Infer → RTT → Backend になっている."""
+        overlay = DetectionOverlay()
+        texts = self._texts(
+            overlay,
+            _make_response(
+                detections=(),
+                phase_times_ms={"pipeline_inference_ms": 8.2},
+            ),
+        )
+        # 先頭 5 行の順序を検証
+        assert texts[0].startswith("Detections:")
+        assert texts[1].startswith("E2E:")
+        assert texts[2].startswith("Infer:")
+        assert texts[3].startswith("RTT:")
+        assert texts[4].startswith("Backend:")


### PR DESCRIPTION
## Summary

- 検出オーバーレイの `Inference: X.Xms` 表示は実体が `e2e_time_ms` (前処理 + 推論 + 後処理) でラベルと乖離していたため, `E2E: X.Xms` に改名.
- `phase_times_ms.pipeline_inference_ms` がレスポンスに含まれる場合は純粋な推論時間を `Infer: X.Xms` として別行に追加.

## Related Issue

Closes #419

## Changes

- `pochivision/capture_runner/detection_overlay.py`: `_draw_result` からメタ行組み立てを `_build_meta_lines` に抽出してテスト可能化. `Inference:` → `E2E:`, `phase_times_ms.pipeline_inference_ms` 有無で `Infer:` 行を条件付き追加. `pipeline_inference_gpu_ms` は画面には出さず CSV 解析に委ねる.
- `pochivision/request/api/detection/client.py`: `phase_times_ms` 欠落 / null 時の空 dict 正規化にコメントを追記.
- `tests/capture_runner/test_detection_overlay.py`: `_make_response` に `phase_times_ms` 引数追加. `TestBuildMetaLines` クラス (5 テスト) を新設.
- `CHANGELOG.md`: PR [#418](https://github.com/kurorosu/pochivision/pull/418) の `(NA.)` を実番号に置換. 本 PR のエントリを `Changed` に追加.

## Code Changes

```python
# pochivision/capture_runner/detection_overlay.py (抜粋)
lines: list[tuple[str, tuple[int, int, int]]] = [
    (f"Detections: {len(result.detections)}", self.META_COLOR),
    (f"E2E: {result.e2e_time_ms:.1f}ms", self.META_COLOR),
]
infer_ms = result.phase_times_ms.get("pipeline_inference_ms")
if infer_ms is not None:
    lines.append((f"Infer: {infer_ms:.1f}ms", self.META_COLOR))
```

## Test Plan

- [x] 旧ラベル `Inference:` が画面に出なくなり, `E2E: X.Xms` が代わりに出る
- [x] `phase_times_ms` が空なら `Infer:` 行は出ない (既存サーバー互換)
- [x] `pipeline_inference_ms` があれば `Infer: X.Xms` が追加表示される
- [x] `pipeline_inference_gpu_ms` が併せて返っても画面には併記しない
- [x] 表示順が Detections → E2E → Infer → RTT → Backend

## Checklist

- [x] pre-commit 全 pass (black / isort / pydocstyle / mypy / gitleaks / pytest)
