### PR TITLE
fix: 経過時間計測を time.time から perf_counter に置換

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,15 +15,16 @@
 - **BREAKING**: 検出モードの有効化を `DetectConfig.mode` から CLI フラグ `--detect` に変更. 既存 JSON の `mode` キーは warning を出して無視 (後方互換). ([#416](https://github.com/kurorosu/pochivision/pull/416))
 - `DetectionResponse` に `phase_times_ms` / `gpu_clock_mhz` / `gpu_vram_used_mb` / `gpu_temperature_c` フィールドを追加. サーバー未提供時は空 dict / None で補う. ([#418](https://github.com/kurorosu/pochivision/pull/418))
 - `DetectionOverlay` の `Inference: X.Xms` 表示を実体に合わせ `E2E: X.Xms` に変更. `phase_times_ms.pipeline_inference_ms` が返る場合は純粋な推論時間を `Infer: X.Xms` として別行に追加. ([#420](https://github.com/kurorosu/pochivision/pull/420))
-- `DetectionOverlay` の E2E 内訳表示を拡張. `phase_times_ms` の `api_preprocess_ms` / `pipeline_preprocess_ms` / `pipeline_inference_ms` / `pipeline_postprocess_ms` / `api_postprocess_ms` を `- ` プレフィックス付きサブ行で時系列順に表示 (例: `- APIpre: 1.4ms` / `- Pre: 1.1ms` / `- Infer: 8.2ms` / `- Post: 0.5ms` / `- APIpost: 0.9ms`). キー欠損時はその行を出さない. ((NA.))
-- `MetricsRecorder` に `api_preprocess_ms` / `api_postprocess_ms` カラムを追加し, `detection_metrics.csv` の phase 群を時系列順 (api_pre → pipeline_* → api_post) に整理. キー欠損時は空セル. ((NA.))
+- `DetectionOverlay` の E2E 内訳表示を拡張. `phase_times_ms` の `api_preprocess_ms` / `pipeline_preprocess_ms` / `pipeline_inference_ms` / `pipeline_postprocess_ms` / `api_postprocess_ms` を `- ` プレフィックス付きサブ行で時系列順に表示 (例: `- APIpre: 1.4ms` / `- Pre: 1.1ms` / `- Infer: 8.2ms` / `- Post: 0.5ms` / `- APIpost: 0.9ms`). キー欠損時はその行を出さない. ([#422](https://github.com/kurorosu/pochivision/pull/422))
+- `MetricsRecorder` に `api_preprocess_ms` / `api_postprocess_ms` カラムを追加し, `detection_metrics.csv` の phase 群を時系列順 (api_pre → pipeline_* → api_post) に整理. キー欠損時は空セル. ([#422](https://github.com/kurorosu/pochivision/pull/422))
+- `DetectionClient.detect()` の全体所要時間 (画像エンコード + RTT + JSON parse) を `DetectionResponse.total_ms` として計測・返却. オーバーレイに `Total: X.Xms` 行を追加 (Total ⊃ RTT ⊃ E2E の階層が縦並びで表示). `detection_metrics.csv` にも `total_ms` カラムを追加. ((NA.))
 - **BREAKING**: API クライアント / config のキー名を `url` → `base_url`, `format` → `image_format` に統一. 既存 `config/*.json` は要更新. ([#412](https://github.com/kurorosu/pochivision/pull/412))
 - `DetectionClient` のバリデーション / レスポンスパースを堅牢化. frame dtype / shape / timeout / URL / JSON / 型不一致を適切な例外にマッピング. ([#406](https://github.com/kurorosu/pochivision/pull/406))
 - `DetectionOverlay` で bbox 異常値 (NaN / Inf / 反転 / フレーム外) をガード, ラベル矩形をフレーム範囲でクリップ. 非 BGR 3ch フレームは描画しない. ([#410](https://github.com/kurorosu/pochivision/pull/410))
 - `DetectionOverlay` / `InferenceOverlay` の色定数定義を統一. 共通色 (`META_COLOR` / `ERROR_COLOR`) を `capture_runner/_overlay_colors.py` に抽出. ([#413](https://github.com/kurorosu/pochivision/pull/413))
 
 ### Fixed
-- 無し
+- 経過時間計測に `time.time()` (wall-clock) を使用していた 9 箇所を `time.perf_counter()` に置換 (`capture_runner/viewer._measure_actual_fps`, `core/image_saver`, `core/pipeline_executor`). NTP 同期 / 時刻調整で計測値が歪む問題を解消. ((NA.))
 
 ### Removed
 - 無し

--- a/pochivision/capture_runner/viewer.py
+++ b/pochivision/capture_runner/viewer.py
@@ -190,6 +190,9 @@ class LivePreviewRunner:
         """
         実際のフレームレートを測定します.
 
+        経過時間の計測には, NTP 同期や時刻調整の影響を受けない
+        `time.perf_counter()` を使用する.
+
         Args:
             duration (float): 測定時間（秒）
 
@@ -199,10 +202,10 @@ class LivePreviewRunner:
         self.logger.info(f"Measuring actual FPS for {duration} seconds...")
 
         frame_count = 0
-        start_time = time.time()
+        start_time = time.perf_counter()
         end_time = start_time + duration
 
-        while time.time() < end_time:
+        while time.perf_counter() < end_time:
             ret, frame = self.cap.read()
             if ret:
                 frame_count += 1
@@ -210,7 +213,7 @@ class LivePreviewRunner:
                 cv2.imshow("Live View", self._resize_for_preview(frame))
                 cv2.waitKey(1)
 
-        actual_duration = time.time() - start_time
+        actual_duration = time.perf_counter() - start_time
         measured_fps = frame_count / actual_duration if actual_duration > 0 else 0.0
 
         self.logger.info(

--- a/pochivision/core/image_saver.py
+++ b/pochivision/core/image_saver.py
@@ -66,10 +66,10 @@ class ImageSaver:
             )
             path = save_dir / filename
 
-            save_start = time.time()
+            save_start = time.perf_counter()
             try:
                 success = cv2.imwrite(str(path), image)
-                save_time = time.time() - save_start
+                save_time = time.perf_counter() - save_start
                 if success:
                     height, width = image.shape[:2]
                     self.logger.info(

--- a/pochivision/core/pipeline_executor.py
+++ b/pochivision/core/pipeline_executor.py
@@ -141,7 +141,7 @@ class PipelineExecutor:
         Args:
             image: 入力画像.
         """
-        start_time = time.time()
+        start_time = time.perf_counter()
 
         self.saver.save(image, "original")
 
@@ -151,12 +151,12 @@ class PipelineExecutor:
         if self.mode == "parallel":
             for processor in self.processors:
                 try:
-                    proc_start = time.time()
+                    proc_start = time.perf_counter()
                     # parallel モードでは複数プロセッサが同一フレームを
                     # 共有するため, in-place 変更による相互干渉を防ぐため
                     # 各プロセッサに独立した copy を渡す.
                     result = processor.process(image.copy())
-                    proc_time = time.time() - proc_start
+                    proc_time = time.perf_counter() - proc_start
                     self.logger.info(
                         f"Processing time ({processor.name}): {proc_time:.3f} sec"
                     )
@@ -193,7 +193,7 @@ class PipelineExecutor:
                     continue
 
                 try:
-                    proc_start = time.time()
+                    proc_start = time.perf_counter()
 
                     if hasattr(processor, "target_image_name") and hasattr(
                         processor, "set_target_image"
@@ -213,7 +213,7 @@ class PipelineExecutor:
                             )  # type: ignore
 
                     result = processor.process(result)
-                    proc_time = time.time() - proc_start
+                    proc_time = time.perf_counter() - proc_start
                     self.logger.info(
                         f"Processing time ({processor.name}): {proc_time:.3f} sec"
                     )
@@ -240,5 +240,5 @@ class PipelineExecutor:
                     "final result not saved"
                 )
 
-        total_time = time.time() - start_time
+        total_time = time.perf_counter() - start_time
         self.logger.info(f"Total processing time: {total_time:.3f} sec")


### PR DESCRIPTION
## Summary

- `pochivision/` 内で **経過時間計測** に `time.time()` (wall-clock) を使用していた 9 箇所を `time.perf_counter()` に置換.
- NTP 同期 / 手動時刻調整 / DST 切替が計測中に発生すると wall-clock ジャンプで計測値が歪む問題を解消. 単調時計を使うことで安定した計測になる.
- Issue #426 は `_measure_actual_fps` が起票スコープだが, 同テーマの誤用が `core/image_saver.py` (2 箇所) と `core/pipeline_executor.py` (6 箇所) にも残っていたため, 本 PR にまとめて含めた.

## Related Issue

Closes #426

## Changes

- `pochivision/capture_runner/viewer.py::_measure_actual_fps`:
  - 開始 / ループ条件 / 終了差分の 3 箇所を `time.time()` → `time.perf_counter()` に置換.
  - docstring に NTP 同期や時刻調整の影響を受けない旨を追記.
- `pochivision/core/image_saver.py`: 画像保存時間ログの 2 箇所.
- `pochivision/core/pipeline_executor.py`: プロセッサ処理時間 / 全体処理時間ログの 6 箇所.

## Code Changes

```python
# pochivision/core/pipeline_executor.py (抜粋)
start_time = time.perf_counter()
...
    proc_start = time.perf_counter()
    result = processor.process(image.copy())
    proc_time = time.perf_counter() - proc_start
    self.logger.info(f"Processing time ({processor.name}): {proc_time:.3f} sec")
...
total_time = time.perf_counter() - start_time
self.logger.info(f"Total processing time: {total_time:.3f} sec")
```

## Test Plan

- [x] 機械的置換のみで挙動は同一 (`time.time()` / `time.perf_counter()` 共に float 秒を返す経過時間 API).
- [x] 全 pytest (925 passed) が通過し, 既存テストの回帰なし.
- [x] `_measure_actual_fps` の周辺は実カメラ依存のためロジックテストは追加せず (DI 化はスコープ外と判断).
- [x] ログ出力のフォーマット (`"Processing time (name): 0.003 sec"` 等) は変更なし.

## Checklist

- [x] `uv run pre-commit run --all-files` 全 pass.
- [x] フル pytest (925 passed, warning は既存の無害な cast warning).

## Note

CHANGELOG は並列 PR ルール (`.claude/rules/worktree-workflow.md`) に従い, 本 PR を「並列 PR のうち最後の PR」とし, 後続コミットで本 PR と [#430](https://github.com/kurorosu/pochivision/pull/430) の CHANGELOG エントリをまとめて追加する.
