### PR TITLE
fix: DetectionOverlay の bbox 描画にプレビュースケール補正を追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,8 @@
 
 ### Fixed
 - 経過時間計測に `time.time()` (wall-clock) を使用していた 9 箇所を `time.perf_counter()` に置換 (`capture_runner/viewer._measure_actual_fps`, `core/image_saver`, `core/pipeline_executor`). NTP 同期 / 時刻調整で計測値が歪む問題を解消. ([#431](https://github.com/kurorosu/pochivision/pull/431))
-- `GLCMTextureExtractor` で単色 / 均一画像時に `correlation` が NaN (σ_x σ_y = 0 の不定形) となり後段の集計で全体が NaN に汚染される問題を修正. correlation の NaN を 1.0 (完全相関) にフォールバックし, warning ログは従来通り出力. 他 5 特徴量 (contrast / dissimilarity / homogeneity / energy / ASM) は skimage が単色画像で正常な値 (0 / 1) を返すため影響なし. ((NA.))
+- `GLCMTextureExtractor` で単色 / 均一画像時に `correlation` が NaN (σ_x σ_y = 0 の不定形) となり後段の集計で全体が NaN に汚染される問題を修正. correlation の NaN を 1.0 (完全相関) にフォールバックし, warning ログは従来通り出力. 他 5 特徴量 (contrast / dissimilarity / homogeneity / energy / ASM) は skimage が単色画像で正常な値 (0 / 1) を返すため影響なし. ([#432](https://github.com/kurorosu/pochivision/pull/432))
+- `DetectionOverlay` で送信フレーム (オリジナル) 座標系の bbox をリサイズ済みプレビューにスケール補正なしで描画していた問題を修正. `ROIRectSelector` と同じパターンで `set_preview_scale(frame_w, preview_w)` を追加し, `_draw_bbox` 内で bbox を縮小描画する. `viewer.py` の detect モード分岐から毎フレーム scale を設定. 静止物体の bbox がキャプチャ画像とずれる現象を解消. ((NA.))
 
 ### Removed
 - 無し

--- a/pochivision/capture_runner/detection_overlay.py
+++ b/pochivision/capture_runner/detection_overlay.py
@@ -73,6 +73,24 @@ class DetectionOverlay:
         self.context = context
         self._inferring = False
         self._lock = threading.Lock()
+        # サーバー応答の bbox は送信フレーム (オリジナル) 座標系のため,
+        # プレビューにリサイズ描画する際は preview / frame の比率で縮小する.
+        # 1.0 = 同サイズ (補正不要).
+        self._preview_scale: float = 1.0
+
+    def set_preview_scale(self, frame_w: int, preview_w: int) -> None:
+        """プレビュー座標系への bbox 縮小スケールを設定する.
+
+        送信フレーム (オリジナル) で計算された bbox を, リサイズ済みプレビュー
+        画像に正しい位置で描画するための縮小率を保持する. アスペクト比保持
+        リサイズを前提として width 比のみで scale を決定する.
+
+        Args:
+            frame_w: 送信フレーム (オリジナル) の幅.
+            preview_w: プレビュー表示の幅.
+        """
+        if frame_w > 0:
+            self._preview_scale = preview_w / frame_w
 
     def update(self, result: DetectionResponse) -> None:
         """検出結果を更新する.
@@ -244,7 +262,9 @@ class DetectionOverlay:
             return
 
         h, w = frame.shape[:2]
-        x1, y1, x2, y2 = (int(v) for v in bbox)
+        # 送信フレーム座標系の bbox をプレビュー座標系に縮小する.
+        s = self._preview_scale
+        x1, y1, x2, y2 = (int(v * s) for v in bbox)
         if x2 <= x1 or y2 <= y1:
             return
         if x2 < 0 or y2 < 0 or x1 >= w or y1 >= h:

--- a/pochivision/capture_runner/viewer.py
+++ b/pochivision/capture_runner/viewer.py
@@ -282,6 +282,11 @@ class LivePreviewRunner:
                     self.roi_selector.draw(preview)
                     self.inference_overlay.draw(preview)
                 else:
+                    # 送信フレーム座標系の bbox を preview に正しく描画するため
+                    # スケールを設定する.
+                    self.detection_overlay.set_preview_scale(
+                        frame.shape[1], preview.shape[1]
+                    )
                     self.detection_overlay.draw(preview)
                 self.help_overlay.draw(preview)
                 cv2.imshow("Live View", preview)

--- a/tests/capture_runner/test_detection_overlay.py
+++ b/tests/capture_runner/test_detection_overlay.py
@@ -480,3 +480,47 @@ class TestBuildMetaLines:
         texts = self._texts(overlay, _make_response(detections=(), total_ms=20.5))
 
         assert any(t.startswith("Total: 20.5") for t in texts)
+
+
+class TestPreviewScale:
+    """`set_preview_scale` による bbox 描画位置の補正テスト."""
+
+    def test_default_scale_is_one(self):
+        """初期値はスケール 1.0 (補正なし) で従来動作を維持."""
+        overlay = DetectionOverlay()
+        # bbox 50-150, 60-180 をそのまま描画する.
+        det = _make_detection(bbox=(50.0, 60.0, 150.0, 180.0))
+        overlay.update(_make_response(detections=(det,)))
+        frame = np.zeros((240, 320, 3), dtype=np.uint8)
+        result = overlay.draw(frame)
+        # オリジナル位置に bbox が描画される.
+        assert result[60:180, 50:150].sum() > 0
+
+    def test_scale_shrinks_bbox_to_preview(self):
+        """frame_w=400 / preview_w=200 のとき bbox が 1/2 に縮小描画される."""
+        overlay = DetectionOverlay()
+        # 送信フレーム座標 bbox: (100, 80, 300, 160).
+        det = _make_detection(bbox=(100.0, 80.0, 300.0, 160.0))
+        overlay.update(_make_response(detections=(det,)))
+        # frame_w=400, preview_w=200 → scale=0.5.
+        overlay.set_preview_scale(frame_w=400, preview_w=200)
+        # preview サイズ (200x100) に描画.
+        preview = np.zeros((100, 200, 3), dtype=np.uint8)
+        result = overlay.draw(preview)
+        # 縮小後の bbox: (50, 40, 150, 80) 領域に描画.
+        assert result[40:80, 50:150].sum() > 0
+        # 縮小前の元位置 (300 など) は preview 範囲外なので描画されない.
+        # 念のため 0-50 / 150-200 の bbox 周辺ではない領域に矩形辺がないことは
+        # 厳密検証しない (色パレット衝突を避ける).
+
+    def test_scale_zero_frame_w_keeps_previous_scale(self):
+        """frame_w=0 を渡された場合は scale を更新せず従来値を維持."""
+        overlay = DetectionOverlay()
+        overlay.set_preview_scale(frame_w=400, preview_w=200)  # scale=0.5
+        overlay.set_preview_scale(frame_w=0, preview_w=100)  # 無視される
+        # scale=0.5 のままなので bbox が 1/2 に縮小描画されることを確認.
+        det = _make_detection(bbox=(100.0, 80.0, 300.0, 160.0))
+        overlay.update(_make_response(detections=(det,)))
+        preview = np.zeros((100, 200, 3), dtype=np.uint8)
+        result = overlay.draw(preview)
+        assert result[40:80, 50:150].sum() > 0


### PR DESCRIPTION
## Summary

- `DetectionOverlay` が送信フレーム (オリジナル) 座標系の bbox をリサイズ済みプレビューに **スケール補正なしで描画** していた問題を修正.
- 静止物体でも bbox がキャプチャ画像と一致せずずれて表示されていたが, `ROIRectSelector` と同じパターンで `set_preview_scale(frame_w, preview_w)` を導入し, `_draw_bbox` 内で bbox を縮小描画するようにした.
- ユーザー実機での動作確認済み.

## Related Issue

Closes #433

## Changes

- `pochivision/capture_runner/detection_overlay.py`:
  - `_preview_scale: float = 1.0` フィールドを追加 (デフォルトは補正なし = 1.0 で後方互換).
  - `set_preview_scale(frame_w, preview_w)` メソッドを追加. `frame_w > 0` のとき `preview_w / frame_w` で scale を保持.
  - `_draw_bbox` 内で bbox 座標を `* scale` してから `cv2.rectangle` する.
- `pochivision/capture_runner/viewer.py`: detect モード分岐で `self.detection_overlay.set_preview_scale(frame.shape[1], preview.shape[1])` を毎フレーム呼ぶ.
- `tests/capture_runner/test_detection_overlay.py::TestPreviewScale`:
  - `test_default_scale_is_one` (デフォルトスケール 1.0 = 従来動作)
  - `test_scale_shrinks_bbox_to_preview` (scale 0.5 で bbox が 1/2 縮小)
  - `test_scale_zero_frame_w_keeps_previous_scale` (frame_w=0 ガード)
- `CHANGELOG.md`:
  - PR [#432](https://github.com/kurorosu/pochivision/pull/432) の `(NA.)` を実番号に置換.
  - Fixed に本 PR 用エントリを `(NA.)` で追加.

## Code Changes

```python
# pochivision/capture_runner/detection_overlay.py (抜粋)
def set_preview_scale(self, frame_w: int, preview_w: int) -> None:
    """プレビュー座標系への bbox 縮小スケールを設定する."""
    if frame_w > 0:
        self._preview_scale = preview_w / frame_w

def _draw_bbox(self, frame, det):
    ...
    s = self._preview_scale
    x1, y1, x2, y2 = (int(v * s) for v in bbox)
    ...
```

```python
# pochivision/capture_runner/viewer.py (抜粋)
preview = self._resize_for_preview(frame)
...
else:
    self.detection_overlay.set_preview_scale(
        frame.shape[1], preview.shape[1]
    )
    self.detection_overlay.draw(preview)
```

## Test Plan

- [x] 静止物体の bbox がキャプチャ画像と一致して描画される (実機確認済み).
- [x] デフォルトスケール 1.0 で従来動作 (補正なし) を維持.
- [x] `set_preview_scale(400, 200)` 後に bbox が 1/2 縮小描画される.
- [x] `set_preview_scale(0, ...)` を渡すとスケールは更新されず従来値を維持 (ゼロ除算ガード).
- [x] 既存の bbox 描画 / メタ情報描画テストが回帰なく pass.

## Checklist

- [x] `uv run pre-commit run --all-files` 全 pass.
