### PR TITLE
fix: GLCM の均一画像で correlation が NaN を返す問題を修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,14 +17,15 @@
 - `DetectionOverlay` の `Inference: X.Xms` 表示を実体に合わせ `E2E: X.Xms` に変更. `phase_times_ms.pipeline_inference_ms` が返る場合は純粋な推論時間を `Infer: X.Xms` として別行に追加. ([#420](https://github.com/kurorosu/pochivision/pull/420))
 - `DetectionOverlay` の E2E 内訳表示を拡張. `phase_times_ms` の `api_preprocess_ms` / `pipeline_preprocess_ms` / `pipeline_inference_ms` / `pipeline_postprocess_ms` / `api_postprocess_ms` を `- ` プレフィックス付きサブ行で時系列順に表示 (例: `- APIpre: 1.4ms` / `- Pre: 1.1ms` / `- Infer: 8.2ms` / `- Post: 0.5ms` / `- APIpost: 0.9ms`). キー欠損時はその行を出さない. ([#422](https://github.com/kurorosu/pochivision/pull/422))
 - `MetricsRecorder` に `api_preprocess_ms` / `api_postprocess_ms` カラムを追加し, `detection_metrics.csv` の phase 群を時系列順 (api_pre → pipeline_* → api_post) に整理. キー欠損時は空セル. ([#422](https://github.com/kurorosu/pochivision/pull/422))
-- `DetectionClient.detect()` の全体所要時間 (画像エンコード + RTT + JSON parse) を `DetectionResponse.total_ms` として計測・返却. オーバーレイに `Total: X.Xms` 行を追加 (Total ⊃ RTT ⊃ E2E の階層が縦並びで表示). `detection_metrics.csv` にも `total_ms` カラムを追加. ((NA.))
+- `DetectionClient.detect()` の全体所要時間 (画像エンコード + RTT + JSON parse) を `DetectionResponse.total_ms` として計測・返却. オーバーレイに `Total: X.Xms` 行を追加 (Total ⊃ RTT ⊃ E2E の階層が縦並びで表示). `detection_metrics.csv` にも `total_ms` カラムを追加. ([#430](https://github.com/kurorosu/pochivision/pull/430))
 - **BREAKING**: API クライアント / config のキー名を `url` → `base_url`, `format` → `image_format` に統一. 既存 `config/*.json` は要更新. ([#412](https://github.com/kurorosu/pochivision/pull/412))
 - `DetectionClient` のバリデーション / レスポンスパースを堅牢化. frame dtype / shape / timeout / URL / JSON / 型不一致を適切な例外にマッピング. ([#406](https://github.com/kurorosu/pochivision/pull/406))
 - `DetectionOverlay` で bbox 異常値 (NaN / Inf / 反転 / フレーム外) をガード, ラベル矩形をフレーム範囲でクリップ. 非 BGR 3ch フレームは描画しない. ([#410](https://github.com/kurorosu/pochivision/pull/410))
 - `DetectionOverlay` / `InferenceOverlay` の色定数定義を統一. 共通色 (`META_COLOR` / `ERROR_COLOR`) を `capture_runner/_overlay_colors.py` に抽出. ([#413](https://github.com/kurorosu/pochivision/pull/413))
 
 ### Fixed
-- 経過時間計測に `time.time()` (wall-clock) を使用していた 9 箇所を `time.perf_counter()` に置換 (`capture_runner/viewer._measure_actual_fps`, `core/image_saver`, `core/pipeline_executor`). NTP 同期 / 時刻調整で計測値が歪む問題を解消. ((NA.))
+- 経過時間計測に `time.time()` (wall-clock) を使用していた 9 箇所を `time.perf_counter()` に置換 (`capture_runner/viewer._measure_actual_fps`, `core/image_saver`, `core/pipeline_executor`). NTP 同期 / 時刻調整で計測値が歪む問題を解消. ([#431](https://github.com/kurorosu/pochivision/pull/431))
+- `GLCMTextureExtractor` で単色 / 均一画像時に `correlation` が NaN (σ_x σ_y = 0 の不定形) となり後段の集計で全体が NaN に汚染される問題を修正. correlation の NaN を 1.0 (完全相関) にフォールバックし, warning ログは従来通り出力. 他 5 特徴量 (contrast / dissimilarity / homogeneity / energy / ASM) は skimage が単色画像で正常な値 (0 / 1) を返すため影響なし. ((NA.))
 
 ### Removed
 - 無し

--- a/pochivision/feature_extractors/glcm_texture.py
+++ b/pochivision/feature_extractors/glcm_texture.py
@@ -203,13 +203,17 @@ class GLCMTextureExtractor(BaseFeatureExtractor):
                             # 特徴量値を取得
                             feature_value = float(prop_values[d_idx, a_idx])
 
-                            # NaN/Inf は未定義を示す (例: 均一画像の correlation)
-                            if np.isnan(feature_value) or np.isinf(feature_value):
+                            # 単色 / 均一画像では correlation のみ σ_x σ_y = 0 で
+                            # skimage が NaN を返す. 学習モデル入力で NaN 伝播を避ける
+                            # ため 1.0 (完全相関) に置換する.
+                            if prop == "correlation" and (
+                                np.isnan(feature_value) or np.isinf(feature_value)
+                            ):
                                 LogManager().get_logger().warning(
                                     f"GLCM {feature_name} is {feature_value}, "
-                                    "replacing with NaN"
+                                    "replacing with 1.0 (fallback for uniform image)"
                                 )
-                                feature_value = float("nan")
+                                feature_value = 1.0
 
                             results[feature_name] = feature_value
 

--- a/tests/extractors/test_glcm_texture_extractor.py
+++ b/tests/extractors/test_glcm_texture_extractor.py
@@ -595,6 +595,16 @@ class TestGLCMBehavior:
         for angle in [0, 45, 90, 135]:
             assert f[f"dissimilarity_1_{angle}"] == 0.0
 
+    def test_uniform_correlation_is_one_not_nan(self):
+        """均一画像の correlation は NaN ではなく 1.0 (fallback)."""
+        # skimage は σ_x σ_y = 0 の不定形で NaN を返すが, 学習モデル入力で
+        # NaN 伝播を避けるため 1.0 (完全相関) に置換される.
+        f = self.ext.extract(DummyImages.uniform())
+        for angle in [0, 45, 90, 135]:
+            value = f[f"correlation_1_{angle}"]
+            assert not np.isnan(value), f"correlation_1_{angle} is NaN"
+            assert value == 1.0
+
     # --- チェッカーボード ---
 
     def test_checker_contrast_high_in_axis_directions(self):


### PR DESCRIPTION
## Summary

- 単色 / 均一画像を入力したときに `GLCMTextureExtractor` が `correlation` で NaN を返し, 後段の `np.mean()` 等の集計で全体が NaN に汚染される問題を修正.
- 学習モデル入力時の NaN 伝播を避けるため, `correlation` の NaN/Inf を **1.0 (完全相関)** にフォールバック. warning ログは従来通り出力する.

## Related Issue

Closes #424

## Changes

- `pochivision/feature_extractors/glcm_texture.py`:
  - NaN/Inf 検出時のフォールバック対象を **`correlation` のみ** に限定 (他 5 特徴量は skimage が単色画像で正常値を返す).
  - 既存の「NaN を NaN で置換」を「1.0 で置換」に変更. warning メッセージも更新.
- `tests/extractors/test_glcm_texture_extractor.py::TestGLCMBehavior`:
  - `test_uniform_correlation_is_one_not_nan` を追加. 均一画像で 4 方向全ての `correlation` が NaN ではなく 1.0 になることを検証.
- `CHANGELOG.md`:
  - `(NA.)` 2 件を実番号 [#430](https://github.com/kurorosu/pochivision/pull/430) / [#431](https://github.com/kurorosu/pochivision/pull/431) に置換.
  - Fixed に本 PR 用エントリを `(NA.)` で追加.

## Code Changes

```python
# pochivision/feature_extractors/glcm_texture.py (抜粋)
# 単色 / 均一画像では correlation のみ σ_x σ_y = 0 で
# skimage が NaN を返す. 学習モデル入力で NaN 伝播を避ける
# ため 1.0 (完全相関) に置換する.
if prop == "correlation" and (
    np.isnan(feature_value) or np.isinf(feature_value)
):
    LogManager().get_logger().warning(
        f"GLCM {feature_name} is {feature_value}, "
        "replacing with 1.0 (fallback for uniform image)"
    )
    feature_value = 1.0
```

## Test Plan

- [x] 均一画像の `correlation_1_{0,45,90,135}` が NaN ではなく 1.0 を返す.
- [x] warning ログが出力される (NaN 発生事実は情報として残す).
- [x] 他 5 特徴量 (contrast / dissimilarity / homogeneity / energy / ASM) は既存の期待値 (0 / 1) のまま.
- [x] 既存テスト全 pass (pre-commit 経由で pytest 実行).
- [x] チェッカーボード / グラデーション等の非均一画像では従来通り正しい値を返す.

## Checklist

- [x] `uv run pre-commit run --all-files` 全 pass (black / isort / pydocstyle / mypy / gitleaks / pytest).
